### PR TITLE
simple fix isXXX bugs

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -1134,6 +1134,9 @@ public class TypeUtils {
 
                 if (field == null) {
                     field = ParserConfig.getField(clazz, methodName);
+                    if(field != null){
+                        propertyName = methodName;
+                    }
                 }
 
                 if (field != null) {

--- a/src/test/java/com/alibaba/json/demo/TestCase.java
+++ b/src/test/java/com/alibaba/json/demo/TestCase.java
@@ -1,0 +1,64 @@
+package com.alibaba.json.demo;
+
+import com.alibaba.fastjson.JSON;
+
+/**
+ * Created by hanzhankang on 15/9/30.
+ */
+public class TestCase {
+    boolean isPromiseSale1;
+    Boolean isPromiseSale2;
+    String isName;
+    String getName;
+    String name;
+
+    public boolean isPromiseSale1() {
+        return isPromiseSale1;
+    }
+
+    public void setIsPromiseSale1(boolean isPromiseSale1) {
+        this.isPromiseSale1 = isPromiseSale1;
+    }
+
+    public Boolean isPromiseSale2() {
+        return isPromiseSale2;
+    }
+
+    public void setIsPromiseSale2(Boolean isPromiseSale2) {
+        this.isPromiseSale2 = isPromiseSale2;
+    }
+
+    public String getIsName() {
+        return isName;
+    }
+
+    public void setIsName(String isName) {
+        this.isName = isName;
+    }
+
+    public String getGetName() {
+        return getName;
+    }
+
+    public void setGetName(String getName) {
+        this.getName = getName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public static void main(String[] args) {
+        TestCase tb = new TestCase();
+        tb.setIsPromiseSale1(true);
+        tb.setIsPromiseSale2(true);
+        tb.setName("name");
+        tb.setGetName("getName");
+        tb.setIsName("isName");
+        System.out.println("结果输出："+JSON.toJSON(tb));
+    }
+}


### PR DESCRIPTION
纯粹的JavaBean中含有boolean isXXX的属性，且get方法通过自动生成器生成代码：boolean isXXX(){...}时，调用JSON.toJSON(object)时，生成的json字符串中会将此属性名中的“is”去掉，引起通过字符串反序列化类数据丢失。
这种情况与属性是否被boolean/Boolean修饰无关。