### PR TITLE
修复解析JsonString时没有方括号的字符串可以转成对象List属性的问题。

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
+++ b/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
@@ -690,7 +690,7 @@ public class DefaultJSONParser implements Closeable {
         }
 
         if (token != JSONToken.LBRACKET) {
-            throw new JSONException("exepct '[', but " + JSONToken.name(token) + ", " + lexer.info());
+            throw new JSONException("expect '[', but " + JSONToken.name(token) + ", " + lexer.info());
         }
 
         ObjectDeserializer deserializer = null;

--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/ArrayListTypeFieldDeserializer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/ArrayListTypeFieldDeserializer.java
@@ -1,5 +1,9 @@
 package com.alibaba.fastjson.parser.deserializer;
 
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.parser.*;
+import com.alibaba.fastjson.util.FieldInfo;
+import com.alibaba.fastjson.util.ParameterizedTypeImpl;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -7,15 +11,6 @@ import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
-
-import com.alibaba.fastjson.parser.DefaultJSONParser;
-import com.alibaba.fastjson.parser.Feature;
-import com.alibaba.fastjson.parser.JSONLexer;
-import com.alibaba.fastjson.parser.JSONToken;
-import com.alibaba.fastjson.parser.ParseContext;
-import com.alibaba.fastjson.parser.ParserConfig;
-import com.alibaba.fastjson.util.FieldInfo;
-import com.alibaba.fastjson.util.ParameterizedTypeImpl;
 
 public class ArrayListTypeFieldDeserializer extends FieldDeserializer {
 
@@ -42,6 +37,7 @@ public class ArrayListTypeFieldDeserializer extends FieldDeserializer {
         }
     }
 
+    @Override
     public int getFastMatchToken() {
         return JSONToken.LBRACKET;
     }
@@ -187,12 +183,7 @@ public class ArrayListTypeFieldDeserializer extends FieldDeserializer {
 
             lexer.nextToken(JSONToken.COMMA);
         } else {
-            if (itemTypeDeser == null) {
-                itemTypeDeser = deserializer = parser.getConfig().getDeserializer(itemType);
-            }
-            Object val = itemTypeDeser.deserialze(parser, itemType, 0);
-            array.add(val);
-            parser.checkListResolve(array);
+            throw new JSONException("expect '[', but " + JSONToken.name(token) + ", " + lexer.info());
         }
     }
 }

--- a/src/test/java/com/alibaba/json/bvt/ArrayListTypeFieldDeserializerTest.java
+++ b/src/test/java/com/alibaba/json/bvt/ArrayListTypeFieldDeserializerTest.java
@@ -1,0 +1,35 @@
+package com.alibaba.json.bvt;
+
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.JSONObject;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * ArrayListTypeFieldDeserializer test cases
+ *
+ * @author maxiaoyao
+ * @date 2018-05-08 18:28
+ */
+public class ArrayListTypeFieldDeserializerTest {
+
+    @Test(expected = JSONException.class)
+    public void parseObjectListPropertyWithOutSquareBracketsThrowException() {
+        String body = "{\"sources\":\"5,6\"}";
+        JSONObject.parseObject(body, ListPropertyBean.class);
+    }
+
+    private static class ListPropertyBean {
+
+        private List<Integer> sources;
+
+        public List<Integer> getSources() {
+            return sources;
+        }
+
+        public void setSources(List<Integer> sources) {
+            this.sources = sources;
+        }
+    }
+
+}


### PR DESCRIPTION
1.修复解析JsonString时没有方括号的字符串可以转成对象List属性的问题。
2.修复一个异常输出信息拼写错误。
3.add testcase.