### PR TITLE
Use StringBuilder instead of StringBuffer.

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
@@ -436,7 +436,7 @@ public class JavaBeanDeserializer implements ObjectDeserializer {
                     return null;
                 }
                 
-                StringBuffer buf = (new StringBuffer()) //
+                StringBuilder buf = (new StringBuilder()) //
                                                         .append("syntax error, expect {, actual ") //
                                                         .append(lexer.tokenName()) //
                                                         .append(", pos ") //


### PR DESCRIPTION
Use StringBuilder instead of StringBuffer for local variable inside the method code block.