### PR TITLE
browserCompatible feature add: double quote long fields exceed [-2^53+1, 2^53-1]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<gpg.skip>false</gpg.skip>
 		<javadoc.skip>false</javadoc.skip>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jdk.version>1.5</jdk.version>
+		<jdk.version>1.6</jdk.version>
 	</properties>
 
 	<developers>

--- a/src/test/java/com/alibaba/json/bvt/serializer/ListSerializerTest.java
+++ b/src/test/java/com/alibaba/json/bvt/serializer/ListSerializerTest.java
@@ -1,15 +1,15 @@
 package com.alibaba.json.bvt.serializer;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import org.junit.Assert;
-import junit.framework.TestCase;
-
 import com.alibaba.fastjson.serializer.JSONSerializer;
 import com.alibaba.fastjson.serializer.ListSerializer;
 import com.alibaba.fastjson.serializer.SerializeWriter;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class ListSerializerTest extends TestCase {
 
@@ -74,5 +74,43 @@ public class ListSerializerTest extends TestCase {
         listSerializer.write(new JSONSerializer(out), list, null, null, 0);
 
         Assert.assertEquals("[1,21474836480,null,{},21474836480]", out.toString());
+    }
+
+    public void test_6_s() throws Exception {
+        SerializeWriter out = new SerializeWriter(SerializerFeature.BrowserCompatible);
+
+        ListSerializer listSerializer = new ListSerializer();
+        List<Object> list = new ArrayList<Object>();
+        list.add(1L);
+        list.add(1453964515792017682L);
+        listSerializer.write(new JSONSerializer(out), list, null, null, 0);
+
+        Assert.assertEquals("[1,\"1453964515792017682\"]", out.toString());
+    }
+
+    public void test_7_s() throws Exception {
+        SerializeWriter out = new SerializeWriter(
+                SerializerFeature.BrowserCompatible, SerializerFeature.WriteClassName
+        );
+
+        ListSerializer listSerializer = new ListSerializer();
+        List<Object> list = new ArrayList<Object>();
+        list.add(1L);
+        list.add(1453964515792017682L);
+        listSerializer.write(new JSONSerializer(out), list, null, null, 0);
+
+        Assert.assertEquals("[1L,1453964515792017682L]", out.toString());
+    }
+
+    public void test_8_s() throws Exception {
+        SerializeWriter out = new SerializeWriter(SerializerFeature.WriteClassName);
+
+        ListSerializer listSerializer = new ListSerializer();
+        List<Object> list = new ArrayList<Object>();
+        list.add(1L);
+        list.add(1453964515792017682L);
+        listSerializer.write(new JSONSerializer(out), list, null, null, 0);
+
+        Assert.assertEquals("[1L,1453964515792017682L]", out.toString());
     }
 }

--- a/src/test/java/com/alibaba/json/bvt/serializer/SerializeWriterTest.java
+++ b/src/test/java/com/alibaba/json/bvt/serializer/SerializeWriterTest.java
@@ -1,11 +1,11 @@
 package com.alibaba.json.bvt.serializer;
 
-import java.io.StringWriter;
-
-import org.junit.Assert;
-import junit.framework.TestCase;
-
 import com.alibaba.fastjson.serializer.SerializeWriter;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import java.io.StringWriter;
 
 public class SerializeWriterTest extends TestCase {
 
@@ -64,6 +64,18 @@ public class SerializeWriterTest extends TestCase {
         Assert.assertEquals(Long.toString(Long.MIN_VALUE), out.toString());
     }
 
+    public void test_13_long_browser() throws Exception {
+        SerializeWriter out = new SerializeWriter(SerializerFeature.BrowserCompatible);
+        out.writeLong(Long.MIN_VALUE + 1);
+        Assert.assertEquals("\"" + Long.toString(Long.MIN_VALUE + 1) + "\"", out.toString());
+    }
+
+    public void test_13_long_browser2() throws Exception {
+        SerializeWriter out = new SerializeWriter(SerializerFeature.BrowserCompatible);
+        out.writeLong(Long.MIN_VALUE);
+        Assert.assertEquals("\"" + Long.toString(Long.MIN_VALUE) + "\"", out.toString());
+    }
+
     public void test_14() throws Exception {
         SerializeWriter out = new SerializeWriter(1);
         out.writeInt(Integer.MAX_VALUE);
@@ -98,6 +110,18 @@ public class SerializeWriterTest extends TestCase {
         SerializeWriter out = new SerializeWriter(1);
         out.writeLongAndChar(Long.MIN_VALUE, ',');
         Assert.assertEquals(Long.toString(Long.MIN_VALUE) + ",", out.toString());
+    }
+
+    public void test_16_long_browser() throws Exception {
+        SerializeWriter out = new SerializeWriter(SerializerFeature.BrowserCompatible);
+        out.writeLongAndChar(Long.MIN_VALUE + 1, ',');
+        Assert.assertEquals("\"" + Long.toString(Long.MIN_VALUE + 1) + "\",", out.toString());
+    }
+
+    public void test_16_long_browser2() throws Exception {
+        SerializeWriter out = new SerializeWriter(SerializerFeature.BrowserCompatible);
+        out.writeLongAndChar(Long.MIN_VALUE, ',');
+        Assert.assertEquals("\"" + Long.toString(Long.MIN_VALUE) + "\",", out.toString());
     }
 
     public void test_17() throws Exception {


### PR DESCRIPTION
BrowserCompatible feature 增加一个功能, 将超出  [-2^53+1, 2^53-1] 范围的 long 类型输出为字符串, 以免浏览器将 json 转换为对象后精度丢失, 导致数据错误.