### PR TITLE
let JSON parser support subclass of JSONObject

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/JSONObjectSubclassTest.java
+++ b/src/test/java/com/alibaba/json/bvt/JSONObjectSubclassTest.java
@@ -1,0 +1,45 @@
+package com.alibaba.json.bvt;
+
+import java.util.Iterator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+
+public class JSONObjectSubclassTest extends JSONObject {
+
+    private static final long serialVersionUID = 1L;
+
+    @Test
+    public void test() throws Exception {
+        String content = "{'map':{'key':'value'},'list':[{'key':'value'},{'map':{'key':'value'}}]}";
+        validateMap(JSON.parseObject(content, JSONObjectSubclassTest.class));
+    }
+
+    public static void validateList(JSONArray value) {
+        Iterator<Object> it = value.iterator();
+        while (it.hasNext()) {
+            validateObject(it.next());
+        }
+    }
+
+    public static void validateMap(JSONObject value) {
+        Assert.assertEquals(JSONObjectSubclassTest.class, value.getClass());
+        for (Object v : value.values()) {
+            validateObject(v);
+        }
+    }
+
+    public static void validateObject(Object value) {
+        if (value == null) {
+        } else if (JSONObject.class.isAssignableFrom(value.getClass())) {
+            validateMap((JSONObject) value);
+        } else if (JSONArray.class.isAssignableFrom(value.getClass())) {
+            validateList((JSONArray) value);
+        }
+    }
+
+}


### PR DESCRIPTION
If the struct of JSON is known, we can use `TypeReference`. Otherwise, all the map will be converted to `JSONObject`, even a subclass of `JSONObject` is requested. This patch check the parameter, and let the parser returns the subclass of `JSONObject` if needed.

如果`JSON`的格式是已知的话，我们可以定义相应的类，然后使用`TypeReference`。否则，所有的对象将会被转换成`JSONObject`，即使是期望返回`JSONObject`的子类。这个补丁检查参数，如果需要的话允许解析器返回`JSONObject`的子类。
