### PR TITLE
Fixing flaky test in MaxBufSizeTest

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/serializer/MaxBufSizeTest.java
+++ b/src/test/java/com/alibaba/json/bvt/serializer/MaxBufSizeTest.java
@@ -9,7 +9,7 @@ import junit.framework.TestCase;
  */
 public class MaxBufSizeTest extends TestCase {
     public void test_max_buf() throws Exception {
-        SerializeWriter writer = new SerializeWriter();
+        SerializeWriter writer = new SerializeWriter(2);
 
         Throwable error = null;
         try {


### PR DESCRIPTION
The test test_max_buf in MaxBufSizeTest fails when run after SerializeWriterTest_14. The reason is that tests in SerializeWriterTest_14 create SerializeWriter instances of size 1, and the buffer for those instances are cached. When test_max_buf makes a new SerializeWriter instance, it reuses the prior buffer of size 1, and the later call to `writer.setMaxBufSize(1)` does not throw an exception as expected.

The proposed fix is to have test_max_buf purposely create a valid SerializeWriter, of size 2, such that it is guaranteed for the later exception to be thrown.