### PR TITLE
Fix number parsing in objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /.project
 /.settings
 /.classpath
+/.idea
+*.iml
+

--- a/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
+++ b/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
@@ -402,7 +402,7 @@ public class DefaultJSONParser extends AbstractJSONParser implements Closeable {
                     if (lexer.token() == JSONToken.LITERAL_INT) {
                         value = lexer.integerValue();
                     } else {
-                        value = lexer.numberValue();
+                        value = lexer.decimalValue(isEnabled(Feature.UseBigDecimal));
                     }
 
                     object.put(key, value);

--- a/src/main/java/com/alibaba/fastjson/parser/JSONLexer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONLexer.java
@@ -54,6 +54,7 @@ public interface JSONLexer {
 
     void scanString();
 
+    @Deprecated
     Number numberValue();
 
     int intValue();

--- a/src/main/java/com/alibaba/fastjson/parser/JSONLexerBase.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONLexerBase.java
@@ -2923,6 +2923,7 @@ public abstract class JSONLexerBase implements JSONLexer, Closeable {
         return new BigDecimal(numberString());
     }
 
+    @Deprecated
     public final Number numberValue() {
         char type = charAt(np + sp - 1);
 

--- a/src/test/java/com/alibaba/json/bvt/DefaultJSONParserTest.java
+++ b/src/test/java/com/alibaba/json/bvt/DefaultJSONParserTest.java
@@ -16,6 +16,7 @@
 package com.alibaba.json.bvt;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.Assert;
 import junit.framework.TestCase;
@@ -32,6 +33,14 @@ public class DefaultJSONParserTest extends TestCase {
 		Assert.assertEquals(false, parser.isEnabled(Feature.UseBigDecimal));
 		Object result = parser.parse();
 		Assert.assertEquals(3.4D, result);
+	}
+
+	public void test_double_in_object() {
+		DefaultJSONParser parser = new DefaultJSONParser("{\"double\":3.4}");
+		parser.config(Feature.UseBigDecimal, false);
+		Assert.assertEquals("{\"double\":3.4}", parser.getInput());
+		Object result = parser.parse();
+		Assert.assertEquals(3.4D, ((Map) result).get("double"));
 	}
 
 	public void test_error() {


### PR DESCRIPTION
I suppose the numberValue method is now obsolete, and decimalValue is the right match when parsing an object too.
