### PR TITLE
Fixed 2 more tests that relied on non-deterministic APIs

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/bug/Bug_for_smoothrat5.java
+++ b/src/test/java/com/alibaba/json/bvt/bug/Bug_for_smoothrat5.java
@@ -1,6 +1,6 @@
 package com.alibaba.json.bvt.bug;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -13,9 +13,9 @@ import com.alibaba.fastjson.serializer.SerializerFeature;
 public class Bug_for_smoothrat5 extends TestCase {
 
     public void test_map() throws Exception {
-        Map<Object, Object> map = new HashMap<Object, Object>();
-        map.put(12, "a");
+        Map<Object, Object> map = new LinkedHashMap<Object, Object>();
         map.put(34L, "b");
+        map.put(12, "a");
 
         Entity entity = new Entity();
 
@@ -23,7 +23,7 @@ public class Bug_for_smoothrat5 extends TestCase {
 
         String text = JSON.toJSONString(entity, SerializerFeature.WriteClassName);
         System.out.println(text);
-        Assert.assertEquals("{\"@type\":\"com.alibaba.json.bvt.bug.Bug_for_smoothrat5$Entity\",\"value\":{\"@type\":\"java.util.HashMap\",34L:\"b\",12:\"a\"}}",
+        Assert.assertEquals("{\"@type\":\"com.alibaba.json.bvt.bug.Bug_for_smoothrat5$Entity\",\"value\":{\"@type\":\"java.util.LinkedHashMap\",34L:\"b\",12:\"a\"}}",
                             text);
 
         Entity entity2 = JSON.parseObject(text, Entity.class);

--- a/src/test/java/com/alibaba/json/bvt/bug/Bug_for_smoothrat9.java
+++ b/src/test/java/com/alibaba/json/bvt/bug/Bug_for_smoothrat9.java
@@ -1,6 +1,6 @@
 package com.alibaba.json.bvt.bug;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -12,14 +12,14 @@ import com.alibaba.fastjson.serializer.SerializerFeature;
 public class Bug_for_smoothrat9 extends TestCase {
 
     public void test_set() throws Exception {
-        Map<Integer, Object> map = new HashMap<Integer, Object>();
+        Map<Integer, Object> map = new LinkedHashMap<Integer, Object>();
         map.put(1, "a");
         map.put(2, "b");
 
 
         String text = JSON.toJSONString(map, SerializerFeature.WriteClassName);
         System.out.println(text);
-        Assert.assertEquals("{\"@type\":\"java.util.HashMap\",1:\"a\",2:\"b\"}",
+        Assert.assertEquals("{\"@type\":\"java.util.LinkedHashMap\",1:\"a\",2:\"b\"}",
                             text);
 
         Map<Integer, Object> value = (Map<Integer, Object>) JSON.parse(text);


### PR DESCRIPTION
The tests assume that HashMap is iterated in a certain order, which can cause the tests to fail under different java versions or platforms.

The fix simply changes HashMap to LinkedHashMap, as LinkedHashMap does guarantee an order of iteration.