### PR TITLE
bugfix:issue-1555 当某个字段有JSONField注解，JSONField中name属性不存在，并且类上有属性转换策略，j…

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -1316,9 +1316,9 @@ public class TypeUtils{
                 continue;
             }
             /**
-             *  如果在属性或者方法上存在JSONField注解，不以类上的propertyNamingStrategy设置为准，此字段的JSONField为准。
+             *  如果在属性或者方法上存在JSONField注解，并且定制了name属性，不以类上的propertyNamingStrategy设置为准，以此字段的JSONField的name定制为准。
              */
-            Boolean fieldAnnotationExists = false;
+            Boolean fieldAnnotationAndNameExists = false;
             JSONField annotation = method.getAnnotation(JSONField.class);
             if(annotation == null){
                 annotation = getSuperMethodAnnotation(clazz, method);
@@ -1376,7 +1376,6 @@ public class TypeUtils{
                 }
             }
             if(annotation != null){
-                fieldAnnotationExists = true;
                 if(!annotation.serialize()){
                     continue;
                 }
@@ -1384,6 +1383,7 @@ public class TypeUtils{
                 serialzeFeatures = SerializerFeature.of(annotation.serialzeFeatures());
                 parserFeatures = Feature.of(annotation.parseFeatures());
                 if(annotation.name().length() != 0){
+                    fieldAnnotationAndNameExists = true;
                     String propertyName = annotation.name();
                     if(aliasMap != null){
                         propertyName = aliasMap.get(propertyName);
@@ -1447,7 +1447,6 @@ public class TypeUtils{
                 if(field != null){
                     fieldAnnotation = field.getAnnotation(JSONField.class);
                     if(fieldAnnotation != null){
-                        fieldAnnotationExists = true;
                         if(!fieldAnnotation.serialize()){
                             continue;
                         }
@@ -1455,6 +1454,7 @@ public class TypeUtils{
                         serialzeFeatures = SerializerFeature.of(fieldAnnotation.serialzeFeatures());
                         parserFeatures = Feature.of(fieldAnnotation.parseFeatures());
                         if(fieldAnnotation.name().length() != 0){
+                            fieldAnnotationAndNameExists = true;
                             propertyName = fieldAnnotation.name();
                             if(aliasMap != null){
                                 propertyName = aliasMap.get(propertyName);
@@ -1474,7 +1474,7 @@ public class TypeUtils{
                         continue;
                     }
                 }
-                if(propertyNamingStrategy != null && !fieldAnnotationExists){
+                if(propertyNamingStrategy != null && !fieldAnnotationAndNameExists){
                     propertyName = propertyNamingStrategy.translate(propertyName);
                 }
                 FieldInfo fieldInfo = new FieldInfo(propertyName, method, field, clazz, null, ordinal, serialzeFeatures, parserFeatures,

--- a/src/test/java/com/alibaba/json/bvt/issue_1500/Issue1555.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1500/Issue1555.java
@@ -10,7 +10,7 @@ public class Issue1555 extends TestCase {
     public void test_for_issue() throws Exception {
         Model model = new Model();
         model.userId = 1001;
-        model.userName="test";
+        model.userName = "test";
         String text = JSON.toJSONString(model);
         assertEquals("{\"userName\":\"test\",\"user_id\":1001}", text);
 
@@ -20,8 +20,52 @@ public class Issue1555 extends TestCase {
         assertEquals("test", model2.userName);
     }
 
+    /**
+     * 当某个字段有JSONField注解，JSONField中name属性不存在，json属性名也要用类上的属性名转换策略
+     * @throws Exception
+     */
+    public void test_when_JSONField_have_not_name_attr() throws Exception {
+        ModelTwo modelTwo = new ModelTwo();
+        modelTwo.userId = 1001;
+        modelTwo.userName = "test";
+        String text = JSON.toJSONString(modelTwo);
+        assertEquals("{\"userName\":\"test\",\"user_id\":\"1001\"}", text);
+
+        Model model2 = JSON.parseObject(text, Model.class);
+
+        assertEquals(1001, model2.userId);
+        assertEquals("test", model2.userName);
+    }
+
     @JSONType(naming = PropertyNamingStrategy.SnakeCase)
     public static class Model {
+        private int userId;
+        @JSONField(name = "userName")
+        private String userName;
+
+        public int getUserId() {
+            return userId;
+        }
+
+        public void setUserId(int userId) {
+            this.userId = userId;
+        }
+
+        public String getUserName() {
+            return userName;
+        }
+
+        public void setUserName(String userName) {
+            this.userName = userName;
+        }
+    }
+
+    @JSONType(naming = PropertyNamingStrategy.SnakeCase)
+    public static class ModelTwo {
+        /**
+         * 此字段准备序列化为字符串类型
+         */
+        @JSONField(serializeUsing = StringSerializer.class)
         private int userId;
         @JSONField(name = "userName")
         private String userName;

--- a/src/test/java/com/alibaba/json/bvt/issue_1500/StringSerializer.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1500/StringSerializer.java
@@ -1,0 +1,15 @@
+package com.alibaba.json.bvt.issue_1500;
+
+import com.alibaba.fastjson.serializer.JSONSerializer;
+import com.alibaba.fastjson.serializer.ObjectSerializer;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+public class StringSerializer implements ObjectSerializer {
+
+    public void write(JSONSerializer serializer, Object object, Object fieldName, Type fieldType, int features) throws IOException {
+        serializer.write(String.valueOf(object));
+    }
+
+}


### PR DESCRIPTION
当某个字段有JSONField注解，JSONField中name属性不存在，并且类上有属性转换策略，json属性名也要用类上的属性名转换策略为为准