### PR TITLE
修复SerializeUsing bug

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.annotation.JSONField;
 import com.alibaba.fastjson.util.FieldInfo;
 import com.alibaba.fastjson.util.TypeUtils;
 
@@ -272,7 +273,8 @@ public class JavaBeanSerializer extends SerializeFilterable implements ObjectSer
                     }
 
                     if (!writeAsArray) {
-                        if (fieldClass == String.class) {
+                        JSONField fieldAnnotation = fieldInfo.getAnnotation();
+                        if (fieldClass == String.class && (fieldAnnotation == null || fieldAnnotation.serializeUsing() == Void.class)) {
                             if (propertyValue == null) {
                                 if ((out.features & SerializerFeature.WriteNullStringAsEmpty.mask) != 0
                                     || (fieldSerializer.features

--- a/src/test/java/com/alibaba/json/bvt/annotation/SerializeUsingWhenString.java
+++ b/src/test/java/com/alibaba/json/bvt/annotation/SerializeUsingWhenString.java
@@ -1,0 +1,47 @@
+package com.alibaba.json.bvt.annotation;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.serializer.JSONSerializer;
+import com.alibaba.fastjson.serializer.ObjectSerializer;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+/**
+ * @author by laugh on 16/9/28 12:08.
+ */
+public class SerializeUsingWhenString extends TestCase {
+    public void test_annotation() throws Exception {
+        Model model = new Model();
+        model.value = "100";
+        Assert.assertEquals("{\"value\":\"100元\"}", JSON.toJSONString(model));
+
+        ModelWithOutJsonField modelWithOutJsonField = new ModelWithOutJsonField();
+        modelWithOutJsonField.value = "100";
+        Assert.assertEquals("{\"value\":\"100\"}", JSON.toJSONString(modelWithOutJsonField));
+    }
+
+    public static class Model {
+
+        @JSONField(serializeUsing = ModelValueSerializer.class)
+        public String value;
+    }
+
+    public static class ModelWithOutJsonField {
+
+        public String value;
+    }
+
+    public static class ModelValueSerializer implements ObjectSerializer {
+
+        public void write(JSONSerializer serializer, Object object, Object fieldName, Type fieldType,
+                          int features) throws IOException {
+            String value = (String) object;
+            String text = value + "元";
+            serializer.write(text);
+        }
+    }
+}


### PR DESCRIPTION
bug：在属性为String时，@JSONField中的serializeUsing不起作用