### PR TITLE
fix bug #83.

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/JSONReaderScanner.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONReaderScanner.java
@@ -178,6 +178,10 @@ public final class JSONReaderScanner extends JSONLexerBase {
             if (bufLength == -1) {
                 return ch = EOI;
             }
+            
+            if (bufLength > 0) {
+                np = 0;
+            }            
 
             bufLength += bp;
         }


### PR DESCRIPTION
修正 JSONReaderScanner 无法处理大于 8192 字节的文件的问题。
