### PR TITLE
fix:write boolean key without quoteFieldNames

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
@@ -15,7 +15,9 @@
  */
 package com.alibaba.fastjson.serializer;
 
-import static com.alibaba.fastjson.util.IOUtils.replaceChars;
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.util.IOUtils;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -24,9 +26,7 @@ import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.util.List;
 
-import com.alibaba.fastjson.JSON;
-import com.alibaba.fastjson.JSONException;
-import com.alibaba.fastjson.util.IOUtils;
+import static com.alibaba.fastjson.util.IOUtils.replaceChars;
 
 /**
  * @author wenshao[szujobs@hotmail.com]
@@ -1155,6 +1155,12 @@ public final class SerializeWriter extends Writer {
     }
 
     public void writeFieldValue(char seperator, String name, boolean value) {
+        if (!quoteFieldNames) {
+            write(seperator);
+            writeFieldName(name);
+            write(value);
+            return;
+        }
         int intSize = value ? 4 : 5;
 
         int nameLen = name.length();

--- a/src/test/java/com/alibaba/json/bvt/serializer/stream/StreamWriterTest_writeFieldValue_bool.java
+++ b/src/test/java/com/alibaba/json/bvt/serializer/stream/StreamWriterTest_writeFieldValue_bool.java
@@ -1,7 +1,6 @@
 package com.alibaba.json.bvt.serializer.stream;
 
 import com.alibaba.fastjson.serializer.SerializeWriter;
-import com.alibaba.fastjson.serializer.SerializerFeature;
 
 import junit.framework.TestCase;
 
@@ -10,18 +9,17 @@ import org.junit.Assert;
 import java.io.StringWriter;
 
 
-public class StreamWriterTest_writeFieldValue extends TestCase {
+public class StreamWriterTest_writeFieldValue_bool extends TestCase {
     public void test_0() throws Exception {
         StringWriter out = new StringWriter();
         
         SerializeWriter writer = new SerializeWriter(out, 10);
         Assert.assertEquals(10, writer.getBufferLength());
         
-        writer.config(SerializerFeature.QuoteFieldNames, true);
         writer.writeFieldValue(',', "abcde01245abcde", true);
         writer.close();
         
         String text = out.toString();
-        Assert.assertEquals(",\"abcde01245abcde\":true", text);
+        Assert.assertEquals(",abcde01245abcde:true", text);
     }
 }


### PR DESCRIPTION
Fix issue `https://github.com/alibaba/fastjson/issues/634`, write boolean value  filedName, the unquoteFieldNames should be work. 