### PR TITLE
Fixing flaky test JSONSerializerTest2.test_0

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/serializer/JSONSerializerTest2.java
+++ b/src/test/java/com/alibaba/json/bvt/serializer/JSONSerializerTest2.java
@@ -15,6 +15,7 @@ public class JSONSerializerTest2 extends TestCase {
 
     public void test_0() throws Exception {
         JSONSerializer serializer = new JSONSerializer();
+        serializer.getMapping().clearSerializers();
 
         int size = JSONSerializerMapTest.size(serializer.getMapping());
         serializer.config(SerializerFeature.WriteEnumUsingToString, false);


### PR DESCRIPTION
test_0 in JSONSerializerTest2 has a test-order dependency and it fails when it is run after JSONSerializerTest2.test_3. 

test_0 can be fixed by clearing the serializers. The fix will enable test_0 to now pass in any test run order. Without the fix, the tests will get the following error. Let me know if you want to discuss more.
```
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:86)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.junit.Assert.assertTrue(Assert.java:52)
	at com.alibaba.json.bvt.serializer.JSONSerializerTest2.test_0(JSONSerializerTest2.java:24)
```