### PR TITLE
Fixing flaky tests in DateTest4_indian and DateTest5_iso8601

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/serializer/date/DateTest4_indian.java
+++ b/src/test/java/com/alibaba/json/bvt/serializer/date/DateTest4_indian.java
@@ -5,8 +5,14 @@ import junit.framework.TestCase;
 import org.junit.Assert;
 
 import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 public class DateTest4_indian extends TestCase {
+    protected void setUp() throws Exception {
+        JSON.defaultTimeZone = TimeZone.getTimeZone("Asia/Shanghai");
+        JSON.defaultLocale = Locale.CHINA;
+    }
 
     public void test_date() throws Exception {
         Date date1 = JSON.parseObject("{\"gmtCreate\":\"2018-09-11T21:29:34+0530\"}", VO.class).getGmtCreate();

--- a/src/test/java/com/alibaba/json/bvt/serializer/date/DateTest5_iso8601.java
+++ b/src/test/java/com/alibaba/json/bvt/serializer/date/DateTest5_iso8601.java
@@ -4,8 +4,14 @@ import com.alibaba.fastjson.JSON;
 import junit.framework.TestCase;
 
 import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 public class DateTest5_iso8601 extends TestCase {
+    protected void setUp() throws Exception {
+        JSON.defaultTimeZone = TimeZone.getTimeZone("Asia/Shanghai");
+        JSON.defaultLocale = Locale.CHINA;
+    }
 
     public void test_date() throws Exception {
         Date date1 = JSON.parseObject("{\"gmtCreate\":\"2018-09-12\"}", VO.class).getGmtCreate();


### PR DESCRIPTION
test_date in DateTest4_indian and DateTest5_iso8601 has a test-order dependency and it fails when they are run by themselves.

test_date can be fixed by running a setup to change the time and locale to "Asia/Shanghai" and "China" (respectively). This setup is the same as the one in the DateTest class that these tests were depending on. The fix will enable test_date in the two classes to now pass in any test run order and by itself. Without the fix, the tests will get the following error. Let me know if you want to discuss more.
```
junit.framework.AssertionFailedError: 
Expected :83419000
Actual   :29419000
	at junit.framework.Assert.fail(Assert.java:57)
	at junit.framework.Assert.failNotEquals(Assert.java:329)
	at junit.framework.Assert.assertEquals(Assert.java:78)
	at junit.framework.Assert.assertEquals(Assert.java:159)
	at junit.framework.Assert.assertEquals(Assert.java:166)
	at junit.framework.TestCase.assertEquals(TestCase.java:324)
	at com.alibaba.json.bvt.serializer.date.DateTest5_iso8601.test_date(DateTest5_iso8601.java:27)

```