### PR TITLE
在JSONObject里面添加beLinkedHashMap标志 用于clone方法时使用哪种map进行包装

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONObject.java
+++ b/src/main/java/com/alibaba/fastjson/JSONObject.java
@@ -55,6 +55,8 @@ public class JSONObject extends JSON implements Map<String, Object>, Cloneable, 
 
     private final Map<String, Object> map;
 
+    private boolean beLinkedHashMap;
+
     public JSONObject(){
         this(DEFAULT_INITIAL_CAPACITY, false);
     }
@@ -74,8 +76,10 @@ public class JSONObject extends JSON implements Map<String, Object>, Cloneable, 
     public JSONObject(int initialCapacity, boolean ordered){
         if (ordered) {
             map = new LinkedHashMap<String, Object>(initialCapacity);
+            beLinkedHashMap = true;
         } else {
             map = new HashMap<String, Object>(initialCapacity);
+            beLinkedHashMap = false;
         }
     }
 
@@ -320,7 +324,7 @@ public class JSONObject extends JSON implements Map<String, Object>, Cloneable, 
 
     @Override
     public Object clone() {
-        return new JSONObject(new HashMap<String, Object>(map));
+        return  beLinkedHashMap?new JSONObject(new LinkedHashMap<String, Object>(map)):new JSONObject(new HashMap<String, Object>(map));
     }
 
     public boolean equals(Object obj) {

--- a/src/test/java/com/alibaba/json/bvt/JSONObjectTest5.java
+++ b/src/test/java/com/alibaba/json/bvt/JSONObjectTest5.java
@@ -1,0 +1,19 @@
+package com.alibaba.json.bvt;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.annotation.JSONField;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+public class JSONObjectTest5 extends TestCase {
+
+    public void test() throws Exception {
+        JSONObject jsonObject = new JSONObject(3, true);
+        jsonObject.put("name", "J.K.SAGE");
+        jsonObject.put("age", 21);
+        jsonObject.put("msg", "Hello!");
+        JSONObject cloneObject = (JSONObject) jsonObject.clone();
+        assertEquals(JSON.toJSONString(jsonObject), JSON.toJSONString(cloneObject));
+    }
+}


### PR DESCRIPTION
解决JSONObject使用LinkedMap实现时 clone方法有误 