### PR TITLE
扩展Swagger的Json处理：解决/v2/api-docs获取不到内容，导致显示不出不到API页面内容的问题

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
@@ -259,6 +259,13 @@ public class SerializeConfig {
 		
 		put(WeakReference.class, ReferenceCodec.instance);
 		put(SoftReference.class, ReferenceCodec.instance);
+
+        // swagger support
+        try {
+            put(Class.forName("springfox.documentation.spring.web.json.Json"), SwaggerJsonSerializer.instance);
+        } catch (ClassNotFoundException e) {
+        }
+
 	}
 	
 	/**

--- a/src/main/java/com/alibaba/fastjson/serializer/SwaggerJsonSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SwaggerJsonSerializer.java
@@ -1,0 +1,36 @@
+package com.alibaba.fastjson.serializer;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+
+/**
+ * Swagger的Json处理，解决/v2/api-docs获取不到内容导致获取不到API页面内容的问题
+ *
+ * @Author zhaiyongchao
+ * @Blog http://blog.didispace.com
+ * @Date 2016/07/04
+ */
+public class SwaggerJsonSerializer implements ObjectSerializer {
+
+    public final static SwaggerJsonSerializer instance = new SwaggerJsonSerializer();
+
+    public void write(JSONSerializer serializer, Object object, Object fieldName, Type fieldType, int features) throws IOException {
+        SerializeWriter out = serializer.getWriter();
+        try {
+            Class clazz = Class.forName("springfox.documentation.spring.web.json.Json");
+            Method method = clazz.getDeclaredMethod("value");
+            out.write(method.invoke(object).toString());
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        }
+    }
+
+}


### PR DESCRIPTION
当在spring mvc使用fastjson作为MesageConverter的时候，整合Swagger来生成API文档，会出来/v2/api-docs解析出的json为{}，是由于swagger的springfox.documentation.spring.web.json.Json对象较为特殊，增加这个序列化映射关系可解决此问题，让API文档正常产生。