### PR TITLE
Expose peek method to handle reading object fields that may be null, …

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONReader.java
+++ b/src/main/java/com/alibaba/fastjson/JSONReader.java
@@ -137,6 +137,14 @@ public class JSONReader implements Closeable {
         }
     }
 
+    public int peek() {
+        if (context == null) {
+            throw new JSONException("context is null");
+        }
+
+        return parser.getLexer().token();
+    }
+
     public void close() {
         IOUtils.close(parser);
     }


### PR DESCRIPTION
…similar to GSON.

https://google-gson.googlecode.com/svn/trunk/gson/docs/javadocs/com/google/gson/stream/JsonReader.html

Since I was unable to use JSONReader to handle fields that may be objects (beginObject) or null.  If I overlooked something please let me know :)