### PR TITLE
add support to parse Annotation Object to JSON string. 添加解析注解对象

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -20,6 +20,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.lang.reflect.Array;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
@@ -30,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -51,6 +54,7 @@ import com.alibaba.fastjson.serializer.SerializeWriter;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 import com.alibaba.fastjson.util.IOUtils;
 import com.alibaba.fastjson.util.TypeUtils;
+import sun.reflect.annotation.AnnotationType;
 
 /**
  * This is the main class for using Fastjson. You usually call these two methods {@link #toJSONString(Object)} and {@link #parseObject(String, Class)}.
@@ -904,6 +908,28 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             return javaObject;
         }
         
+        Class[] interfaces = clazz.getInterfaces();
+        if (interfaces.length == 1 && interfaces[0].isAnnotation()) {
+            AnnotationType type = AnnotationType.getInstance(interfaces[0]);
+            Map<String, Method> members = type.members();
+            JSONObject json = new JSONObject(members.size());
+            Iterator<Map.Entry<String, Method>> iterator = members.entrySet().iterator();
+            Map.Entry<String, Method> entry;
+            Object val = null;
+            while (iterator.hasNext()) {
+                entry = iterator.next();
+                try {
+                    val = entry.getValue().invoke(javaObject);
+                } catch (IllegalAccessException e) {
+                    // skip
+                } catch (InvocationTargetException e) {
+                    // skip
+                }
+                json.put(entry.getKey(), toJSON(val));
+            }
+            return json;
+        }
+
         ObjectSerializer serializer = config.getObjectWriter(clazz);
         if (serializer instanceof JavaBeanSerializer) {
             JavaBeanSerializer javaBeanSerializer = (JavaBeanSerializer) serializer;

--- a/src/test/java/demo/annotations/AnnotationTest.java
+++ b/src/test/java/demo/annotations/AnnotationTest.java
@@ -1,0 +1,55 @@
+package demo.annotations;
+
+import com.alibaba.fastjson.JSON;
+import sun.reflect.annotation.AnnotationType;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Created by Helly on 2017/04/10.
+ */
+public class AnnotationTest {
+
+    public static void main(String[] args) {
+        print();
+
+        print2();
+
+    }
+
+    private static void print2() {
+        PersonInfo info = Bob.class.getAnnotation(PersonInfo.class);
+        Class<?> clazz = info.getClass();
+        Class[] interfaces = clazz.getInterfaces();
+        if (interfaces.length == 1 && interfaces[0].isAnnotation()) {
+            AnnotationType type = AnnotationType.getInstance(interfaces[0]);
+            Map<String, Method> members = type.members();
+            Iterator<Map.Entry<String, Method>> iterator = members.entrySet().iterator();
+            Map.Entry<String, Method> entry;
+            Object val;
+            while (iterator.hasNext()) {
+                entry = iterator.next();
+                try {
+                    val = entry.getValue().invoke(info);
+                    System.out.println(entry.getKey() + "=" + val);
+                } catch (IllegalAccessException e) {
+                    //skip
+                } catch (InvocationTargetException e) {
+                    //skip
+                }
+            }
+        }
+    }
+
+    private static void print() {
+        Bob bob = new Bob("Bob", 30, true);
+        Object obj = JSON.toJSON(bob);
+        System.out.println(obj.toString());
+        PersonInfo info = Bob.class.getAnnotation(PersonInfo.class);
+        obj = JSON.toJSON(info);
+        System.out.println(obj.toString());
+    }
+}

--- a/src/test/java/demo/annotations/Bob.java
+++ b/src/test/java/demo/annotations/Bob.java
@@ -1,0 +1,49 @@
+package demo.annotations;
+
+/**
+ * Created by Helly on 2017/04/10.
+ */
+@PersonInfo(name = "Bob", age = 30, sex = true)
+public class Bob implements Person {
+    private String name;
+    private int age;
+    private boolean sex;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public boolean isSex() {
+        return sex;
+    }
+
+    public void setSex(boolean sex) {
+        this.sex = sex;
+    }
+
+    public Bob() {
+    }
+
+    public Bob(String name, int age, boolean sex) {
+        this();
+        this.name = name;
+        this.age = age;
+        this.sex = sex;
+    }
+
+    public void hello() {
+        System.out.println("world");
+    }
+}

--- a/src/test/java/demo/annotations/Person.java
+++ b/src/test/java/demo/annotations/Person.java
@@ -1,0 +1,8 @@
+package demo.annotations;
+
+/**
+ * Created by Helly on 2017/04/10.
+ */
+public interface Person {
+    void hello();
+}

--- a/src/test/java/demo/annotations/PersonInfo.java
+++ b/src/test/java/demo/annotations/PersonInfo.java
@@ -1,0 +1,17 @@
+package demo.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Created by Helly on 2017/04/10.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface PersonInfo {
+    String name();
+    int age();
+    boolean sex();
+}


### PR DESCRIPTION
项目中需要将注解对象直接解析为json，但是目前fastjson不支持。修改了代码，增加了对注解对象解析的支持。
由于注解是只读的，所以没有加转换为对象的，只有单向解析为json string的。