### PR TITLE
bug fixed for issue 1036 (DefaultFieldDeserializer).

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/DefaultFieldDeserializer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/DefaultFieldDeserializer.java
@@ -57,7 +57,7 @@ public class DefaultFieldDeserializer extends FieldDeserializer {
 
         // ContextObjectDeserializer
         Object value;
-        if (fieldValueDeserilizer instanceof JavaBeanDeserializer) {
+        if (fieldValueDeserilizer.getClass().equals(JavaBeanDeserializer.class)) {
             JavaBeanDeserializer javaBeanDeser = (JavaBeanDeserializer) fieldValueDeserilizer;
             value = javaBeanDeser.deserialze(parser, fieldType, fieldInfo.name, fieldInfo.parserFeatures);
         } else {

--- a/src/test/java/com/alibaba/json/bvt/bug/Issue1036.java
+++ b/src/test/java/com/alibaba/json/bvt/bug/Issue1036.java
@@ -1,0 +1,63 @@
+package com.alibaba.json.bvt.bug;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.TypeReference;
+import com.alibaba.json.bvt.parser.array.BeanToArrayTest3_private;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+/**
+ * Created by wuwen on 2017/2/24.
+ */
+public class Issue1036 extends TestCase {
+
+    /**
+     * @see BeanToArrayTest3_private#test_array()
+     * @see com.alibaba.fastjson.parser.deserializer.DefaultFieldDeserializer#parseField
+     * */
+    public void test_for_issue() throws Exception {
+        NullPointerException exception = new NullPointerException("test");
+        Result<String> result = new Result<String>();
+        result.setException(exception);
+
+        String json = JSON.toJSONString(result);
+
+        Result<String> a = JSON.parseObject(json, new TypeReference<Result<String>>() {
+        });
+
+        Assert.assertEquals("test", a.getException().getMessage());
+    }
+
+    public static class Result<T> {
+        private T data;
+
+        private Throwable exception;
+
+        public Result() {
+        }
+
+        public T getData() {
+            return data;
+        }
+
+        public void setData(T data) {
+            this.data = data;
+        }
+
+        public Throwable getException() {
+            return exception;
+        }
+
+        public void setException(Throwable exception) {
+            this.exception = exception;
+        }
+
+        @Override
+        public String toString() {
+            return "Result{" +
+                    "data='" + data + '\'' +
+                    ", exception=" + exception +
+                    '}';
+        }
+    }
+}


### PR DESCRIPTION
fixed #1036 。
在```DefaultFieldDeserializer. parseField```处理的时候，如果 ```fieldValueDeserilizer ```为 ```JavaBeanDeserializer```的子类时，直接调用```deserialze(DefaultJSONParser parser, Type type, Object fieldName, int features)```方法不会走子类的反序列化实现。

问题在1.2.12版本引入，似乎是BeanToArray特性引起.