### PR TITLE
fix #2224 复杂继承情况下 TypeUtils.getCollectionItemType() 获取类型错误导致反序列化失败

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/issue_2200/Issue2224.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2200/Issue2224.java
@@ -1,0 +1,18 @@
+package com.alibaba.json.bvt.issue_2200;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.json.bvt.issue_2200.issue2224.PersonCollection;
+import junit.framework.TestCase;
+
+public class Issue2224 extends TestCase {
+    public void test_for_issue() throws Exception {
+        String json = "[{\"idNo\":\"123456\",\"name\":\"tom\"},{\"idNo\":\"123457\",\"name\":\"jack\"}]";
+        PersonCollection personCollection = JSON.parseObject(json, PersonCollection.class);
+        assertNotNull(personCollection);
+        assertEquals(2, personCollection.size());
+        assertEquals("tom", personCollection.get("123456").getName());
+        assertEquals("jack", personCollection.get("123457").getName());
+        String json2 = JSON.toJSONString(personCollection);
+        assertNotNull(json2);
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/issue_2200/issue2224/CollectionEx.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2200/issue2224/CollectionEx.java
@@ -1,0 +1,6 @@
+package com.alibaba.json.bvt.issue_2200.issue2224;
+
+import java.util.Collection;
+
+public interface CollectionEx<TElement> extends Collection<TElement> {
+}

--- a/src/test/java/com/alibaba/json/bvt/issue_2200/issue2224/KeyedCollection.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2200/issue2224/KeyedCollection.java
@@ -1,0 +1,104 @@
+package com.alibaba.json.bvt.issue_2200.issue2224;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+abstract class KeyedCollection<TKey, TItem> implements CollectionEx<TItem>, Cloneable {
+    private transient Map<TKey, TItem> items = new LinkedHashMap<TKey, TItem>();
+
+    protected abstract TKey getKeyForItem(TItem item);
+
+    public TItem get(TKey key) {
+        return this.items.get(key);
+    }
+
+    //region override
+
+    public int size() {
+        return this.items.size();
+    }
+
+    public boolean isEmpty() {
+        return this.items.isEmpty();
+    }
+
+    public boolean contains(Object key) {
+        return this.items.containsKey(key);
+    }
+
+    public Iterator<TItem> iterator() {
+        return this.items.values().iterator();
+    }
+
+    public Object[] toArray() {
+        return this.items.values().toArray();
+    }
+
+    public <T> T[] toArray(T[] a) {
+        return this.items.values().toArray(a);
+    }
+
+    public boolean add(TItem item) {
+        if (item == null)
+            throw new IllegalArgumentException("item can not be null.");
+        TKey key = this.getKeyForItem(item);
+        this.items.put(key, item);
+        return true;
+    }
+
+    public boolean remove(Object key) {
+        return this.items.remove(key) != null;
+    }
+
+    public boolean containsAll(Collection<?> keys) {
+        return this.items.keySet().containsAll(keys);
+    }
+
+    public boolean addAll(Collection<? extends TItem> items) {
+        boolean modified = false;
+        for (TItem item : items)
+            modified |= this.add(item);
+        return modified;
+    }
+
+    public boolean removeAll(Collection<?> keys) {
+        boolean modified = false;
+        for (Object key : keys)
+            modified |= this.remove(key);
+        return modified;
+    }
+
+    public boolean retainAll(Collection<?> keys) {
+        boolean modified = false;
+        for (TKey key : this.items.keySet()) {
+            if (!keys.contains(key))
+                modified |= this.remove(key);
+        }
+        return modified;
+    }
+
+    public void clear() {
+        this.items.clear();
+    }
+
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append('[');
+        TItem item;
+        Iterator<TItem> iterator = this.iterator();
+        if (iterator.hasNext()) {
+            item = iterator.next();
+            builder.append(item == this ? "(this Collection)" : item);
+        }
+        while (iterator.hasNext()) {
+            item = iterator.next();
+            builder.append(", ").append(item == this ? "(this Collection)" : item);
+        }
+        builder.append(']');
+        return builder.toString();
+    }
+
+    //endregion
+}

--- a/src/test/java/com/alibaba/json/bvt/issue_2200/issue2224/Person.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2200/issue2224/Person.java
@@ -1,0 +1,22 @@
+package com.alibaba.json.bvt.issue_2200.issue2224;
+
+public class Person {
+    private String idNo;
+    private String name;
+
+    public String getIdNo() {
+        return this.idNo;
+    }
+
+    public void setIdNo(String idNo) {
+        this.idNo = idNo;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/issue_2200/issue2224/PersonCollection.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2200/issue2224/PersonCollection.java
@@ -1,0 +1,7 @@
+package com.alibaba.json.bvt.issue_2200.issue2224;
+
+public class PersonCollection extends KeyedCollection<String, Person> {
+    protected String getKeyForItem(Person person) {
+        return person.getIdNo();
+    }
+}


### PR DESCRIPTION
fix #2224