### PR TITLE
Fixed com.alibaba.json.bvt.parser.DefaultExtJSONParserTest_4#test_1 to not rely on nondeterministic APIs

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/parser/DefaultExtJSONParserTest_4.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/DefaultExtJSONParserTest_4.java
@@ -46,12 +46,12 @@ public class DefaultExtJSONParserTest_4 extends TestCase {
             ext.config(Feature.AllowArbitraryCommas, true);
 
             JSONObject extRes = ext.parseObject();
-            Assert.assertEquals(res.toString(), extRes.toString());
+            Assert.assertEquals(res, extRes);
 
             DefaultJSONParser basic = new DefaultJSONParser(t);
             basic.config(Feature.AllowArbitraryCommas, true);
             JSONObject basicRes = basic.parseObject();
-            Assert.assertEquals(res.toString(), basicRes.toString());
+            Assert.assertEquals(res, basicRes);
         }
     }
 


### PR DESCRIPTION
The `JSONObject` uses a `HashMap` internally, so `res.toString()` has no guarantee to be in the same order as `extRes.toString()`

The fix simply compares the objects themselves. `JSONObject.equals()` just uses `HashMap.equals()`, so this still tests whether or not the 2 objects have the same elements, irrespective of their internal ordering.