### PR TITLE
bug fixed for JDK 5、6、7 compatible

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
@@ -108,7 +108,7 @@ public class JavaBeanDeserializer implements ObjectDeserializer {
         Object object;
         try {
             Constructor<?> constructor = beanInfo.getDefaultConstructor();
-            if (constructor.getParameterCount() == 0) {
+            if (constructor.getParameterTypes().length == 0) {
                 object = constructor.newInstance();
             } else {
                 object = constructor.newInstance(parser.getContext().getObject());

--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/ThrowableDeserializer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/ThrowableDeserializer.java
@@ -127,19 +127,18 @@ public class ThrowableDeserializer extends JavaBeanDeserializer {
         Constructor<?> messageConstructor = null;
         Constructor<?> causeConstructor = null;
         for (Constructor<?> constructor : exClass.getConstructors()) {
-            if (constructor.getParameterCount() == 0) {
+        	Class<?>[] types = constructor.getParameterTypes();
+            if (types.length == 0) {
                 defaultConstructor = constructor;
                 continue;
             }
 
-            if (constructor.getParameterCount() == 1 && constructor.getParameterTypes()[0] == String.class) {
+            if (types.length == 1 && types[0] == String.class) {
                 messageConstructor = constructor;
                 continue;
             }
 
-            Class<?>[] types;
-            if (constructor.getParameterCount() == 2 && (types = constructor.getParameterTypes())[0] == String.class
-                && types[1] == Throwable.class) {
+            if (types.length == 2 && types[0] == String.class && types[1] == Throwable.class) {
                 causeConstructor = constructor;
                 continue;
             }

--- a/src/main/java/com/alibaba/fastjson/util/DeserializeBeanInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/DeserializeBeanInfo.java
@@ -142,10 +142,10 @@ public class DeserializeBeanInfo {
                 TypeUtils.setAccessible(creatorConstructor);
                 beanInfo.setCreatorConstructor(creatorConstructor);
 
-                int count = creatorConstructor.getParameterCount();
-                if (count > 0) {
+                Class<?>[] types = creatorConstructor.getParameterTypes();
+                if (types.length > 0) {
                 	Annotation[][] paramAnnotationArrays = creatorConstructor.getParameterAnnotations();
-                	for (int i = 0; i < count; ++i) {
+                	for (int i = 0; i < types.length; ++i) {
                 		Annotation[] paramAnnotations = paramAnnotationArrays[i];
                 		JSONField fieldAnnotation = null;
                 		for (Annotation paramAnnotation : paramAnnotations) {
@@ -157,7 +157,7 @@ public class DeserializeBeanInfo {
                 		if (fieldAnnotation == null) {
                 			throw new JSONException("illegal json creator");
                 		}
-                		Class<?> fieldClass = creatorConstructor.getParameterTypes()[i];
+                		Class<?> fieldClass = types[i];
                 		Type fieldType = creatorConstructor.getGenericParameterTypes()[i];
                 		Field field = TypeUtils.getField(clazz, fieldAnnotation.name());
                 		final int ordinal = fieldAnnotation.ordinal();
@@ -174,11 +174,10 @@ public class DeserializeBeanInfo {
             if (factoryMethod != null) {
                 TypeUtils.setAccessible(factoryMethod);
                 beanInfo.setFactoryMethod(factoryMethod);
-                
-                int count = factoryMethod.getParameterCount();
-                if (count > 0) {
+                Class<?>[] types = factoryMethod.getParameterTypes();
+                if (types.length > 0) {
                 	Annotation[][] paramAnnotationArrays = factoryMethod.getParameterAnnotations();
-                	for (int i = 0; i < count; ++i) {
+                	for (int i = 0; i < types.length; ++i) {
                         Annotation[] paramAnnotations = paramAnnotationArrays[i];
                         JSONField fieldAnnotation = null;
                         for (Annotation paramAnnotation : paramAnnotations) {
@@ -191,7 +190,7 @@ public class DeserializeBeanInfo {
                             throw new JSONException("illegal json creator");
                         }
 
-                        Class<?> fieldClass = factoryMethod.getParameterTypes()[i];
+                        Class<?> fieldClass = types[i];
                         Type fieldType = factoryMethod.getGenericParameterTypes()[i];
                         Field field = TypeUtils.getField(clazz, fieldAnnotation.name());
                         final int ordinal = fieldAnnotation.ordinal();
@@ -328,8 +327,8 @@ public class DeserializeBeanInfo {
             if (!(method.getReturnType().equals(Void.TYPE) || method.getReturnType().equals(clazz))) {
                 continue;
             }
-
-            if (method.getParameterCount() != 1) {
+            Class<?>[] types = method.getParameterTypes();
+            if (types.length != 1) {
                 continue;
             }
 
@@ -380,7 +379,7 @@ public class DeserializeBeanInfo {
             }
 
             Field field = TypeUtils.getField(clazz, propertyName);
-            if (field == null && method.getParameterTypes()[0] == boolean.class) {
+            if (field == null && types[0] == boolean.class) {
                 String isFieldName = "is" + Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
                 field = TypeUtils.getField(clazz, isFieldName);
             }
@@ -448,7 +447,7 @@ public class DeserializeBeanInfo {
             }
 
             if (methodName.startsWith("get") && Character.isUpperCase(methodName.charAt(3))) {
-                if (method.getParameterCount() != 0) {
+                if (method.getParameterTypes().length != 0) {
                     continue;
                 }
 
@@ -489,7 +488,7 @@ public class DeserializeBeanInfo {
         final Constructor<?>[] constructors = clazz.getDeclaredConstructors();
         
         for (Constructor<?> constructor : constructors) {
-            if (constructor.getParameterCount() == 0) { // getParameterTypes() 内部是调用数组的克隆方法，开销相对较大
+            if (constructor.getParameterTypes().length == 0) {
                 defaultConstructor = constructor;
                 break;
             }
@@ -497,9 +496,9 @@ public class DeserializeBeanInfo {
 
         if (defaultConstructor == null) {
             if (clazz.isMemberClass() && !Modifier.isStatic(clazz.getModifiers())) {
+            	Class<?>[] types;
                 for (Constructor<?> constructor : constructors) {
-                    if (constructor.getParameterCount() == 1 
-                    		&& constructor.getParameterTypes()[0].equals(clazz.getDeclaringClass())) {
+                    if ( (types = constructor.getParameterTypes()).length == 1 && types[0].equals(clazz.getDeclaringClass())) {
                         defaultConstructor = constructor;
                         break;
                     }

--- a/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
@@ -84,8 +84,9 @@ public class FieldInfo implements Comparable<FieldInfo> {
         Type fieldType;
         Class<?> fieldClass;
         if (method != null) {
-            if (method.getParameterTypes().length == 1) {
-                fieldClass = method.getParameterTypes()[0];
+        	Class<?>[] types;
+            if ((types = method.getParameterTypes()).length == 1) {
+                fieldClass = types[0];
                 fieldType = method.getGenericParameterTypes()[0];
             } else {
                 fieldClass = method.getReturnType();

--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -1330,28 +1330,22 @@ public class TypeUtils {
     public static JSONField getSupperMethodAnnotation(final Class<?> clazz, final Method method) {
     	Class<?>[] interfaces = clazz.getInterfaces();
     	if (interfaces.length > 0) {
-    		int paramsCount = method.getParameterCount();
-    		Class<?>[] methodParamTypes = null;
+    		Class<?>[] types = method.getParameterTypes(); 
     		for (Class<?> interfaceClass : interfaces) {
                 for (Method interfaceMethod : interfaceClass.getMethods()) {
-                	if (interfaceMethod.getParameterCount() != paramsCount) {
+                	Class<?>[] interfaceTypes = interfaceMethod.getParameterTypes(); 
+                	if (interfaceTypes.length != types.length) {
                 		continue;					
 					}
                     if (!interfaceMethod.getName().equals(method.getName())) {
                         continue;
                     }
                     boolean match = true;
-                    if (paramsCount > 0) {						
-                    	Class<?>[] interfaceTypes = interfaceMethod.getParameterTypes();
-                    	if (methodParamTypes == null) {
-                    		methodParamTypes = method.getParameterTypes();							
-						}
-	                    for (int i = 0; i < paramsCount; ++i) {
-	                        if (!interfaceTypes[i].equals(methodParamTypes[i])) {
-	                            match = false;
-	                            break;
-	                        }
-	                    }
+                    for (int i = 0; i < types.length; ++i) {
+                        if (!interfaceTypes[i].equals(types[i])) {
+                            match = false;
+                            break;
+                        }
                     }
 
                     if (!match) {


### PR DESCRIPTION
将 getParameterCount() 系列方法还原并进行细微优化，以向下兼容JDK 5、6、7等低版本。
Java 官方 API 中只要是返回类型为数组的方法，为了保证数组内部的完整性（不被外部进行引用修改），它们在方法内部都是"克隆"一个新的数组出来再返回。不过这也导致其存在一定的性能和内存消耗，有些时候我们只是想获得数组的长度罢了，或者只是简单地引用数组（而不会对其进行修改）。这种开销在"大"数组上体现得尤为明显。如果 Java 能够提供一种机制实现"不可变"的数组就好了。