### PR TITLE
Fixed issues with timezone and locale incorrectly set in DateTest, DateTest_tz, Issue1298, Issue1679, and Issue1977

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/date/DateTest.java
+++ b/src/test/java/com/alibaba/json/bvt/date/DateTest.java
@@ -1,6 +1,8 @@
 package com.alibaba.json.bvt.date;
 
 import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import junit.framework.TestCase;
 
@@ -10,6 +12,10 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 
 public class DateTest extends TestCase {
+    protected void setUp() throws Exception {
+        JSON.defaultTimeZone = TimeZone.getTimeZone("Asia/Shanghai");
+        JSON.defaultLocale = Locale.CHINA;
+    }
 
     public void test_date() throws Exception {
         long millis = 1324138987429L;

--- a/src/test/java/com/alibaba/json/bvt/date/DateTest_tz.java
+++ b/src/test/java/com/alibaba/json/bvt/date/DateTest_tz.java
@@ -8,15 +8,16 @@ import java.util.TimeZone;
 
 import org.junit.Assert;
 
+import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONReader;
 
 import junit.framework.TestCase;
 
 public class DateTest_tz extends TestCase {
-//    protected void setUp() throws Exception {
-//        JSON.defaultTimeZone = TimeZone.getTimeZone("Asia/Shanghai");
-//        JSON.defaultLocale = Locale.CHINA;
-//    }
+    protected void setUp() throws Exception {
+        JSON.defaultTimeZone = TimeZone.getTimeZone("Asia/Shanghai");
+        JSON.defaultLocale = Locale.CHINA;
+    }
     
     public void test_codec() throws Exception {
         JSONReader reader = new JSONReader(new StringReader("{\"value\":\"2016-04-29\"}"));

--- a/src/test/java/com/alibaba/json/bvt/issue_1200/Issue1298.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1200/Issue1298.java
@@ -6,11 +6,18 @@ import com.alibaba.fastjson.serializer.SerializerFeature;
 import junit.framework.TestCase;
 
 import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 /**
  * Created by wenshao on 30/06/2017.
  */
 public class Issue1298 extends TestCase {
+    protected void setUp() throws Exception {
+        JSON.defaultTimeZone = TimeZone.getTimeZone("Asia/Shanghai");
+        JSON.defaultLocale = Locale.US;
+    }
+
     public void test_for_issue() throws Exception {
         JSONObject object = new JSONObject();
 

--- a/src/test/java/com/alibaba/json/bvt/issue_1600/Issue1679.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1600/Issue1679.java
@@ -5,8 +5,14 @@ import com.alibaba.fastjson.serializer.SerializerFeature;
 import junit.framework.TestCase;
 
 import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 public class Issue1679 extends TestCase {
+    protected void setUp() throws Exception {
+        JSON.defaultTimeZone = TimeZone.getTimeZone("Asia/Shanghai");
+        JSON.defaultLocale = Locale.CHINA;
+    }
 
     public void test_for_issue() throws Exception {
         String json = "{\"create\":\"2018-01-10 08:30:00\"}";

--- a/src/test/java/com/alibaba/json/bvt/issue_1900/Issue1977.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1900/Issue1977.java
@@ -4,7 +4,15 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 import junit.framework.TestCase;
 
+import java.util.Locale;
+import java.util.TimeZone;
+
 public class Issue1977 extends TestCase {
+    protected void setUp() throws Exception {
+        JSON.defaultTimeZone = TimeZone.getTimeZone("Asia/Shanghai");
+        JSON.defaultLocale = Locale.CHINA;
+    }
+
     public void test_for_issue() throws Exception {
         java.sql.Date date = new java.sql.Date(1533265119604L);
         String json = JSON.toJSONString(date, SerializerFeature.UseISO8601DateFormat);


### PR DESCRIPTION
Similar to the following, recently accepted pull request, https://github.com/alibaba/fastjson/pull/2148 the tests in DateTest, DateTest_tz, Issue1298, Issue1679, and Issue1977 also depends on the time zone and the locale. To the best of my knowledge, these are the remaining classes in the project with this issue.

The tests in these classes can be fixed by running a setup to change the time and locale to "Asia/Shanghai" and "China" (respectively). This setup is the same as the one in other classes such as the DateTest class. This fix will enable the tests in these classes to now pass in any test run order and by itself. Let me know if you want to discuss more.