### PR TITLE
注释掉 JerseyAutoDiscoverable.java 

### DIFF
--- a/src/main/java/com/alibaba/fastjson/support/jaxrs/JerseyAutoDiscoverable.java
+++ b/src/main/java/com/alibaba/fastjson/support/jaxrs/JerseyAutoDiscoverable.java
@@ -1,11 +1,5 @@
 package com.alibaba.fastjson.support.jaxrs;
 
-import org.glassfish.jersey.internal.spi.AutoDiscoverable;
-
-import javax.annotation.Priority;
-import javax.ws.rs.core.Configuration;
-import javax.ws.rs.core.FeatureContext;
-
 /**
  * <p>Title: JerseyAutoDiscoverable</p>
  * <p>Description: JerseyAutoDiscoverable</p>
@@ -14,18 +8,18 @@ import javax.ws.rs.core.FeatureContext;
  * @see AutoDiscoverable
  * @since 1.2.36
  */
-@Priority(AutoDiscoverable.DEFAULT_PRIORITY + 1)
-public class JerseyAutoDiscoverable implements AutoDiscoverable {
-
-    @Override
-    public void configure(FeatureContext context) {
-
-        final Configuration config = context.getConfiguration();
-
-        // Register FastJson.
-        if (!config.isRegistered(FastJsonProvider.class)) {
-
-            context.register(FastJsonProvider.class);
-        }
-    }
-}
+//@Priority(AutoDiscoverable.DEFAULT_PRIORITY + 1)
+//public class JerseyAutoDiscoverable implements AutoDiscoverable {
+//
+//    @Override
+//    public void configure(FeatureContext context) {
+//
+//        final Configuration config = context.getConfiguration();
+//
+//        // Register FastJson.
+//        if (!config.isRegistered(FastJsonProvider.class)) {
+//
+//            context.register(FastJsonProvider.class);
+//        }
+//    }
+//}


### PR DESCRIPTION
JerseyAutoDiscoverable.java  默认注册的fastjsonprovider满足不了使用者定制fastjsonprovider 的功能，比如失效DisableCircularReferenceDetect