### PR TITLE
Fixed#849#937

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/ParameterizedTypeImpl.java
+++ b/src/main/java/com/alibaba/fastjson/util/ParameterizedTypeImpl.java
@@ -42,4 +42,12 @@ public class ParameterizedTypeImpl implements ParameterizedType {
         return rawType != null ? rawType.equals(that.rawType) : that.rawType == null;
 
     }
+
+    @Override
+    public int hashCode() {
+        int result = actualTypeArguments != null ? Arrays.hashCode(actualTypeArguments) : 0;
+        result = 31 * result + (ownerType != null ? ownerType.hashCode() : 0);
+        result = 31 * result + (rawType != null ? rawType.hashCode() : 0);
+        return result;
+    }
 }

--- a/src/test/java/com/alibaba/json/bvt/TypeReferenceTest12.java
+++ b/src/test/java/com/alibaba/json/bvt/TypeReferenceTest12.java
@@ -1,0 +1,33 @@
+package com.alibaba.json.bvt;
+
+import com.alibaba.fastjson.TypeReference;
+import junit.framework.TestCase;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+/**
+ * Created by wuwen on 2016/12/7.
+ */
+public class TypeReferenceTest12 extends TestCase {
+
+    public void test_same() throws Exception {
+        ParameterizedType type1 = getType(Integer.class);
+        ParameterizedType type2 = getType();
+
+        assertEquals(type1.getRawType(), type2.getRawType());
+        assertSame(type1.getRawType(), type2.getRawType());
+    }
+
+    <T> ParameterizedType getType(Type type) {
+        return (ParameterizedType)new TypeReference<Model<T>>(type) {}.getType();
+    }
+
+    ParameterizedType getType() {
+        return (ParameterizedType)new TypeReference<Model<Integer>>() {}.getType();
+    }
+
+    public static class Model<T> {
+        public T value;
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/bug/Bug_for_issue_937.java
+++ b/src/test/java/com/alibaba/json/bvt/bug/Bug_for_issue_937.java
@@ -1,0 +1,54 @@
+package com.alibaba.json.bvt.bug;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.TypeReference;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+/**
+ * Created by wuwen on 2016/12/7.
+ */
+public class Bug_for_issue_937 extends TestCase {
+
+    public void test_for_issue() throws Exception {
+        String json = "{outPara:{name:\"user\"}}";
+        Out<Info> out = returnOut(json, Info.class);
+        Assert.assertEquals("user", out.getOutPara().getName());
+    }
+
+    public static <T> Out<T> returnOut(String jsonStr, Class<T> c2) {
+        return JSON.parseObject(jsonStr, new TypeReference<Out<T>>(c2) {
+        });
+    }
+
+    public static class Out<T> {
+        private T outPara;
+
+        public void setOutPara(T t) {
+            outPara = t;
+        }
+
+        public T getOutPara() {
+            return outPara;
+        }
+
+        public Out() {
+        }
+
+        public Out(T t) {
+            setOutPara(t);
+        }
+    }
+
+    public static class Info {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}


### PR DESCRIPTION
fix #849 双参数时同样存在内存占用大得问题.
```Java
public static <K, V> Map<K, V> parseToMap(String json, 
                                            Class<K> keyType, 
                                            Class<V> valueType) {
     return JSON.parseObject(json, 
                            new TypeReference<Map<K, V>>(keyType, valueType) {
                            });
}

// 可以这样使用
String json = "{1:{name:\"ddd\"},2:{name:\"zzz\"}}";
Map<Integer, Model> map = parseToMap(json, Integer.class, Model.class);
assertEquals("ddd", map.get(1).name);
assertEquals("zzz", map.get(2).name);
```

视乎 https://github.com/alibaba/fastjson/commit/ef50a5b756a6cab1ab753f4a661bdfb0ccbd6b7e 引入了 #937  问题 ？
