### PR TITLE
修复对象转json字符串时处理类的范型属性的bug，若第一次类的范型属性为数组类型，第二次空值期望null却返回第一次缓存的数组类型。

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/FieldSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/FieldSerializer.java
@@ -15,20 +15,17 @@
  */
 package com.alibaba.fastjson.serializer;
 
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.text.SimpleDateFormat;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Map;
-
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.annotation.JSONField;
 import com.alibaba.fastjson.annotation.JSONType;
 import com.alibaba.fastjson.util.FieldInfo;
 import com.alibaba.fastjson.util.TypeUtils;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.text.SimpleDateFormat;
+import java.util.Collection;
+import java.util.Date;
 
 /**
  * @author wenshao[szujobs@hotmail.com]
@@ -197,7 +194,17 @@ public class FieldSerializer implements Comparable<FieldSerializer> {
                 (fieldInfo.serialzeFeatures|SerializerFeature.DisableCircularReferenceDetect.getMask()):fieldInfo.serialzeFeatures;
 
         if (propertyValue == null) {
-            Class<?> runtimeFieldClass = runtimeInfo.runtimeFieldClass;
+            Class<?> runtimeFieldClass;
+            ObjectSerializer fieldSerializer;
+
+            Class<?> thisRuntimeFieldClass = this.fieldInfo.fieldClass;
+            if (Object.class == thisRuntimeFieldClass) {
+                runtimeFieldClass = thisRuntimeFieldClass;
+                fieldSerializer = serializer.getObjectWriter(thisRuntimeFieldClass);
+            } else {
+                runtimeFieldClass = runtimeInfo.runtimeFieldClass;
+                fieldSerializer = runtimeInfo.fieldSerializer;
+            }
             SerializeWriter out  = serializer.out;
             if (Number.class.isAssignableFrom(runtimeFieldClass)) {
                 out.writeNull(features, SerializerFeature.WriteNullNumberAsZero.mask);
@@ -213,8 +220,6 @@ public class FieldSerializer implements Comparable<FieldSerializer> {
                 return;
             }
 
-            ObjectSerializer fieldSerializer = runtimeInfo.fieldSerializer;
-            
             if ((out.isEnabled(SerializerFeature.WRITE_MAP_NULL_FEATURES))
                     && fieldSerializer instanceof JavaBeanSerializer) {
                 out.writeNull();

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
@@ -154,7 +154,7 @@ public final class SerializeWriter extends Writer {
         computeFeatures();
     }
 
-    final static int nonDirectFeautres = 0 // 
+    final static int nonDirectFeatures = 0 //
             | SerializerFeature.UseSingleQuotes.mask //
             | SerializerFeature.BrowserCompatible.mask //
             | SerializerFeature.PrettyFormat.mask //
@@ -177,7 +177,7 @@ public final class SerializeWriter extends Writer {
         writeEnumUsingToString = (this.features & SerializerFeature.WriteEnumUsingToString.mask) != 0;
 
         writeDirect = quoteFieldNames //
-                      && (this.features & nonDirectFeautres) == 0 //
+                      && (this.features & nonDirectFeatures) == 0 //
                       && (beanToArray || writeEnumUsingName)
                       ;
 

--- a/src/test/java/com/alibaba/json/bvt/parser/deser/FieldSerializerTest4.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/deser/FieldSerializerTest4.java
@@ -1,0 +1,47 @@
+package com.alibaba.json.bvt.parser.deser;
+
+import com.google.common.collect.Lists;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Created By maxiaoyao
+ * Date: 2017/10/8
+ * Time: 下午10:52
+ */
+public class FieldSerializerTest4 {
+    @Test
+    public void testPattern() {
+        Result<List> listResult = new Result<List>(Lists.newArrayList());
+        Result<Boolean> booleanResult = new Result<Boolean>(null);
+        String listJson = JSON.toJSONString(
+                listResult,
+                SerializerFeature.PrettyFormat
+        );
+        String booleanJson = JSON.toJSONString(
+                booleanResult,
+                SerializerFeature.PrettyFormat,
+                SerializerFeature.WriteNullListAsEmpty
+        );
+        Assert.assertEquals("{\n\t\"data\":[]\n}", listJson);
+        Assert.assertEquals("{\n\t\"data\":null\n}", booleanJson);
+    }
+
+    private static class Result<T>{
+        private T data;
+
+        public Result(T data) {
+            this.data = data;
+        }
+
+        public T getData() {
+            return data;
+        }
+    }
+}


### PR DESCRIPTION
![31304910-0ce550b8-aaf3-11e7-9f67-0c36edcdd268](https://user-images.githubusercontent.com/18508587/31318207-0907e6aa-ac14-11e7-93fc-1064884bc587.png)
