### PR TITLE
fix getter处理中对javaBean is方法的处理逻辑

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -1253,6 +1253,11 @@ public class TypeUtils {
                     continue;
                 }
 
+                if (method.getReturnType() != Boolean.TYPE
+                        && method.getReturnType() != Boolean.class) {
+                    continue;
+                }
+
                 char c2 = methodName.charAt(2);
 
                 String propertyName;
@@ -1316,6 +1321,11 @@ public class TypeUtils {
                 
                 if (propertyNamingStrategy != null) {
                     propertyName = propertyNamingStrategy.translate(propertyName);
+                }
+
+                //优先选择get
+                if (fieldInfoMap.containsKey(propertyName)) {
+                    continue;
                 }
 
                 FieldInfo fieldInfo = new FieldInfo(propertyName, method, field, clazz, null, ordinal, serialzeFeatures, parserFeatures,

--- a/src/test/java/com/alibaba/json/bvt/serializer/BooleanFieldTest3.java
+++ b/src/test/java/com/alibaba/json/bvt/serializer/BooleanFieldTest3.java
@@ -1,0 +1,54 @@
+package com.alibaba.json.bvt.serializer;
+
+import com.alibaba.fastjson.JSON;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+/**
+ * Created by wuwen on 2016/11/3.
+ */
+public class BooleanFieldTest3 extends TestCase {
+
+    public void test_model() throws Exception {
+        Model model = new Model();
+
+        String text = JSON.toJSONString(model);
+        Assert.assertEquals("{\"ok\":true,\"ok2\":true,\"ok3\":true}", text);
+    }
+
+    public static class Model {
+
+        private Long fail;
+
+        private boolean ok;
+
+        private Boolean ok2;
+
+        private boolean ok3;
+
+        public Long isFail() {
+            return 1L;
+        }
+
+        public boolean getOk() {
+            return true;
+        }
+
+        public boolean isOk() {
+            return false;
+        }
+
+        public Boolean getOk2() {
+            return true;
+        }
+
+        public Boolean isOk2() {
+            return false;
+        }
+
+        public boolean isOk3() {
+            return true;
+        }
+
+    }
+}


### PR DESCRIPTION
参考
[javabeans约定里（章节8.3.2）](http://download.oracle.com/otndocs/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/)

> 8.3.2 Boolean properties
>>In addition, for boolean properties, we allow a getter method to match the pattern:
>>            *```public boolean is<PropertyName>();```*  
>>
>> This “is<PropertyName>” method may be provided instead of a “get<PropertyName>” method,
   or it may be provided in addition to a “get<PropertyName>” method.
   In either case, if the “is<PropertyName>” method is present for a boolean property then we will
   use the “is<PropertyName>” method to read the property value.
   An example boolean property might be:
>>
>>         public boolean isMarsupial();
>>         public void setMarsupial(boolean m);

同时参考对比了jackson的处理