### PR TITLE
fixed currency bug

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/MiscCodec.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/MiscCodec.java
@@ -252,7 +252,7 @@ public class MiscCodec implements ObjectSerializer, ObjectDeserializer {
                         return (T) Currency.getInstance(currency);
                     }
 
-                    String symbol = jsonObject.getString("symbol");
+                    String symbol = jsonObject.getString("currencyCode");
                     if (symbol != null) {
                         return (T) Currency.getInstance(symbol);
                     }

--- a/src/test/java/com/alibaba/json/bvt/CurrencyTest4.java
+++ b/src/test/java/com/alibaba/json/bvt/CurrencyTest4.java
@@ -24,7 +24,7 @@ public class CurrencyTest4 extends TestCase {
 
     public void test_1() throws Exception {
         JSONObject jsonObject = new JSONObject();
-        jsonObject.put("symbol", "CNY");
+        jsonObject.put("currencyCode", "CNY");
 
         String text = JSON.toJSONString(jsonObject);
 

--- a/src/test/java/com/alibaba/json/bvt/CurrencyTest5.java
+++ b/src/test/java/com/alibaba/json/bvt/CurrencyTest5.java
@@ -18,7 +18,9 @@ public class CurrencyTest5 extends TestCase {
         jsonObject.put("value", Currency.getInstance("CNY"));
 
         String text = JSON.toJSONString(jsonObject, config);
-        assertEquals("{\"value\":{\"currencyCode\":\"CNY\",\"displayName\":\"Chinese Yuan\",\"symbol\":\"CNY\"}}", text);
+        String str1 = "{\"value\":{\"currencyCode\":\"CNY\",\"displayName\":\"Chinese Yuan\",\"symbol\":\"CNY\"}}";
+        String str2 = "{\"value\":{\"currencyCode\":\"CNY\",\"displayName\":\"人民币\",\"symbol\":\"￥\"}}";
+        assertTrue(text.equals(str1)||text.equals(str2));
 
         Currency currency = JSON.parseObject(text, VO.class).value;
 


### PR DESCRIPTION
1. use currencyCode instead of symbol, when it's not english lang OS, symbol may be like ￥.
2. fixed test case in Chinese, the jsonstring may be \"displayName\":\"人民币\",\"symbol\":\"￥\"}}"