### PR TITLE
Fixing flaky test in Issue1769

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/issue_1700/Issue1769.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1700/Issue1769.java
@@ -6,8 +6,15 @@ import com.alibaba.fastjson.annotation.JSONType;
 import junit.framework.TestCase;
 
 import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 public class Issue1769 extends TestCase {
+    protected void setUp() throws Exception {
+        JSON.defaultTimeZone = TimeZone.getTimeZone("Asia/Shanghai");
+        JSON.defaultLocale = Locale.CHINA;
+    }
+
     public void test_for_issue() throws Exception {
         byte[] newby = "{\"beginTime\":\"420180319160440\"}".getBytes();
         QueryTaskResultReq rsp3 = JSON.parseObject(newby, QueryTaskResultReq.class);


### PR DESCRIPTION
Similar to #2148 and #2172, Issue1769 also depends on the time zone and locale, so when it runs by itself the test fails. The fix is the same as with the fixes in the previous pull requests. Let me know if you want to discuss more.