### PR TITLE
Support for Generic Type in Setter-Method Added!

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
@@ -147,8 +147,35 @@ public class FieldInfo implements Comparable<FieldInfo> {
 				if (clazz.getTypeParameters()[i].getName().equals(
 						typeVar.getName())) {
 					fieldType = paramType.getActualTypeArguments()[i];
-					break;
+					return fieldType;
 				}
+			}
+		}
+		
+		if (fieldType instanceof ParameterizedType) {
+			ParameterizedType parameterizedFieldType = (ParameterizedType) fieldType;
+
+			Type[] arguments = parameterizedFieldType.getActualTypeArguments();
+			boolean changed = false;
+			for (int i = 0; i < arguments.length; ++i) {
+				Type feildTypeArguement = arguments[i];
+				if (feildTypeArguement instanceof TypeVariable) {
+					TypeVariable<?> typeVar = (TypeVariable<?>) feildTypeArguement;
+
+					if (type instanceof ParameterizedType) {
+						ParameterizedType parameterizedType = (ParameterizedType) type;
+						for (int j = 0; j < clazz.getTypeParameters().length; ++j) {
+							if (clazz.getTypeParameters()[j].getName().equals(typeVar.getName())) {
+								arguments[i] = parameterizedType.getActualTypeArguments()[j];
+								changed = true;
+							}
+						}
+					}
+				}
+	            	}
+			if (changed) {
+				fieldType = new ParameterizedTypeImpl(arguments, parameterizedFieldType.getOwnerType(), parameterizedFieldType.getRawType());
+				return fieldType;
 			}
 		}
 


### PR DESCRIPTION
V1.1.28 only support generic type in public-field, now it can support generic type in setter-method now!

But there is also a limit: Only single generic type is support!
If there are multi generic types in public-field or setter-method, it won't work!
