### PR TITLE
feat(date): add support for different timeZone offsets

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/DateCodec.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/DateCodec.java
@@ -131,8 +131,9 @@ public class DateCodec extends AbstractDateDeserializer implements ObjectSeriali
             
             out.write(buf);
 
-            int timeZone = calendar.getTimeZone().getOffset(calendar.getTimeInMillis()) / (3600 * 1000);
-            if (timeZone == 0) {
+            float timeZoneF = calendar.getTimeZone().getOffset(calendar.getTimeInMillis()) / (3600.0f * 1000);
+            int timeZone = (int)timeZoneF;
+            if (timeZone == 0.0) {
                 out.write('Z');
             } else {
                 if (timeZone > 9) {
@@ -150,8 +151,11 @@ public class DateCodec extends AbstractDateDeserializer implements ObjectSeriali
                     out.write('0');
                     out.writeInt(-timeZone);
                 }
-
-                out.append(":00");
+                out.write(':');
+                // handles uneven timeZones 30 mins, 45 mins
+                // this would always be less than 60
+                int offSet = (int)((timeZoneF - timeZone) * 60);
+                out.append(String.format("%02d", offSet));
             }
 
             out.write(quote);

--- a/src/test/java/com/alibaba/json/bvt/parser/deser/date/DateParseTest9.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/deser/date/DateParseTest9.java
@@ -1,6 +1,8 @@
 package com.alibaba.json.bvt.parser.deser.date;
 
+import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
 import junit.framework.TestCase;
 
@@ -9,7 +11,6 @@ import org.junit.Assert;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.parser.JSONToken;
 import com.alibaba.fastjson.serializer.CalendarCodec;
-import com.alibaba.json.bvt.parser.deser.date.DateParseTest14.VO;
 
 
 public class DateParseTest9 extends TestCase {
@@ -18,6 +19,11 @@ public class DateParseTest9 extends TestCase {
         Date date = JSON.parseObject(text, Date.class);
         Assert.assertEquals(date.getTime(), 1242357713797L);
         
+        Assert.assertEquals(JSONToken.LITERAL_INT, CalendarCodec.instance.getFastMatchToken());
+
+        text = "\"/Date(1242357713797+0545)/\"";
+        date = JSON.parseObject(text, Date.class);
+        Assert.assertEquals(date.getTime(), 1242357713797L);
         Assert.assertEquals(JSONToken.LITERAL_INT, CalendarCodec.instance.getFastMatchToken());
     }
     
@@ -39,5 +45,21 @@ public class DateParseTest9 extends TestCase {
             error = ex;
         }
         Assert.assertNotNull(error);
+    }
+
+    public void test_dates_different_timeZones() {
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("IST"));
+        Date now = cal.getTime();
+
+        VO vo = new VO();
+        vo.date = now;
+
+        String json = JSON.toJSONString(vo);
+        VO result = JSON.parseObject(json, VO.class);
+        assertEquals(vo.date, result.date);
+    }
+
+    public static class VO {
+        public Date date;
     }
 }


### PR DESCRIPTION
* usually offset for timeZone is 1 hour but there are countries
  with 30mins and 45mins offset. For example, IST is +5:30 and Nepal is +5:45
* modify `CalenderCodec` write date logic(similar to DateCodec)