### PR TITLE
Incorrect Spelling of A Constant

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -81,7 +81,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         DEFAULT_PARSER_FEATURE = features;
     }
 
-    public static String DEFFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+    public static String DEFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
     public static int    DEFAULT_GENERATE_FEATURE;
 


### PR DESCRIPTION
Line 84 there is a spelling mistake - 'DEFFAULT_DATE_FORMAT',which I suppose to be 'DEFAULT_DATE_FORMAT'.