### PR TITLE
Fixed com.alibaba.json.bvt.bug.Bug_for_smoothrat8 to not rely on unguaranteed order

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/bug/Bug_for_smoothrat8.java
+++ b/src/test/java/com/alibaba/json/bvt/bug/Bug_for_smoothrat8.java
@@ -1,6 +1,6 @@
 package com.alibaba.json.bvt.bug;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -12,7 +12,7 @@ import com.alibaba.fastjson.serializer.SerializerFeature;
 public class Bug_for_smoothrat8 extends TestCase {
 
     public void test_set() throws Exception {
-        Map<Integer, Object> map = new HashMap<Integer, Object>();
+        Map<Integer, Object> map = new LinkedHashMap<Integer, Object>();
         map.put(1, "a");
         map.put(2, "b");
 
@@ -22,7 +22,7 @@ public class Bug_for_smoothrat8 extends TestCase {
 
         String text = JSON.toJSONString(entity, SerializerFeature.WriteClassName);
         System.out.println(text);
-        Assert.assertEquals("{\"@type\":\"com.alibaba.json.bvt.bug.Bug_for_smoothrat8$Entity\",\"value\":{\"@type\":\"java.util.HashMap\",1:\"a\",2:\"b\"}}",
+        Assert.assertEquals("{\"@type\":\"com.alibaba.json.bvt.bug.Bug_for_smoothrat8$Entity\",\"value\":{\"@type\":\"java.util.LinkedHashMap\",1:\"a\",2:\"b\"}}",
                             text);
 
         Entity entity2 = JSON.parseObject(text, Entity.class);


### PR DESCRIPTION
The test assumes that HashMap is iterated in a certain order, which can cause the test to fail under different java versions or platforms.

The fix simply changes HashMap to LinkedHashMap, as LinkedHashMap does guarantee an order of iteration.