### PR TITLE
fix#1868,优先使用注解配置的时间格式

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/JSONSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JSONSerializer.java
@@ -316,7 +316,7 @@ public class JSONSerializer extends SerializeFilterable {
     public final void writeWithFormat(Object object, String format) {
         if (object instanceof Date) {
             DateFormat dateFormat = this.getDateFormat();
-            if (dateFormat == null) {
+			if (format != null) {// 优先使用注解配置的时间格式#1868
                 dateFormat = new SimpleDateFormat(format, locale);
                 dateFormat.setTimeZone(timeZone);
             }

--- a/src/test/java/com/alibaba/json/bvt/support/spring/FastJsonHttpMessageConverter4Test2.java
+++ b/src/test/java/com/alibaba/json/bvt/support/spring/FastJsonHttpMessageConverter4Test2.java
@@ -1,0 +1,80 @@
+package com.alibaba.json.bvt.support.spring;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Date;
+
+import org.junit.Assert;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import com.alibaba.fastjson.support.config.FastJsonConfig;
+import com.alibaba.fastjson.support.spring.FastJsonHttpMessageConverter4;
+
+import junit.framework.TestCase;
+
+public class FastJsonHttpMessageConverter4Test2 extends TestCase {
+    public FastJsonHttpMessageConverter4Test2() {
+        
+    }
+
+	public void test_1() throws Exception {
+		FastJsonHttpMessageConverter4 converter = new FastJsonHttpMessageConverter4();
+
+		Assert.assertNotNull(converter.getFastJsonConfig());
+		FastJsonConfig fastJsonConfig = new FastJsonConfig();
+		fastJsonConfig.setDateFormat("yyyy-MM-dd HH:mm:ss");
+		fastJsonConfig.setSerializerFeatures(SerializerFeature.PrettyFormat);
+		converter.setFastJsonConfig(fastJsonConfig);
+		
+		VO vo = new VO();
+		vo.setId(123);
+		vo.setStatDate(new Date());
+
+		final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+		HttpOutputMessage out = new HttpOutputMessage() {
+
+			public HttpHeaders getHeaders() {
+				return new HttpHeaders();
+			}
+
+			public OutputStream getBody() throws IOException {
+				return byteOut;
+			}
+		};
+		converter.write(vo, VO.class, MediaType.TEXT_PLAIN, out);
+
+		byte[] bytes = byteOut.toByteArray();
+		System.out.println(new String(bytes, "UTF-8"));
+		
+	}
+	
+	public static class VO {
+
+		private int id;
+		
+		@JSONField(format = "yyyy-MM-dd")
+		private Date statDate;
+
+		public int getId() {
+			return id;
+		}
+
+		public void setId(int id) {
+			this.id = id;
+		}
+		
+		public Date getStatDate() {
+			return this.statDate;
+		}
+		
+		public void setStatDate(Date statDate) {
+			this.statDate = statDate;
+		}
+
+	}
+}


### PR DESCRIPTION
使用JSONField注解配置时间格式，优先于FastJsonConfig。