### PR TITLE
bugfix: 通过jsonpath修改jsonarray中的值时抛出异常UnsupportedOperationException

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONPath.java
+++ b/src/main/java/com/alibaba/fastjson/JSONPath.java
@@ -1682,6 +1682,16 @@ public class JSONPath implements ObjectSerializer {
             return true;
         }
 
+        if (parent instanceof List) {
+            for (Object element : (List) parent) {
+                if (element == null) {
+                    continue;
+                }
+                setPropertyValue(element, name, value);
+            }
+            return true;
+        }
+
         ObjectDeserializer derializer = parserConfig.getDeserializer(parent.getClass());
 
         JavaBeanDeserializer beanDerializer = null;


### PR DESCRIPTION
the code JSONPath.set(rootObject, "$.array[0:].key", "123") will throw UnsupportedOperationException