### PR TITLE
Spring MVC中将POJO输出为JSONP，支持跨域数据访问

### DIFF
--- a/src/main/java/com/alibaba/fastjson/support/spring/FastJsonpHttpMessageConverter4.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/FastJsonpHttpMessageConverter4.java
@@ -1,0 +1,188 @@
+package com.alibaba.fastjson.support.spring;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Type;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractGenericHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.support.config.FastJsonConfig;
+import com.alibaba.fastjson.util.IOUtils;
+
+/**
+ * Fastjson for Spring MVC Converter.
+ * <p>
+ * Compatible Spring MVC version 4.2+
+ * <p>
+ * support to write JSONP
+ *
+ * <pre>
+ * Configuration in xml:
+ * <code>
+ *     &lt;mvc:annotation-driven&gt;
+ *         &lt;mvc:message-converters&gt;
+ *             &lt;bean
+ *                 class=&quot;com.alibaba.fastjson.support.spring.FastJsonpHttpMessageConverter4&quot;&gt;
+ *                 &lt;property name=&quot;supportedMediaTypes&quot;&gt;
+ *                     &lt;list&gt;
+ *                         &lt;value&gt;application/json;charset=UTF-8&lt;/value&gt;
+ *                     &lt;/list&gt;
+ *                 &lt;/property&gt;
+ *             &lt;/bean&gt;
+ *         &lt;/mvc:message-converters&gt;
+ *     &lt;/mvc:annotation-driven&gt;
+ * 
+ *     &lt;bean id=&quot;fastJsonpResponseBodyAdvice&quot; class=&quot;com.alibaba.fastjson.support.spring.FastJsonpResponseBodyAdvice&quot;&gt;
+ *         &lt;constructor-arg&gt;
+ *             &lt;list&gt;
+ *                 &lt;value&gt;callback&lt;/value&gt;
+ *                 &lt;value&gt;jsonp&lt;/value&gt;
+ *             &lt;/list&gt;
+ *         &lt;/constructor-arg&gt;
+ *     &lt;/bean&gt;
+ * </code>
+ * </pre>
+ *
+ * <pre>
+ * Configuration in java:
+ *     &#064;EnableWebMvc
+ *     &#064;Configuration
+ *     public class Config extends WebMvcConfigurerAdapter {
+ *         &#064;ean
+ *         public FastJsonpResponseBodyAdvice fastJsonpResponseBodyAdvice() {
+ *             return new FastJsonpResponseBodyAdvice("callback", "jsonp");
+ *         }
+ * 
+ *         &#064;Override
+ *         public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+ *             converters.add(0, new FastJsonpHttpMessageConverter4());
+ *             super.extendMessageConverters(converters);
+ *         }
+ *     }
+ * <code>
+ * </code>
+ * </pre>
+ *
+ * @author Jerry.Chen
+ * @since 1.2.20
+ */
+public class FastJsonpHttpMessageConverter4 extends AbstractGenericHttpMessageConverter<Object> {
+    /**
+     * with fastJson config
+     */
+    private FastJsonConfig fastJsonConfig = new FastJsonConfig();
+
+    /**
+     * @return the fastJsonConfig.
+     * @since 1.2.11
+     */
+    public FastJsonConfig getFastJsonConfig() {
+        return fastJsonConfig;
+    }
+
+    /**
+     * @param fastJsonConfig the fastJsonConfig to set.
+     * @since 1.2.11
+     */
+    public void setFastJsonConfig(FastJsonConfig fastJsonConfig) {
+        this.fastJsonConfig = fastJsonConfig;
+    }
+
+    /**
+     * Can serialize/deserialize all types.
+     */
+    public FastJsonpHttpMessageConverter4() {
+
+        super(MediaType.ALL);
+    }
+
+    @Override
+    protected boolean supports(Class<?> paramClass) {
+        return true;
+    }
+
+    @Override
+    public Object read(Type type, //
+            Class<?> contextClass, //
+            HttpInputMessage inputMessage //
+    ) throws IOException, HttpMessageNotReadableException {
+        InputStream in = inputMessage.getBody();
+        return JSON.parseObject(in, fastJsonConfig.getCharset(), type, fastJsonConfig.getFeatures());
+    }
+
+    @Override
+    protected Object readInternal(Class<? extends Object> clazz, //
+            HttpInputMessage inputMessage //
+    ) throws IOException, HttpMessageNotReadableException {
+        InputStream in = inputMessage.getBody();
+        return JSON.parseObject(in, fastJsonConfig.getCharset(), clazz, fastJsonConfig.getFeatures());
+    }
+
+    @Override
+    protected void writeInternal(Object obj, Type type, HttpOutputMessage outputMessage) throws IOException,
+            HttpMessageNotWritableException {
+        HttpHeaders headers = outputMessage.getHeaders();
+        ByteArrayOutputStream outnew = new ByteArrayOutputStream();
+        int len = writePrefix(outnew, obj);
+        Object value = obj;
+        if (obj instanceof MappingFastJsonValue) {
+            MappingFastJsonValue container = (MappingFastJsonValue) obj;
+            value = container.getValue();
+        }
+        len += JSON.writeJSONString(outnew, //
+                fastJsonConfig.getCharset(), //
+                value, //
+                fastJsonConfig.getSerializeConfig(), //
+                fastJsonConfig.getSerializeFilters(), //
+                fastJsonConfig.getDateFormat(), //
+                JSON.DEFAULT_GENERATE_FEATURE, //
+                fastJsonConfig.getSerializerFeatures());
+        len += writeSuffix(outnew, obj);
+        headers.setContentLength(len);
+        OutputStream out = outputMessage.getBody();
+        outnew.writeTo(out);
+        outnew.close();
+    }
+
+    private static final byte[] JSONP_FUNCTION_PREFIX_BYTES = "/**/".getBytes(IOUtils.UTF8);
+    private static final byte[] JSONP_FUNCTION_SUFFIX_BYTES = ");".getBytes(IOUtils.UTF8);
+
+    /**
+     * Write a prefix before the main content.
+     */
+    protected int writePrefix(ByteArrayOutputStream out, Object object) throws IOException {
+        String jsonpFunction = (object instanceof MappingFastJsonValue ? ((MappingFastJsonValue) object)
+                .getJsonpFunction() : null);
+        int length = 0;
+        if (jsonpFunction != null) {
+            out.write(JSONP_FUNCTION_PREFIX_BYTES);
+            byte[] bytes = (jsonpFunction + "(").getBytes(IOUtils.UTF8);
+            out.write(bytes);
+            length += JSONP_FUNCTION_PREFIX_BYTES.length + bytes.length;
+        }
+        return length;
+    }
+
+    /**
+     * Write a suffix after the main content.
+     */
+    protected int writeSuffix(ByteArrayOutputStream out, Object object) throws IOException {
+        String jsonpFunction = (object instanceof MappingFastJsonValue ? ((MappingFastJsonValue) object)
+                .getJsonpFunction() : null);
+        int length = 0;
+        if (jsonpFunction != null) {
+            out.write(JSONP_FUNCTION_SUFFIX_BYTES);
+            length += JSONP_FUNCTION_SUFFIX_BYTES.length;
+        }
+        return length;
+    }
+}

--- a/src/main/java/com/alibaba/fastjson/support/spring/FastJsonpResponseBodyAdvice.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/FastJsonpResponseBodyAdvice.java
@@ -1,0 +1,106 @@
+package com.alibaba.fastjson.support.spring;
+
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/**
+ * A convenient base class for {@code ResponseBodyAdvice} implementations
+ * that customize the response before JSON serialization with {@link FastJsonpHttpMessageConverter4}'s concrete
+ * subclasses.
+ * <p>
+ * Compatible Spring MVC version 4.2+
+ *
+ * @author Jerry.Chen
+ * @since 1.2.20
+ */
+@ControllerAdvice
+public class FastJsonpResponseBodyAdvice implements ResponseBodyAdvice<Object> {
+    /**
+     * Pattern for validating jsonp callback parameter values.
+     */
+    private static final Pattern CALLBACK_PARAM_PATTERN = Pattern.compile("[0-9A-Za-z_\\.]*");
+    private final String[] jsonpQueryParamNames;
+
+    public FastJsonpResponseBodyAdvice(String... queryParamNames) {
+        Assert.isTrue(!ObjectUtils.isEmpty(queryParamNames), "At least one query param name is required");
+        this.jsonpQueryParamNames = queryParamNames;
+    }
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return FastJsonpHttpMessageConverter4.class.isAssignableFrom(converterType);
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+            Class<? extends HttpMessageConverter<?>> selectedConverterType, ServerHttpRequest request,
+            ServerHttpResponse response) {
+        MappingFastJsonValue container = getOrCreateContainer(body);
+        beforeBodyWriteInternal(container, selectedContentType, returnType, request, response);
+        return container;
+    }
+
+    /**
+     * Wrap the body in a {@link MappingFastJsonValue} value container (for providing
+     * additional serialization instructions) or simply cast it if already wrapped.
+     */
+    protected MappingFastJsonValue getOrCreateContainer(Object body) {
+        return (body instanceof MappingFastJsonValue ? (MappingFastJsonValue) body : new MappingFastJsonValue(body));
+    }
+
+    /**
+     * Invoked only if the converter type is {@code FastJsonpHttpMessageConverter4}.
+     */
+    public void beforeBodyWriteInternal(MappingFastJsonValue bodyContainer, MediaType contentType,
+            MethodParameter returnType, ServerHttpRequest request, ServerHttpResponse response) {
+        HttpServletRequest servletRequest = ((ServletServerHttpRequest) request).getServletRequest();
+        for (String name : this.jsonpQueryParamNames) {
+            String value = servletRequest.getParameter(name);
+            if (value != null) {
+                if (!isValidJsonpQueryParam(value)) {
+                    continue;
+                }
+                MediaType contentTypeToUse = getContentType(contentType, request, response);
+                response.getHeaders().setContentType(contentTypeToUse);
+                bodyContainer.setJsonpFunction(value);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Validate the jsonp query parameter value. The default implementation
+     * returns true if it consists of digits, letters, or "_" and ".".
+     * Invalid parameter values are ignored.
+     *
+     * @param value the query param value, never {@code null}
+     */
+    protected boolean isValidJsonpQueryParam(String value) {
+        return CALLBACK_PARAM_PATTERN.matcher(value).matches();
+    }
+
+    /**
+     * Return the content type to set the response to.
+     * This implementation always returns "application/javascript".
+     *
+     * @param contentType the content type selected through content negotiation
+     * @param request the current request
+     * @param response the current response
+     * @return the content type to set the response to
+     */
+    protected MediaType getContentType(MediaType contentType, ServerHttpRequest request, ServerHttpResponse response) {
+        return new MediaType("application", "javascript");
+    }
+}

--- a/src/main/java/com/alibaba/fastjson/support/spring/MappingFastJsonValue.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/MappingFastJsonValue.java
@@ -1,0 +1,57 @@
+package com.alibaba.fastjson.support.spring;
+
+/**
+ * A simple holder for the POJO to serialize via {@link FastJsonpHttpMessageConverter4} along with further
+ * serialization instructions to be passed in to the converter.
+ *
+ * <p>
+ * On the server side this wrapper is added with a {@code ResponseBodyInterceptor} after content negotiation selects the
+ * converter to use but before the write.
+ *
+ * <p>
+ * On the client side, simply wrap the POJO and pass it in to the {@code RestTemplate}.
+ *
+ * @author Jerry.Chen
+ * @since 1.2.20
+ */
+public class MappingFastJsonValue {
+    private Object value;
+    private String jsonpFunction;
+
+    /**
+     * Create a new instance wrapping the given POJO to be serialized.
+     *
+     * @param value the Object to be serialized
+     */
+    public MappingFastJsonValue(Object value) {
+        this.value = value;
+    }
+
+    /**
+     * Modify the POJO to serialize.
+     */
+    public void setValue(Object value) {
+        this.value = value;
+    }
+
+    /**
+     * Return the POJO that needs to be serialized.
+     */
+    public Object getValue() {
+        return this.value;
+    }
+
+    /**
+     * Set the name of the JSONP function name.
+     */
+    public void setJsonpFunction(String functionName) {
+        this.jsonpFunction = functionName;
+    }
+
+    /**
+     * Return the configured JSONP function name.
+     */
+    public String getJsonpFunction() {
+        return this.jsonpFunction;
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/support/spring/FastJsonpHttpMessageConverter4Test.java
+++ b/src/test/java/com/alibaba/json/bvt/support/spring/FastJsonpHttpMessageConverter4Test.java
@@ -1,0 +1,141 @@
+package com.alibaba.json.bvt.support.spring;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.Charset;
+
+import org.junit.Assert;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+
+import com.alibaba.fastjson.support.config.FastJsonConfig;
+import com.alibaba.fastjson.support.spring.FastJsonpHttpMessageConverter4;
+import com.alibaba.fastjson.support.spring.MappingFastJsonValue;
+
+import junit.framework.TestCase;
+
+public class FastJsonpHttpMessageConverter4Test extends TestCase {
+    public void test_1() throws Exception {
+
+        FastJsonpHttpMessageConverter4 converter = new FastJsonpHttpMessageConverter4();
+
+        Assert.assertNotNull(converter.getFastJsonConfig());
+        converter.setFastJsonConfig(new FastJsonConfig());
+
+        converter.canRead(VO.class, VO.class, MediaType.APPLICATION_JSON_UTF8);
+
+        converter.canWrite(VO.class, VO.class, MediaType.APPLICATION_JSON_UTF8);
+
+        Method method1 = FastJsonpHttpMessageConverter4.class.getDeclaredMethod("supports", Class.class);
+        method1.setAccessible(true);
+        method1.invoke(converter, int.class);
+
+        HttpInputMessage input = new HttpInputMessage() {
+
+            public HttpHeaders getHeaders() {
+                return null;
+            }
+
+            public InputStream getBody() throws IOException {
+                return new ByteArrayInputStream("{\"id\":123}".getBytes(Charset.forName("UTF-8")));
+            }
+
+        };
+        VO vo = (VO) converter.read(VO.class, VO.class, input);
+        Assert.assertEquals(123, vo.getId());
+
+        final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+        HttpOutputMessage out = new HttpOutputMessage() {
+
+            public HttpHeaders getHeaders() {
+                return new HttpHeaders();
+            }
+
+            public OutputStream getBody() throws IOException {
+                return byteOut;
+            }
+        };
+        converter.write(vo, VO.class, MediaType.TEXT_PLAIN, out);
+
+        byte[] bytes = byteOut.toByteArray();
+        Assert.assertEquals("{\"id\":123}", new String(bytes, "UTF-8"));
+
+        Method method2 = FastJsonpHttpMessageConverter4.class.getDeclaredMethod("readInternal", Class.class,
+                HttpInputMessage.class);
+        method2.setAccessible(true);
+        method2.invoke(converter, VO.class, input);
+    }
+
+    public void test_2() throws Exception {
+
+        FastJsonpHttpMessageConverter4 converter = new FastJsonpHttpMessageConverter4();
+
+        Assert.assertNotNull(converter.getFastJsonConfig());
+        converter.setFastJsonConfig(new FastJsonConfig());
+
+        converter.canRead(VO.class, VO.class, MediaType.APPLICATION_JSON_UTF8);
+
+        converter.canWrite(VO.class, VO.class, MediaType.APPLICATION_JSON_UTF8);
+
+        Method method1 = FastJsonpHttpMessageConverter4.class.getDeclaredMethod("supports", Class.class);
+        method1.setAccessible(true);
+        method1.invoke(converter, int.class);
+
+        HttpInputMessage input = new HttpInputMessage() {
+
+            public HttpHeaders getHeaders() {
+                return null;
+            }
+
+            public InputStream getBody() throws IOException {
+                return new ByteArrayInputStream("{\"id\":123}".getBytes(Charset.forName("UTF-8")));
+            }
+
+        };
+        VO vo = (VO) converter.read(VO.class, VO.class, input);
+        Assert.assertEquals(123, vo.getId());
+
+        final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+        HttpOutputMessage out = new HttpOutputMessage() {
+
+            public HttpHeaders getHeaders() {
+                return new HttpHeaders();
+            }
+
+            public OutputStream getBody() throws IOException {
+                return byteOut;
+            }
+        };
+        MappingFastJsonValue mappingFastJsonValue = new MappingFastJsonValue(vo);
+        mappingFastJsonValue.setJsonpFunction("callback");
+        converter.write(mappingFastJsonValue, VO.class, MediaType.TEXT_PLAIN, out);
+
+        byte[] bytes = byteOut.toByteArray();
+        Assert.assertEquals("/**/callback({\"id\":123});", new String(bytes, "UTF-8"));
+
+        Method method2 = FastJsonpHttpMessageConverter4.class.getDeclaredMethod("readInternal", Class.class,
+                HttpInputMessage.class);
+        method2.setAccessible(true);
+        method2.invoke(converter, VO.class, input);
+    }
+
+    public static class VO {
+
+        private int id;
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/support/spring/mock/testcase/FastJsonpHttpMessageConverter4Case1Test.java
+++ b/src/test/java/com/alibaba/json/bvt/support/spring/mock/testcase/FastJsonpHttpMessageConverter4Case1Test.java
@@ -1,0 +1,163 @@
+package com.alibaba.json.bvt.support.spring.mock.testcase;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.support.spring.FastJsonpResponseBodyAdvice;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration({ "classpath*:/config/applicationContext-mvc4.xml" })
+public class FastJsonpHttpMessageConverter4Case1Test {
+    private static final MediaType APPLICATION_JAVASCRIPT = new MediaType("application", "javascript");
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    private MockMvc mockMvc;
+
+    @Before
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac) //
+                .addFilter(new CharacterEncodingFilter("UTF-8", true)) // 设置服务器端返回的字符集为：UTF-8
+                .build();
+    }
+
+    @Test
+    public void isInjectComponent() {
+        wac.getBean(FastJsonpResponseBodyAdvice.class);
+    }
+
+    @Test
+    public void test1() throws Exception {
+
+        JSONObject json = new JSONObject();
+
+        json.put("id", 123);
+
+        json.put("name", "哈哈哈");
+
+        mockMvc.perform(
+                (post("/fastjson/test1").characterEncoding("UTF-8").content(json.toJSONString())
+                        .contentType(MediaType.APPLICATION_JSON))).andExpect(status().isOk()).andDo(print());
+    }
+
+    @Test
+    public void test1_2() throws Exception {
+
+        JSONObject json = new JSONObject();
+
+        json.put("id", 123);
+
+        json.put("name", "哈哈哈");
+
+        ResultActions actions = mockMvc.perform((post("/fastjson/test1?callback=fnUpdateSome").characterEncoding(
+                "UTF-8").content(json.toJSONString()).contentType(MediaType.APPLICATION_JSON)));
+        actions.andDo(print());
+        actions.andExpect(status().isOk()).andExpect(content().contentType(APPLICATION_JAVASCRIPT))
+                .andExpect(content().string("/**/fnUpdateSome({\"name\":\"哈哈哈\",\"id\":123});"));
+    }
+
+    @Test
+    public void test2() throws Exception {
+
+        String jsonStr = "[{\"name\":\"p1\",\"sonList\":[{\"name\":\"s1\"}]},{\"name\":\"p2\",\"sonList\":[{\"name\":\"s2\"},{\"name\":\"s3\"}]}]";
+
+        mockMvc.perform(
+                (post("/fastjson/test2").characterEncoding("UTF-8").content(jsonStr)
+                        .contentType(MediaType.APPLICATION_JSON))).andExpect(status().isOk()).andDo(print());
+    }
+
+    @Test
+    public void test2_2() throws Exception {
+
+        String jsonStr = "[{\"name\":\"p1\",\"sonList\":[{\"name\":\"s1\"}]},{\"name\":\"p2\",\"sonList\":[{\"name\":\"s2\"},{\"name\":\"s3\"}]}]";
+
+        ResultActions actions = mockMvc.perform((post("/fastjson/test2?jsonp=fnUpdateSome").characterEncoding("UTF-8")
+                .content(jsonStr).contentType(MediaType.APPLICATION_JSON)));
+        actions.andDo(print());
+        actions.andExpect(status().isOk()).andExpect(content().contentType(APPLICATION_JAVASCRIPT))
+                .andExpect(content().string("/**/fnUpdateSome({\"p1\":1,\"p2\":2});"));
+    }
+
+    @Test
+    public void test3() throws Exception {
+        List<Object> list = this.mockMvc.perform(post("/fastjson/test3")).andReturn().getResponse()
+                .getHeaderValues("Content-Length");
+        Assert.assertNotEquals(list.size(), 0);
+    }
+
+    @Test
+    public void test3_2() throws Exception {
+        ResultActions actions = this.mockMvc.perform(post("/fastjson/test3?jsonp=fnUpdateSome"));
+        actions.andDo(print());
+        actions.andExpect(status().isOk()).andExpect(content().contentType(APPLICATION_JAVASCRIPT))
+                .andExpect(content().string("/**/fnUpdateSome({});"));
+    }
+
+    @Test
+    public void test4() throws Exception {
+
+        String jsonStr = "{\"t\":{\"id\":123,\"name\":\"哈哈哈\"}}";
+
+        mockMvc.perform(
+                (post("/fastjson/test4").characterEncoding("UTF-8").content(jsonStr)
+                        .contentType(MediaType.APPLICATION_JSON))).andDo(print());
+    }
+
+    @Test
+    public void test4_2() throws Exception {
+
+        String jsonStr = "{\"t\":{\"id\":123,\"name\":\"哈哈哈\"}}";
+
+        ResultActions actions = mockMvc.perform((post("/fastjson/test4?callback=myUpdate").characterEncoding("UTF-8")
+                .content(jsonStr).contentType(MediaType.APPLICATION_JSON)));
+        actions.andDo(print());
+        actions.andExpect(status().isOk())
+                .andExpect(content().contentType(APPLICATION_JAVASCRIPT))
+                .andExpect(content().string("/**/myUpdate(\"{\\\"t\\\":{\\\"id\\\":123,\\\"name\\\":\\\"哈哈哈\\\"}}\");"));
+    }
+
+    @Test
+    public void test5() throws Exception {
+
+        String jsonStr = "{\"packet\":{\"smsType\":\"USER_LOGIN\"}}";
+
+        mockMvc.perform(
+                (post("/fastjson/test5").characterEncoding("UTF-8").content(jsonStr)
+                        .contentType(MediaType.APPLICATION_JSON))).andDo(print());
+    }
+
+    @Test
+    public void test5_2() throws Exception {
+
+        String jsonStr = "{\"packet\":{\"smsType\":\"USER_LOGIN\"}}";
+
+        ResultActions actions = mockMvc.perform((post("/fastjson/test5?callback=myUpdate").characterEncoding("UTF-8")
+                .content(jsonStr).contentType(MediaType.APPLICATION_JSON)));
+        actions.andDo(print());
+        actions.andExpect(status().isOk())
+                .andExpect(content().contentType(APPLICATION_JAVASCRIPT))
+                .andExpect(content().string("/**/myUpdate(\"{\\\"packet\\\":{\\\"smsType\\\":\\\"USER_LOGIN\\\"}}\");"));
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/support/spring/mock/testcase/FastJsonpHttpMessageConverter4Case2Test.java
+++ b/src/test/java/com/alibaba/json/bvt/support/spring/mock/testcase/FastJsonpHttpMessageConverter4Case2Test.java
@@ -1,0 +1,186 @@
+package com.alibaba.json.bvt.support.spring.mock.testcase;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.support.spring.FastJsonpHttpMessageConverter4;
+import com.alibaba.fastjson.support.spring.FastJsonpResponseBodyAdvice;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration
+public class FastJsonpHttpMessageConverter4Case2Test {
+    private static final MediaType APPLICATION_JAVASCRIPT = new MediaType("application", "javascript");
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    private MockMvc mockMvc;
+
+    @ComponentScan(basePackages = "com.alibaba.json.bvt.support.spring.mock.controller")
+    @EnableWebMvc
+    @Configuration
+    protected static class Config extends WebMvcConfigurerAdapter {
+        @Bean
+        public FastJsonpResponseBodyAdvice fastJsonpResponseBodyAdvice() {
+            return new FastJsonpResponseBodyAdvice("callback", "jsonp");
+        }
+
+        @Override
+        public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+            converters.add(0, new FastJsonpHttpMessageConverter4());
+            super.extendMessageConverters(converters);
+        }
+    }
+
+    @Before
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac) //
+                .addFilter(new CharacterEncodingFilter("UTF-8", true)) // 设置服务器端返回的字符集为：UTF-8
+                .build();
+    }
+
+    @Test
+    public void isInjectComponent() {
+        wac.getBean(FastJsonpResponseBodyAdvice.class);
+    }
+
+    @Test
+    public void test1() throws Exception {
+
+        JSONObject json = new JSONObject();
+
+        json.put("id", 123);
+
+        json.put("name", "哈哈哈");
+
+        mockMvc.perform(
+                (post("/fastjson/test1").characterEncoding("UTF-8").content(json.toJSONString())
+                        .contentType(MediaType.APPLICATION_JSON))).andExpect(status().isOk()).andDo(print());
+    }
+
+    @Test
+    public void test1_2() throws Exception {
+
+        JSONObject json = new JSONObject();
+
+        json.put("id", 123);
+
+        json.put("name", "哈哈哈");
+
+        ResultActions actions = mockMvc.perform((post("/fastjson/test1?callback=fnUpdateSome").characterEncoding(
+                "UTF-8").content(json.toJSONString()).contentType(MediaType.APPLICATION_JSON)));
+        actions.andDo(print());
+        actions.andExpect(status().isOk()).andExpect(content().contentType(APPLICATION_JAVASCRIPT))
+                .andExpect(content().string("/**/fnUpdateSome({\"name\":\"哈哈哈\",\"id\":123});"));
+    }
+
+    @Test
+    public void test2() throws Exception {
+
+        String jsonStr = "[{\"name\":\"p1\",\"sonList\":[{\"name\":\"s1\"}]},{\"name\":\"p2\",\"sonList\":[{\"name\":\"s2\"},{\"name\":\"s3\"}]}]";
+
+        mockMvc.perform(
+                (post("/fastjson/test2").characterEncoding("UTF-8").content(jsonStr)
+                        .contentType(MediaType.APPLICATION_JSON))).andExpect(status().isOk()).andDo(print());
+    }
+
+    @Test
+    public void test2_2() throws Exception {
+
+        String jsonStr = "[{\"name\":\"p1\",\"sonList\":[{\"name\":\"s1\"}]},{\"name\":\"p2\",\"sonList\":[{\"name\":\"s2\"},{\"name\":\"s3\"}]}]";
+
+        ResultActions actions = mockMvc.perform((post("/fastjson/test2?jsonp=fnUpdateSome").characterEncoding("UTF-8")
+                .content(jsonStr).contentType(MediaType.APPLICATION_JSON)));
+        actions.andDo(print());
+        actions.andExpect(status().isOk()).andExpect(content().contentType(APPLICATION_JAVASCRIPT))
+                .andExpect(content().string("/**/fnUpdateSome({\"p1\":1,\"p2\":2});"));
+    }
+
+    @Test
+    public void test3() throws Exception {
+        List<Object> list = this.mockMvc.perform(post("/fastjson/test3")).andReturn().getResponse()
+                .getHeaderValues("Content-Length");
+        Assert.assertNotEquals(list.size(), 0);
+    }
+
+    @Test
+    public void test3_2() throws Exception {
+        ResultActions actions = this.mockMvc.perform(post("/fastjson/test3?jsonp=fnUpdateSome"));
+        actions.andDo(print());
+        actions.andExpect(status().isOk()).andExpect(content().contentType(APPLICATION_JAVASCRIPT))
+                .andExpect(content().string("/**/fnUpdateSome({});"));
+    }
+
+    @Test
+    public void test4() throws Exception {
+
+        String jsonStr = "{\"t\":{\"id\":123,\"name\":\"哈哈哈\"}}";
+
+        mockMvc.perform(
+                (post("/fastjson/test4").characterEncoding("UTF-8").content(jsonStr)
+                        .contentType(MediaType.APPLICATION_JSON))).andDo(print());
+    }
+
+    @Test
+    public void test4_2() throws Exception {
+
+        String jsonStr = "{\"t\":{\"id\":123,\"name\":\"哈哈哈\"}}";
+
+        ResultActions actions = mockMvc.perform((post("/fastjson/test4?callback=myUpdate").characterEncoding("UTF-8")
+                .content(jsonStr).contentType(MediaType.APPLICATION_JSON)));
+        actions.andDo(print());
+        actions.andExpect(status().isOk())
+                .andExpect(content().contentType(APPLICATION_JAVASCRIPT))
+                .andExpect(content().string("/**/myUpdate(\"{\\\"t\\\":{\\\"id\\\":123,\\\"name\\\":\\\"哈哈哈\\\"}}\");"));
+    }
+
+    @Test
+    public void test5() throws Exception {
+
+        String jsonStr = "{\"packet\":{\"smsType\":\"USER_LOGIN\"}}";
+
+        mockMvc.perform(
+                (post("/fastjson/test5").characterEncoding("UTF-8").content(jsonStr)
+                        .contentType(MediaType.APPLICATION_JSON))).andDo(print());
+    }
+
+    @Test
+    public void test5_2() throws Exception {
+
+        String jsonStr = "{\"packet\":{\"smsType\":\"USER_LOGIN\"}}";
+
+        ResultActions actions = mockMvc.perform((post("/fastjson/test5?callback=myUpdate").characterEncoding("UTF-8")
+                .content(jsonStr).contentType(MediaType.APPLICATION_JSON)));
+        actions.andDo(print());
+        actions.andExpect(status().isOk())
+                .andExpect(content().contentType(APPLICATION_JAVASCRIPT))
+                .andExpect(content().string("/**/myUpdate(\"{\\\"packet\\\":{\\\"smsType\\\":\\\"USER_LOGIN\\\"}}\");"));
+    }
+}

--- a/src/test/resources/config/applicationContext-mvc4.xml
+++ b/src/test/resources/config/applicationContext-mvc4.xml
@@ -1,0 +1,37 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:mvc="http://www.springframework.org/schema/mvc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="
+        http://www.springframework.org/schema/beans     
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context 
+        http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/mvc
+        http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+
+	<context:component-scan base-package="com.alibaba.json.bvt.support.spring.mock.controller" />
+	
+	<mvc:annotation-driven>
+		<mvc:message-converters>
+			<bean
+				class="com.alibaba.fastjson.support.spring.FastJsonpHttpMessageConverter4">
+				<property name="supportedMediaTypes">
+					<list>
+						<value>application/json;charset=UTF-8</value>
+					</list>
+				</property>
+			</bean>
+		</mvc:message-converters>
+	</mvc:annotation-driven>
+
+	<mvc:default-servlet-handler />
+
+	<bean id="fastJsonpResponseBodyAdvice" class="com.alibaba.fastjson.support.spring.FastJsonpResponseBodyAdvice">
+		<constructor-arg>
+			<list>
+				<value>callback</value>
+				<value>jsonp</value>
+			</list>
+		</constructor-arg>
+	</bean>
+</beans>


### PR DESCRIPTION
# 需求

客户端异步请求后端服务接口，前后端不在同一个域名下，需要跨域数据访问。

# 客户端使用方法

```javascript
http://server:port/user/find/1?callback=javaScriptFunction
// javaScriptFunction：JavaScript代码中的回调函数名
// callback：Java代码中约定的请求参数
```

# 后端配置代码

## 使用`xml`配置

```xml
<mvc:annotation-driven>
    <mvc:message-converters>
        <bean
            class="com.alibaba.fastjson.support.spring.FastJsonpHttpMessageConverter4">
            <property name="supportedMediaTypes">
                <list>
                    <value>application/json;charset=UTF-8</value>
                </list>
            </property>
        </bean>
    </mvc:message-converters>
</mvc:annotation-driven>

<mvc:default-servlet-handler />

<bean id="fastJsonpResponseBodyAdvice" class="com.alibaba.fastjson.support.spring.FastJsonpResponseBodyAdvice">
    <constructor-arg>
        <list>
            <value>callback</value>
            <value>jsonp</value>
        </list>
    </constructor-arg>
</bean>

```

## 使用`Java`代码配置

```java
@EnableWebMvc
@Configuration
public class Config extends WebMvcConfigurerAdapter {
    @Bean
    public FastJsonpResponseBodyAdvice fastJsonpResponseBodyAdvice() {
        return new FastJsonpResponseBodyAdvice("callback", "jsonp");
    }

    @Override
    public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
        converters.add(0, new FastJsonpHttpMessageConverter4());
        super.extendMessageConverters(converters);
    }
}
```

spring boot项目中可以不继承`WebMvcConfigurerAdapter `

```java
@Configuration
public class Config{
    @Bean
    public FastJsonpResponseBodyAdvice fastJsonpResponseBodyAdvice() {
        return new FastJsonpResponseBodyAdvice("callback", "jsonp");
    }

    @Bean
    public FastJsonpHttpMessageConverter4 fastJsonpHttpMessageConverter4() {
        return new FastJsonpHttpMessageConverter4();
    }
}
```
