### PR TITLE
bug fixed for compatible jdk8 default method when deserialize using asm

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/ASMDeserializerFactory.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/ASMDeserializerFactory.java
@@ -918,9 +918,10 @@ public class ASMDeserializerFactory implements Opcodes {
     }
 
     private void _set(Context context, MethodVisitor mw, FieldInfo fieldInfo) {
-        if (fieldInfo.method != null) {
-            mw.visitMethodInsn(INVOKEVIRTUAL, type(fieldInfo.declaringClass), fieldInfo.method.getName(),
-                               desc(fieldInfo.method));
+        Method method = fieldInfo.method;
+        if (method != null) {
+            Class<?> declaringClass = method.getDeclaringClass();
+            mw.visitMethodInsn(declaringClass.isInterface() ? INVOKEINTERFACE : INVOKEVIRTUAL, type(fieldInfo.declaringClass), method.getName(), desc(method));
 
             if (!fieldInfo.method.getReturnType().equals(Void.TYPE)) {
                 mw.visitInsn(POP);


### PR DESCRIPTION
jdk1.8 使用 asm 序列化、反序列化时报错 “java.lang.IncompatibleClassChangeError”，@wenshao 的commit [bug fixed for compatible jdk8 default method. issue #289 #830 #935](https://github.com/alibaba/fastjson/commit/ac7852429bb4ddbe1150404e064e13770203b4a5) 修复了序列化时的错误，反序列化的场景未修复此bug。