### PR TITLE
CXF使用FastJsonProvider的bug修复

### DIFF
--- a/src/main/java/com/alibaba/fastjson/support/jaxrs/FastJsonProvider.java
+++ b/src/main/java/com/alibaba/fastjson/support/jaxrs/FastJsonProvider.java
@@ -270,7 +270,7 @@ public class FastJsonProvider //
                 fastJsonConfig.getSerializerFeatures());
 
         // add Content-Length
-        httpHeaders.add("Content-Length", len);
+        httpHeaders.add("Content-Length", String.valueOf(len));
 
         entityStream.flush();
     }


### PR DESCRIPTION
在使用CXF调用REST的时候，使用FastJsonProvider会向MultivaluedMap<String, Object> httpHeaders设置Content-Length，数据类型自动装箱后为Integer。
但是CXF的headers数据类型为Map<String, List《String》> headers，所以CXF在进行header拼装的时候，没有将Integer转换为String，所以会出现转换错误。
这里建议Content-Length的value直接采用String类型，会更加通用，并且可以解决此bug，望采纳