### PR TITLE
#340,#471 fixed

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
+++ b/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
@@ -997,7 +997,7 @@ public class DefaultJSONParser extends AbstractJSONParser implements Closeable {
 
     public JSONObject parseObject() {
         JSONObject object = new JSONObject(isEnabled(Feature.OrderedField));
-        parseObject(object);
+        object = (JSONObject) parseObject(object);
         return object;
     }
 

--- a/src/test/java/com/alibaba/fastjson/serializer/TestBean.java
+++ b/src/test/java/com/alibaba/fastjson/serializer/TestBean.java
@@ -1,0 +1,28 @@
+package com.alibaba.fastjson.serializer;
+
+import com.alibaba.fastjson.JSONObject;
+
+/**
+ * java bean for test
+ * Created by yixian on 2016-02-25.
+ */
+class TestBean {
+    private JSONObject data;
+    private String name;
+
+    public JSONObject getData() {
+        return data;
+    }
+
+    public void setData(JSONObject data) {
+        this.data = data;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/serializer/TestParse.java
+++ b/src/test/java/com/alibaba/fastjson/serializer/TestParse.java
@@ -1,0 +1,37 @@
+package com.alibaba.fastjson.serializer;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.logging.Logger;
+
+/**
+ * test parse json contains jsonobject in javabean
+ * Created by yixian on 2016-02-25.
+ */
+public class TestParse {
+    private final Logger logger = Logger.getLogger(TestParse.class.getSimpleName());
+
+    private String jsonString;
+
+    @Before
+    public void prepareJsonString() {
+        TestBean bean = new TestBean();
+        bean.setName("tester");
+        JSONObject data = new JSONObject();
+        data.put("key", "value");
+        bean.setData(data);
+        jsonString = JSON.toJSONString(bean, SerializerFeature.WriteClassName);
+    }
+
+    @Test
+    public void testParse() {
+        logger.info("parsing json string:" + jsonString);
+        TestBean testBean = (TestBean) JSON.parse(jsonString);
+        assert testBean.getData() != null;
+        assert "tester".equals(testBean.getName());
+        assert "value".equals(testBean.getData().getString("key"));
+    }
+}


### PR DESCRIPTION
当反序列化带classname的json string到java bean时，无法正常反序列化java bean 中的JSONObject类型字段（无论有没有内容返回的JSONObject都是空的，但Map<String,Object>类型可以正常反序列化）的bug修复
---------------
fix the bug of #340 #471 
when serialize a java bean contains a field which type is JSONObject and use WriteClassName feather,
we get a json string.
and then deserialize this json string back to java bean we will find the JSONObject field in the bean is empty

this pull request will fix this problem