### PR TITLE
解决@JSONField UTF-8问题

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/ParserConfig.java
+++ b/src/main/java/com/alibaba/fastjson/parser/ParserConfig.java
@@ -66,6 +66,7 @@ import java.util.regex.Pattern;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.annotation.JSONField;
 import com.alibaba.fastjson.annotation.JSONType;
 import com.alibaba.fastjson.asm.ASMException;
 import com.alibaba.fastjson.parser.deserializer.ASMDeserializerFactory;
@@ -497,6 +498,11 @@ public class ParserConfig {
                 if (!ASMUtils.checkName(fieldInfo.getMember().getName())) {
                     asmEnable = false;
                 }
+                
+                JSONField annotation = fieldInfo.getAnnotation(JSONField.class);
+                if (annotation != null && !ASMUtils.checkName(annotation.name())) {
+                	asmEnable = false;
+				}
             }
         }
 
@@ -505,7 +511,7 @@ public class ParserConfig {
                 asmEnable = false;
             }
         }
-
+        
         if (!asmEnable) {
             return new JavaBeanDeserializer(this, clazz, type);
         }

--- a/src/main/java/com/alibaba/fastjson/serializer/DateSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/DateSerializer.java
@@ -39,7 +39,19 @@ public class DateSerializer implements ObjectSerializer {
             out.writeNull();
             return;
         }
-
+        
+        Date date = (Date) object;
+        
+        if (out.isEnabled(SerializerFeature.WriteDateUseDateFormat)) {
+            DateFormat format = serializer.getDateFormat();
+            if (format == null) {
+                format = new SimpleDateFormat(JSON.DEFFAULT_DATE_FORMAT);
+            }
+            String text = format.format(date);
+            out.writeString(text);
+            return;
+        }
+        
         if (out.isEnabled(SerializerFeature.WriteClassName)) {
             if (object.getClass() != fieldType) {
                 if (object.getClass() == java.util.Date.class) {
@@ -54,18 +66,6 @@ public class DateSerializer implements ObjectSerializer {
                 }
                 return;
             }
-        }
-        
-        Date date = (Date) object;
-        
-        if (out.isEnabled(SerializerFeature.WriteDateUseDateFormat)) {
-            DateFormat format = serializer.getDateFormat();
-            if (format == null) {
-                format = new SimpleDateFormat(JSON.DEFFAULT_DATE_FORMAT);
-            }
-            String text = format.format(date);
-            out.writeString(text);
-            return;
         }
 
         long time = date.getTime();

--- a/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
@@ -131,11 +131,9 @@ public class JavaBeanSerializer implements ObjectSerializer {
 
             if (isWriteClassName(serializer, object, fieldType, fieldName)) {
                 Class<?> objClass = object.getClass();
-                if (objClass != fieldType) {
-                    out.writeFieldName(JSON.DEFAULT_TYPE_KEY);
-                    serializer.write(object.getClass());
-                    commaFlag = true;
-                }
+                out.writeFieldName(JSON.DEFAULT_TYPE_KEY);
+                serializer.write(object.getClass());
+                commaFlag = true;
             }
 
             char seperator = commaFlag ? ',' : '\0';

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.Serializable;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
@@ -55,6 +56,7 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONAware;
 import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.JSONStreamAware;
+import com.alibaba.fastjson.annotation.JSONField;
 import com.alibaba.fastjson.annotation.JSONType;
 import com.alibaba.fastjson.parser.deserializer.Jdk8DateCodec;
 import com.alibaba.fastjson.util.ASMUtils;
@@ -107,11 +109,19 @@ public class SerializeConfig extends IdentityHashMap<Type, ObjectSerializer> {
 				asm = false;
 			}
 		}
-		
+
 		if (asm && !ASMUtils.checkName(clazz.getName())) {
 		    asm = false;
 		}
-
+		
+		for(Field field : clazz.getDeclaredFields()){
+			JSONField annotation = field.getAnnotation(JSONField.class);
+			if (annotation != null && !ASMUtils.checkName(annotation.name())) {
+				asm = false;
+				break;
+			}
+		}
+		
 		if (asm) {
 			try {
 			    ObjectSerializer asmSerializer = createASMSerializer(clazz);


### PR DESCRIPTION
解决@JSONField作用于属性上时name无法为utf-8字符问题,测试类：

```java
public class VO{
    @JSONField(name=“序号”)
    private int id;
    public int getId(){return id;}
    public void setId(int id){this.id = id;}
}
```