### PR TITLE
Support for Generic Type in Setter-Method Added!

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
@@ -71,37 +71,6 @@ public class FieldInfo implements Comparable<FieldInfo> {
 		} else {
 			fieldClass = field.getType();
 			fieldType = field.getGenericType();
-			if (fieldType instanceof ParameterizedType) {
-				ParameterizedType parameterizedFieldType = (ParameterizedType) fieldType;
-
-				Type[] arguments = parameterizedFieldType
-						.getActualTypeArguments();
-				boolean changed = false;
-				for (int i = 0; i < arguments.length; ++i) {
-					Type feildTypeArguement = arguments[i];
-					if (feildTypeArguement instanceof TypeVariable) {
-						TypeVariable<?> typeVar = (TypeVariable<?>) feildTypeArguement;
-
-						if (type instanceof ParameterizedType) {
-							ParameterizedType parameterizedType = (ParameterizedType) type;
-							for (int j = 0; j < clazz.getTypeParameters().length; ++j) {
-								if (clazz.getTypeParameters()[j].getName()
-										.equals(typeVar.getName())) {
-									arguments[i] = parameterizedType
-											.getActualTypeArguments()[j];
-									changed = true;
-								}
-							}
-						}
-					}
-				}
-				if (changed) {
-					fieldType = new ParameterizedTypeImpl(arguments, //
-							parameterizedFieldType.getOwnerType(),//
-							parameterizedFieldType.getRawType() //
-					);
-				}
-			}
 			this.declaringClass = field.getDeclaringClass();
 		}
 

--- a/src/test/java/com/alibaba/json/bvt/util/FieldInfoTest.java
+++ b/src/test/java/com/alibaba/json/bvt/util/FieldInfoTest.java
@@ -1,28 +1,112 @@
 package com.alibaba.json.bvt.util;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.List;
+
 import junit.framework.Assert;
 import junit.framework.TestCase;
 
 import com.alibaba.fastjson.annotation.JSONField;
 import com.alibaba.fastjson.util.FieldInfo;
+import com.alibaba.fastjson.util.ParameterizedTypeImpl;
 
 public class FieldInfoTest extends TestCase {
-	public void test_null() throws Exception {
-		FieldInfo fieldInfo = new FieldInfo("getValue",
-				Entity.class.getMethod("getValue"), null);
-		Assert.assertEquals(null, fieldInfo.getAnnotation(JSONField.class));
-	}
+    public void test_null() throws Exception {
+        FieldInfo fieldInfo = new FieldInfo("getValue", Entity.class.getMethod("getValue"), null);
+        Assert.assertEquals(null, fieldInfo.getAnnotation(JSONField.class));
 
-	public static class Entity {
-		private int value;
+        Field field = GenericFieldEntity.class.getField("value");
+        Type type = new ParameterizedTypeImpl(new Type[] { ValueObject.class }, null, GenericFieldEntity.class);
+        FieldInfo fieldInfoOfField = new FieldInfo("value", null, field, GenericFieldEntity.class, type);
+        Assert.assertEquals(fieldInfoOfField.getFieldType(), ValueObject.class);
+        Assert.assertEquals(fieldInfoOfField.getFieldClass(), ValueObject.class);
 
-		public int getValue() {
-			return value;
-		}
+        field = GenericListFieldEntity.class.getField("value");
+        type = new ParameterizedTypeImpl(new Type[] { ValueObject.class }, null, GenericListFieldEntity.class);
+        FieldInfo fieldInfoOfListField = new FieldInfo("value", null, field, GenericListFieldEntity.class, type);
+        ParameterizedTypeImpl actualFieldType = (ParameterizedTypeImpl) fieldInfoOfListField.getFieldType();
+        Assert.assertEquals(actualFieldType.getActualTypeArguments()[0], ValueObject.class);
+        Assert.assertEquals(actualFieldType.getRawType(), List.class);
+        Assert.assertEquals(fieldInfoOfListField.getFieldClass(), List.class);
 
-		public void setValue(int value) {
-			this.value = value;
-		}
+        Method method = GenericSetterEntity.class.getMethod("setValue", Object.class);
+        type = new ParameterizedTypeImpl(new Type[] { ValueObject.class }, null, GenericSetterEntity.class);
+        FieldInfo fieldInfoOfSetter = new FieldInfo("value", method, null, GenericSetterEntity.class, type);
+        Assert.assertEquals(fieldInfoOfSetter.getFieldType(), ValueObject.class);
+        Assert.assertEquals(fieldInfoOfSetter.getFieldClass(), ValueObject.class);
 
-	}
+        method = GenericListSetterEntity.class.getMethod("setValue", List.class);
+        type = new ParameterizedTypeImpl(new Type[] { ValueObject.class }, null, GenericListSetterEntity.class);
+        FieldInfo fieldInfoOfListSetter = new FieldInfo("value", method, null, GenericListSetterEntity.class, type);
+        Assert.assertEquals(actualFieldType.getActualTypeArguments()[0], ValueObject.class);
+        Assert.assertEquals(actualFieldType.getRawType(), List.class);
+        Assert.assertEquals(fieldInfoOfListSetter.getFieldClass(), List.class);
+    }
+
+    public static class Entity {
+        private int value;
+
+        public int getValue() {
+            return value;
+        }
+
+        public void setValue(int value) {
+            this.value = value;
+        }
+    }
+
+    public static class GenericSetterEntity<T> {
+        private T value;
+
+        public T getValue() {
+            return value;
+        }
+
+        public void setValue(T value) {
+            this.value = value;
+        }
+    }
+
+    public static class GenericListSetterEntity<T> {
+        private List<T> value;
+
+        public List<T> getValue() {
+            return value;
+        }
+
+        public void setValue(List<T> value) {
+            this.value = value;
+        }
+    }
+
+    public static class GenericFieldEntity<T> {
+        public T value;
+    }
+
+    public static class GenericListFieldEntity<T> {
+        public List<T> value;
+    }
+
+    public static class ValueObject {
+        private String name;
+        private int    id;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
 }


### PR DESCRIPTION
Current version supports generic type in public-field, now it can support
generic type in setter-method now!

But there is also a limit: Only single generic type is support!
If there are multi generic types in public-field or setter-method, it
won't work!
