### PR TITLE
Fix the typos reported by Issue#323

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -80,7 +80,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         DEFAULT_PARSER_FEATURE = features;
     }
 
-    public static String DEFFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+    public static String DEFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
     public static int    DEFAULT_GENERATE_FEATURE;
 

--- a/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
+++ b/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
@@ -80,7 +80,7 @@ public class DefaultJSONParser extends AbstractJSONParser implements Closeable {
 
     private final static Set<Class<?>> primitiveClasses   = new HashSet<Class<?>>();
 
-    private String                     dateFormatPattern  = JSON.DEFFAULT_DATE_FORMAT;
+    private String                     dateFormatPattern  = JSON.DEFAULT_DATE_FORMAT;
     private DateFormat                 dateFormat;
 
     protected final JSONLexer          lexer;

--- a/src/main/java/com/alibaba/fastjson/serializer/DateSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/DateSerializer.java
@@ -45,7 +45,7 @@ public class DateSerializer implements ObjectSerializer {
         if (out.isEnabled(SerializerFeature.WriteDateUseDateFormat)) {
             DateFormat format = serializer.getDateFormat();
             if (format == null) {
-                format = new SimpleDateFormat(JSON.DEFFAULT_DATE_FORMAT);
+                format = new SimpleDateFormat(JSON.DEFAULT_DATE_FORMAT);
             }
             String text = format.format(date);
             out.writeString(text);

--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -283,8 +283,8 @@ public class TypeUtils {
 
             if (strVal.indexOf('-') != -1) {
                 String format;
-                if (strVal.length() == JSON.DEFFAULT_DATE_FORMAT.length()) {
-                    format = JSON.DEFFAULT_DATE_FORMAT;
+                if (strVal.length() == JSON.DEFAULT_DATE_FORMAT.length()) {
+                    format = JSON.DEFAULT_DATE_FORMAT;
                 } else if (strVal.length() == 10) {
                     format = "yyyy-MM-dd";
                 } else if (strVal.length() == "yyyy-MM-dd HH:mm:ss".length()) {

--- a/src/test/java/com/alibaba/json/bvt/TimestampTest.java
+++ b/src/test/java/com/alibaba/json/bvt/TimestampTest.java
@@ -14,7 +14,7 @@ public class TimestampTest extends TestCase {
     public void test_0 () throws Exception {
         long millis = (System.currentTimeMillis() / 1000) * 1000;
         
-        String text = "\"" + new SimpleDateFormat(JSON.DEFFAULT_DATE_FORMAT).format(new Date(millis)) + "\"";
+        String text = "\"" + new SimpleDateFormat(JSON.DEFAULT_DATE_FORMAT).format(new Date(millis)) + "\"";
         System.out.println(text);
         Assert.assertEquals(new Timestamp(millis), JSON.parseObject("" + millis, Timestamp.class));
         Assert.assertEquals(new Timestamp(millis), JSON.parseObject("\"" + millis + "\"", Timestamp.class));

--- a/src/test/java/com/alibaba/json/bvt/bug/Bug_for_xiayucai2012.java
+++ b/src/test/java/com/alibaba/json/bvt/bug/Bug_for_xiayucai2012.java
@@ -16,6 +16,6 @@ public class Bug_for_xiayucai2012 extends TestCase {
         JSONObject json = JSON.parseObject(text);
         Date date = json.getObject("date", Date.class);
         
-        Assert.assertEquals(new SimpleDateFormat(JSON.DEFFAULT_DATE_FORMAT).parse(json.getString("date")), date);
+        Assert.assertEquals(new SimpleDateFormat(JSON.DEFAULT_DATE_FORMAT).parse(json.getString("date")), date);
     }
 }

--- a/src/test/java/com/alibaba/json/bvt/parser/TypeUtilsTest_castToDate.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/TypeUtilsTest_castToDate.java
@@ -13,10 +13,10 @@ import com.alibaba.fastjson.util.TypeUtils;
 public class TypeUtilsTest_castToDate extends TestCase {
 
     public void test_castToDate() throws Exception {
-        JSON.DEFFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
+        JSON.DEFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
         Date date = TypeUtils.castToDate("2012-07-15 12:12:11");
         Assert.assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parseObject("2012-07-15 12:12:11"), date);
-        JSON.DEFFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+        JSON.DEFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
     }
 
     public void test_castToDate_error() throws Exception {


### PR DESCRIPTION
As described by [Issue#323](https://github.com/alibaba/fastjson/issues/323)
"DEFFAULT_DATE_FORMAT" in JSON.java is miss-typing,
fix it with "DEFAULT_DATE_FORMAT"