### PR TITLE
Sort field

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/MapSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/MapSerializer.java
@@ -75,8 +75,14 @@ public class MapSerializer extends SerializeFilterable implements ObjectSerializ
             if (out.isEnabled(SerializerFeature.WriteClassName)) {
                 String typeKey = serializer.config.typeKey;
                 Class<?> mapClass = map.getClass();
-                boolean containsKey = (mapClass == JSONObject.class || mapClass == HashMap.class || mapClass == LinkedHashMap.class) 
-                        && map.containsKey(typeKey);
+                boolean containsKey;
+                try {
+                    containsKey = (mapClass == JSONObject.class || mapClass == HashMap.class ||
+                            mapClass == LinkedHashMap.class || mapClass == TreeMap.class)
+                            && map.containsKey(typeKey);
+                } catch (java.lang.ClassCastException e) {
+                    containsKey = false;
+                }
                 if (!containsKey) {
                     out.writeFieldName(typeKey);
                     out.writeString(object.getClass().getName());

--- a/src/main/java/com/alibaba/fastjson/serializer/MapSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/MapSerializer.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
@@ -43,15 +45,15 @@ public class MapSerializer extends SerializeFilterable implements ObjectSerializ
 
         Map<?, ?> map = (Map<?, ?>) object;
 
-//        if (out.isEnabled(SerializerFeature.SortField)) {
-//            if ((!(map instanceof SortedMap)) && !(map instanceof LinkedHashMap)) {
-//                try {
-//                    map = new TreeMap(map);
-//                } catch (Exception ex) {
-//                    // skip
-//                }
-//            }
-//        }
+        if (out.isEnabled(SerializerFeature.SortField)) {
+            if ((!(map instanceof SortedMap)) && !(map instanceof LinkedHashMap)) {
+                try {
+                    map = new TreeMap(map);
+                } catch (Exception ex) {
+                    // skip
+                }
+            }
+        }
 
         if (serializer.containsReference(object)) {
             serializer.writeReference(object);

--- a/src/test/java/com/alibaba/json/bvt/asm/SortFieldTest.java
+++ b/src/test/java/com/alibaba/json/bvt/asm/SortFieldTest.java
@@ -32,32 +32,32 @@ public void test_1() throws Exception {
 
     // 按字段顺序输出
     // {"f1":0,"f2":0,"f3":0,"f4":0,"f5":0} 
-    Assert.assertEquals("{\"f1\":0,\"f2\":0,\"f3\":0,\"f4\":0,\"f5\":0}", text);
+    Assert.assertEquals("{\"abc\":0,\"bar\":0,\"baz\":0,\"foo\":0,\"xyz\":0}", text);
 
     JSONObject object = JSON.parseObject(text);
     text = JSON.toJSONString(object, SerializerFeature.SortField);
-    Assert.assertEquals("{\"f1\":0,\"f2\":0,\"f3\":0,\"f4\":0,\"f5\":0}", text);
+    Assert.assertEquals("{\"abc\":0,\"bar\":0,\"baz\":0,\"foo\":0,\"xyz\":0}", text);
 
 }
 
 public static class V1 {
 
-    private int f2;
-    private int f1;
-    private int f4;
-    private int f3;
-    private int f5;
+    private int abc;
+    private int xyz;
+    private int foo;
+    private int bar;
+    private int baz;
 
-    public int getF2() { return f2;}
-    public void setF2(int f2) {this.f2 = f2;}
-    public int getF1() {return f1;}
-    public void setF1(int f1) {this.f1 = f1;}
-    public int getF4() {return f4;}
-    public void setF4(int f4) {this.f4 = f4;}
-    public int getF3() {return f3;}
-    public void setF3(int f3) {this.f3 = f3;}
-    public int getF5() {return f5;}
-    public void setF5(int f5) {this.f5 = f5;}
+    public int getAbc() {return abc;}
+    public void setAbc(int abc) {this.abc = abc;}
+    public int getXyz() {return xyz;}
+    public void setXyz(int xyz) {this.xyz = xyz;}
+    public int getFoo() {return foo;}
+    public void setFoo(int foo) {this.foo = foo;}
+    public int getBar() {return bar;}
+    public void setBar(int bar) {this.bar = bar;}
+    public int getBaz() {return baz;}
+    public void setBaz(int baz) {this.baz = baz;}
 }
 
     public static class V0 {

--- a/src/test/java/com/alibaba/json/bvt/parser/JSONLexerAllowCommentTest.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/JSONLexerAllowCommentTest.java
@@ -43,7 +43,7 @@ public class JSONLexerAllowCommentTest extends TestCase {
 
         Assert
             .assertEquals(
-                "{\"hello\":\"asafsadf\",\"test\":1,\"array\":[\"10000sfsaf\",100,{\"nihao\":{\"test\":\"sdfasdf\"}}],\"object\":{\"teset\":1000}}",
+                "{\"array\":[\"10000sfsaf\",100,{\"nihao\":{\"test\":\"sdfasdf\"}}],\"hello\":\"asafsadf\",\"object\":{\"teset\":1000},\"test\":1}",
                 object.toJSONString());
     }
 }


### PR DESCRIPTION
The second assertion in `com.alibaba.json.bvt.asm.SortFieldTest#test_1` only passes because the fields `f0`, `f1`, `f2`, `f3`, `f4`, and `f5` happen to have hashcodes that put them in alphabetical order when inserted in `JSONObject`'s `HashMap`. If you changed the fields in `V1` then `text = JSON.toJSONString(object, SerializerFeature.SortField);` on line 38 would no longer result in a sorted string. This is due to the fact that `SerializerFeature.SortField` is being ignored in `com.alibaba.fastjson.serializer.MapSerializer`.

Here, I've uncommented the code that respects `SerializerFeature.SortField` so that `JSON.toJSONString()` respects `SerializerFeature.SortField`. I have also changed the test to detect this kind of problem.