### PR TITLE
修复JSON解析异常时错误的提示信息：拼写错误

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
+++ b/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
@@ -705,7 +705,7 @@ public class DefaultJSONParser implements Closeable {
         }
 
         if (token != JSONToken.LBRACKET) {
-            throw new JSONException("exepct '[', but " + JSONToken.name(token) + ", " + lexer.info());
+            throw new JSONException("expect '[', but " + JSONToken.name(token) + ", " + lexer.info());
         }
 
         ObjectDeserializer deserializer = null;


### PR DESCRIPTION
解析JSON异常时，异常提示信息的拼写存在问题。