### PR TITLE
添加深度复制功能，方便大家的使用

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -917,7 +917,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
                 ((Object)clazz == (Object)Object[].class) ? (Object[])new Object[arr.length] : (Object[])Array.newInstance(
                     clazz.getComponentType(), arr.length);
             for(int i=0; i < arr.length; i++) {
-                res[i]=deepClone(arr[i]);
+                res[i]=deepClone(arr[i], features);
             }
             return res;
         } else {

--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -905,6 +905,26 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         return TypeUtils.cast(json, clazz, ParserConfig.getGlobalInstance());
     }
     
+	public static Object deepClone(Object obj, SerializerFeature... features) throws Exception {
+        if(null == obj) {
+            return null;
+        }
+        Class<?> clazz=obj.getClass();
+        if(clazz.isArray()) {
+            Object[] arr=(Object[])obj;
+
+            Object[] res=
+                ((Object)clazz == (Object)Object[].class) ? (Object[])new Object[arr.length] : (Object[])Array.newInstance(
+                    clazz.getComponentType(), arr.length);
+            for(int i=0; i < arr.length; i++) {
+                res[i]=deepClone(arr[i]);
+            }
+            return res;
+        } else {
+            String json=JSON.toJSONString(obj, features);
+            return JSON.parseObject(json, clazz);
+        }
+    }
     /**
      * @since 1.2.9
      */


### PR DESCRIPTION
使用fastjson进行深度复制要比较使用jdk或hessian要高些，所在以实际项目还是很大的价值。
下面是我的测试代码：

    private static void fastJsonTest() {
        List<User> list=new ArrayList<User>();
        User user=new User();
        user.setId(1);
        user.setName("test");
        user.setBirthday(new Date());
        list.add(user);
        Map<Integer, User> map=new HashMap<Integer, User>();
        map.put(user.getId(), user);
        Object[] arr=new Object[]{1, "test", list, map, User.class};
        ISerializer<Object> s=new FastjsonSerializer();
        try {
            System.out.println("--------------obj arr------------------");
            Object[] rs=(Object[])s.deepClone(arr);
            for(int i=0; i < rs.length; i++) {
                Object obj=rs[i];
                System.out.println(obj.getClass().getName() + "--->" + obj);
            }
        } catch(Exception e) {
            // TODO Auto-generated catch block
            e.printStackTrace();
        }
        System.out.println("--------------user arr------------------");
        User[] arr2=new User[]{user};
        try {
            Object[] rs=(Object[])s.deepClone(arr2);
            for(int i=0; i < rs.length; i++) {
                Object obj=rs[i];
                System.out.println(obj.getClass().getName() + "--->" + obj);
            }
        } catch(Exception e) {
            // TODO Auto-generated catch block
            e.printStackTrace();
        }
        System.out.println("--------------map------------------");
        try {
            Map<Integer, User> obj=(Map<Integer, User>)s.deepClone(map);
            System.out.println(obj.getClass().getName() + "--->" + obj);
        } catch(Exception e) {
            // TODO Auto-generated catch block
            e.printStackTrace();
        }
    }