### PR TITLE
Add PropertyNamingStrategy.LowerCaseWithDots

### DIFF
--- a/src/main/java/com/alibaba/fastjson/PropertyNamingStrategy.java
+++ b/src/main/java/com/alibaba/fastjson/PropertyNamingStrategy.java
@@ -4,45 +4,23 @@ package com.alibaba.fastjson;
  * @since 1.2.15
  */
 public enum PropertyNamingStrategy {
-                                    CamelCase, //
-                                    PascalCase, //
-                                    SnakeCase, //
-                                    KebabCase;
+                                    CamelCase,          //
+                                    PascalCase,         //
+                                    SnakeCase,          //lower case separated by '_'
+                                    KebabCase,          //lower case separated by '-'
+                                    LowerCaseWithDots;  //lower case separated by '.'
 
     public String translate(String propertyName) {
         switch (this) {
-            case SnakeCase: {
-                StringBuilder buf = new StringBuilder();
-                for (int i = 0; i < propertyName.length(); ++i) {
-                    char ch = propertyName.charAt(i);
-                    if (ch >= 'A' && ch <= 'Z') {
-                        char ch_ucase = (char) (ch + 32);
-                        if (i > 0) {
-                            buf.append('_');
-                        }
-                        buf.append(ch_ucase);
-                    } else {
-                        buf.append(ch);
-                    }
-                }
-                return buf.toString();
-            }
-            case KebabCase: {
-                StringBuilder buf = new StringBuilder();
-                for (int i = 0; i < propertyName.length(); ++i) {
-                    char ch = propertyName.charAt(i);
-                    if (ch >= 'A' && ch <= 'Z') {
-                        char ch_ucase = (char) (ch + 32);
-                        if (i > 0) {
-                            buf.append('-');
-                        }
-                        buf.append(ch_ucase);
-                    } else {
-                        buf.append(ch);
-                    }
-                }
-                return buf.toString();
-            }
+            case SnakeCase:
+                return toLowerCaseWithSeparator(propertyName, '_');
+
+            case KebabCase:
+                return toLowerCaseWithSeparator(propertyName, '-');
+
+            case LowerCaseWithDots:
+                return toLowerCaseWithSeparator(propertyName, '.');
+
             case PascalCase: {
                 char ch = propertyName.charAt(0);
                 if (ch >= 'a' && ch <= 'z') {
@@ -50,9 +28,9 @@ public enum PropertyNamingStrategy {
                     chars[0] -= 32;
                     return new String(chars);
                 }
-
                 return propertyName;
             }
+
             case CamelCase: {
                 char ch = propertyName.charAt(0);
                 if (ch >= 'A' && ch <= 'Z') {
@@ -60,11 +38,35 @@ public enum PropertyNamingStrategy {
                     chars[0] += 32;
                     return new String(chars);
                 }
-
                 return propertyName;
             }
+
             default:
                 return propertyName;
         }
+    }
+
+    /**
+     * Translate property name to lower case with a separator like
+     * '_' (SnakeCase), '-' (KebabCase), '.'(LowerCaseWithDots) etc.
+     * @param propertyName The property (field) name in the java bean.
+     * @param separator Separator where we see an upper case letter.
+     * @return The property name in the json text.
+     */
+    public static String toLowerCaseWithSeparator(String propertyName, char separator) {
+        StringBuilder buf = new StringBuilder();
+        for (int i = 0; i < propertyName.length(); ++i) {
+            char ch = propertyName.charAt(i);
+            if (ch >= 'A' && ch <= 'Z') {
+                char chUpperCase =  (char) (ch + 32);
+                if (i > 0) {
+                    buf.append(separator);
+                }
+                buf.append(chUpperCase);
+            } else {
+                buf.append(ch);
+            }
+        }
+        return buf.toString();
     }
 }

--- a/src/test/java/com/alibaba/json/bvt/naming/PropertyNamingStrategyTest.java
+++ b/src/test/java/com/alibaba/json/bvt/naming/PropertyNamingStrategyTest.java
@@ -9,9 +9,9 @@ import com.alibaba.fastjson.serializer.SerializeConfig;
 
 import junit.framework.TestCase;
 
-public class NamingSerTest extends TestCase {
+public class PropertyNamingStrategyTest extends TestCase {
 
-    public void test_snake() throws Exception {
+    public void testSnakeCase() {
         SerializeConfig config = new SerializeConfig();
         config.propertyNamingStrategy = PropertyNamingStrategy.SnakeCase;
 
@@ -29,7 +29,7 @@ public class NamingSerTest extends TestCase {
         Assert.assertEquals(model.personId, model3.personId);
     }
 
-    public void test_kebab() throws Exception {
+    public void testKebabCase() {
         SerializeConfig config = new SerializeConfig();
         config.propertyNamingStrategy = PropertyNamingStrategy.KebabCase;
 
@@ -47,7 +47,25 @@ public class NamingSerTest extends TestCase {
         Assert.assertEquals(model.personId, model3.personId);
     }
 
-    public void test_pascal() throws Exception {
+    public void testLowerCaseWithDots() {
+        SerializeConfig config = new SerializeConfig();
+        config.propertyNamingStrategy = PropertyNamingStrategy.LowerCaseWithDots;
+
+        Model model = new Model();
+        model.personId = 1001;
+        String text = JSON.toJSONString(model, config);
+        Assert.assertEquals("{\"person.id\":1001}", text);
+
+        ParserConfig parserConfig = new ParserConfig();
+        parserConfig.propertyNamingStrategy = PropertyNamingStrategy.LowerCaseWithDots;
+        Model model2 = JSON.parseObject(text, Model.class, parserConfig);
+        Assert.assertEquals(model.personId, model2.personId);
+
+        Model model3 = JSON.parseObject(text, Model.class);
+        Assert.assertEquals(model.personId, model3.personId);
+    }
+
+    public void testPascalCase() {
         SerializeConfig config = new SerializeConfig();
         config.propertyNamingStrategy = PropertyNamingStrategy.PascalCase;
 
@@ -65,7 +83,7 @@ public class NamingSerTest extends TestCase {
         Assert.assertEquals(model.personId, model3.personId);
     }
 
-    public void test_camel() throws Exception {
+    public void testCamelCase() {
         SerializeConfig config = new SerializeConfig();
         config.propertyNamingStrategy = PropertyNamingStrategy.CamelCase;
 


### PR DESCRIPTION
This name strategy is widely used as configuration property names, which maps, e.g., `sparkDriverMemory` to `spark.driver.memory`.

Similar PR has been adopted in gson 2.8.5 and jackson 2.10.

Also refactored the class and test class a little bit.
