### PR TITLE
针对IdentityHashMap类中的put方法中，使用System.identityHashCode获取hash值时，会出现问题，比如…

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/IdentityHashMap.java
+++ b/src/main/java/com/alibaba/fastjson/util/IdentityHashMap.java
@@ -48,11 +48,11 @@ public class IdentityHashMap<K, V> {
     }
 
     public boolean put(K key, V value) {
-        final int hash = System.identityHashCode(key);
+        final int hash = key.hashCode();
         final int bucket = hash & indexMask;
 
         for (Entry<K, V> entry = buckets[bucket]; entry != null; entry = entry.next) {
-            if (key == entry.key) {
+            if (hash == entry.hashCode) {
                 entry.value = value;
                 return true;
             }


### PR DESCRIPTION
针对IdentityHashMap类中的put方法中，使用System.identityHashCode获取hash值时，会出现问题，比如key为username；传入的是string字符串【String key="username"】时跟传入string对象【new String("a")】时对应的hash值是不同的，会导致map中存入虽然hash值不同，但是key值相同的两个数据项；会导致不确定问题。

例如：
`               String key = new String("username");
		IdentityHashMap<String,Object> ih = new IdentityHashMap<String,Object>();
		ih.put("username", "zhangsan");
		ih.put(key, "zhangsanfeng");`