### PR TITLE
Add support to run date tests in different timezones

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/jdk8/LocalDateTimeTest5.java
+++ b/src/test/java/com/alibaba/json/bvt/jdk8/LocalDateTimeTest5.java
@@ -1,9 +1,10 @@
 package com.alibaba.json.bvt.jdk8;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Locale;
-
-import org.junit.Assert;
+import java.util.Random;
+import java.util.TimeZone;
 
 import com.alibaba.fastjson.JSON;
 
@@ -11,153 +12,169 @@ import junit.framework.TestCase;
 
 public class LocalDateTimeTest5 extends TestCase {
 
-    private Locale origin;
+    private static Random random = new Random();
 
+    private Locale origin;
+    private TimeZone original = TimeZone.getDefault();
+    private String[] zoneIds = TimeZone.getAvailableIDs();
+
+    @Override
     protected void setUp() throws Exception {
+        int index = random.nextInt(zoneIds.length);
+        TimeZone timeZone = TimeZone.getTimeZone(zoneIds[index]);
+        TimeZone.setDefault(timeZone);
+        JSON.defaultTimeZone = timeZone; // While running mvn tests defaultTimeZone might already be initialized
         origin = Locale.getDefault();
     }
 
+    @Override
     protected void tearDown() throws Exception {
+        TimeZone.setDefault(original);
+        JSON.defaultTimeZone = original;
         Locale.setDefault(origin);
     }
 
     public void test_for_long() throws Exception {
-        VO vo = JSON.parseObject("{\"date\":1322874196000}", VO.class);
+        long millis = 1322874196000L;
+        // using localDataTime instance so that different timeZones are tested
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(
+                Instant.ofEpochMilli(millis), TimeZone.getDefault().toZoneId());
+        VO vo = JSON.parseObject("{\"date\":" + millis + "}", VO.class);
 
-        Assert.assertEquals(2011, vo.date.getYear());
-        Assert.assertEquals(12, vo.date.getMonthValue());
-        Assert.assertEquals(3, vo.date.getDayOfMonth());
-//        Assert.assertEquals(9, vo.date.getHour());
-        Assert.assertEquals(3, vo.date.getMinute());
-        Assert.assertEquals(16, vo.date.getSecond());
-        Assert.assertEquals(0, vo.date.getNano());
+        assertEquals("Not Matching year", localDateTime.getYear(), vo.date.getYear());
+        assertEquals("Not Matching month", localDateTime.getMonthValue(), vo.date.getMonthValue());
+        assertEquals("Not Matching day", localDateTime.getDayOfMonth(), vo.date.getDayOfMonth());
+        assertEquals("Not Matching hour", localDateTime.getHour(), vo.date.getHour());
+        assertEquals("Not Matching minute", localDateTime.getMinute(), vo.date.getMinute());
+        assertEquals("Not Matching second", localDateTime.getSecond(), vo.date.getSecond());
+        assertEquals("Not Matching nano", localDateTime.getNano(), vo.date.getNano());
     }
     
     public void test_for_normal() throws Exception {
         VO vo = JSON.parseObject("{\"date\":\"2011-12-03 09:03:16\"}", VO.class);
         
-        Assert.assertEquals(2011, vo.date.getYear());
-        Assert.assertEquals(12, vo.date.getMonthValue());
-        Assert.assertEquals(3, vo.date.getDayOfMonth());
-        Assert.assertEquals(9, vo.date.getHour());
-        Assert.assertEquals(3, vo.date.getMinute());
-        Assert.assertEquals(16, vo.date.getSecond());
-        Assert.assertEquals(0, vo.date.getNano());
+        assertEquals(2011, vo.date.getYear());
+        assertEquals(12, vo.date.getMonthValue());
+        assertEquals(3, vo.date.getDayOfMonth());
+        assertEquals(9, vo.date.getHour());
+        assertEquals(3, vo.date.getMinute());
+        assertEquals(16, vo.date.getSecond());
+        assertEquals(0, vo.date.getNano());
     }
     
     public void test_for_iso() throws Exception {
         VO vo = JSON.parseObject("{\"date\":\"2011-12-03T09:03:16\"}", VO.class);
         
-        Assert.assertEquals(2011, vo.date.getYear());
-        Assert.assertEquals(12, vo.date.getMonthValue());
-        Assert.assertEquals(3, vo.date.getDayOfMonth());
+        assertEquals(2011, vo.date.getYear());
+        assertEquals(12, vo.date.getMonthValue());
+        assertEquals(3, vo.date.getDayOfMonth());
         
-        Assert.assertEquals(9, vo.date.getHour());
-        Assert.assertEquals(3, vo.date.getMinute());
-        Assert.assertEquals(16, vo.date.getSecond());
-        Assert.assertEquals(0, vo.date.getNano());
+        assertEquals(9, vo.date.getHour());
+        assertEquals(3, vo.date.getMinute());
+        assertEquals(16, vo.date.getSecond());
+        assertEquals(0, vo.date.getNano());
     }
     
     public void test_for_tw() throws Exception {
         VO vo = JSON.parseObject("{\"date\":\"2016/05/06 09:03:16\"}", VO.class);
 
-        Assert.assertEquals(2016, vo.date.getYear());
-        Assert.assertEquals(5, vo.date.getMonthValue());
-        Assert.assertEquals(6, vo.date.getDayOfMonth());
+        assertEquals(2016, vo.date.getYear());
+        assertEquals(5, vo.date.getMonthValue());
+        assertEquals(6, vo.date.getDayOfMonth());
     }
 
     public void test_for_jp() throws Exception {
         VO vo = JSON.parseObject("{\"date\":\"2016年5月6日 09:03:16\"}", VO.class);
 
-        Assert.assertEquals(2016, vo.date.getYear());
-        Assert.assertEquals(5, vo.date.getMonthValue());
-        Assert.assertEquals(6, vo.date.getDayOfMonth());
+        assertEquals(2016, vo.date.getYear());
+        assertEquals(5, vo.date.getMonthValue());
+        assertEquals(6, vo.date.getDayOfMonth());
     }
     
     public void test_for_cn() throws Exception {
         VO vo = JSON.parseObject("{\"date\":\"2016年5月6日 9时3分16秒\"}", VO.class);
 
-        Assert.assertEquals(2016, vo.date.getYear());
-        Assert.assertEquals(5, vo.date.getMonthValue());
-        Assert.assertEquals(6, vo.date.getDayOfMonth());
+        assertEquals(2016, vo.date.getYear());
+        assertEquals(5, vo.date.getMonthValue());
+        assertEquals(6, vo.date.getDayOfMonth());
     }
 
     public void test_for_kr() throws Exception {
         VO vo = JSON.parseObject("{\"date\":\"2016년5월6일 09:03:16\"}", VO.class);
 
-        Assert.assertEquals(2016, vo.date.getYear());
-        Assert.assertEquals(5, vo.date.getMonthValue());
-        Assert.assertEquals(6, vo.date.getDayOfMonth());
+        assertEquals(2016, vo.date.getYear());
+        assertEquals(5, vo.date.getMonthValue());
+        assertEquals(6, vo.date.getDayOfMonth());
     }
 
     public void test_for_us() throws Exception {
         VO vo = JSON.parseObject("{\"date\":\"05/26/2016 09:03:16\"}", VO.class);
 
-        Assert.assertEquals(2016, vo.date.getYear());
-        Assert.assertEquals(5, vo.date.getMonthValue());
-        Assert.assertEquals(26, vo.date.getDayOfMonth());
+        assertEquals(2016, vo.date.getYear());
+        assertEquals(5, vo.date.getMonthValue());
+        assertEquals(26, vo.date.getDayOfMonth());
     }
 
     public void test_for_eur() throws Exception {
         VO vo = JSON.parseObject("{\"date\":\"26/05/2016 09:03:16\"}", VO.class);
 
-        Assert.assertEquals(2016, vo.date.getYear());
-        Assert.assertEquals(5, vo.date.getMonthValue());
-        Assert.assertEquals(26, vo.date.getDayOfMonth());
+        assertEquals(2016, vo.date.getYear());
+        assertEquals(5, vo.date.getMonthValue());
+        assertEquals(26, vo.date.getDayOfMonth());
     }
 
     public void test_for_us_1() throws Exception {
         Locale.setDefault(Locale.US);
         VO vo = JSON.parseObject("{\"date\":\"05/06/2016 09:03:16\"}", VO.class);
 
-        Assert.assertEquals(2016, vo.date.getYear());
-        Assert.assertEquals(5, vo.date.getMonthValue());
-        Assert.assertEquals(06, vo.date.getDayOfMonth());
+        assertEquals(2016, vo.date.getYear());
+        assertEquals(5, vo.date.getMonthValue());
+        assertEquals(06, vo.date.getDayOfMonth());
     }
 
     public void test_for_br() throws Exception {
         Locale.setDefault(new Locale("pt", "BR"));
         VO vo = JSON.parseObject("{\"date\":\"06/05/2016 09:03:16\"}", VO.class);
 
-        Assert.assertEquals(2016, vo.date.getYear());
-        Assert.assertEquals(5, vo.date.getMonthValue());
-        Assert.assertEquals(6, vo.date.getDayOfMonth());
+        assertEquals(2016, vo.date.getYear());
+        assertEquals(5, vo.date.getMonthValue());
+        assertEquals(6, vo.date.getDayOfMonth());
     }
 
     public void test_for_au() throws Exception {
         Locale.setDefault(new Locale("en", "AU"));
         VO vo = JSON.parseObject("{\"date\":\"06/05/2016 09:03:16\"}", VO.class);
 
-        Assert.assertEquals(2016, vo.date.getYear());
-        Assert.assertEquals(5, vo.date.getMonthValue());
-        Assert.assertEquals(6, vo.date.getDayOfMonth());
+        assertEquals(2016, vo.date.getYear());
+        assertEquals(5, vo.date.getMonthValue());
+        assertEquals(6, vo.date.getDayOfMonth());
     }
 
     public void test_for_de() throws Exception {
         Locale.setDefault(new Locale("pt", "BR"));
         VO vo = JSON.parseObject("{\"date\":\"06.05.2016 09:03:16\"}", VO.class);
 
-        Assert.assertEquals(2016, vo.date.getYear());
-        Assert.assertEquals(5, vo.date.getMonthValue());
-        Assert.assertEquals(6, vo.date.getDayOfMonth());
+        assertEquals(2016, vo.date.getYear());
+        assertEquals(5, vo.date.getMonthValue());
+        assertEquals(6, vo.date.getDayOfMonth());
         
-        Assert.assertEquals(9, vo.date.getHour());
-        Assert.assertEquals(3, vo.date.getMinute());
-        Assert.assertEquals(16, vo.date.getSecond());
-        Assert.assertEquals(0, vo.date.getNano());
+        assertEquals(9, vo.date.getHour());
+        assertEquals(3, vo.date.getMinute());
+        assertEquals(16, vo.date.getSecond());
+        assertEquals(0, vo.date.getNano());
     }
     
     public void test_for_in() throws Exception {
         VO vo = JSON.parseObject("{\"date\":\"06-05-2016 09:03:16\"}", VO.class);
 
-        Assert.assertEquals(2016, vo.date.getYear());
-        Assert.assertEquals(5, vo.date.getMonthValue());
-        Assert.assertEquals(6, vo.date.getDayOfMonth());
+        assertEquals(2016, vo.date.getYear());
+        assertEquals(5, vo.date.getMonthValue());
+        assertEquals(6, vo.date.getDayOfMonth());
         
-        Assert.assertEquals(9, vo.date.getHour());
-        Assert.assertEquals(3, vo.date.getMinute());
-        Assert.assertEquals(16, vo.date.getSecond());
-        Assert.assertEquals(0, vo.date.getNano());
+        assertEquals(9, vo.date.getHour());
+        assertEquals(3, vo.date.getMinute());
+        assertEquals(16, vo.date.getSecond());
+        assertEquals(0, vo.date.getNano());
     }
 
     public static class VO {

--- a/src/test/java/com/alibaba/json/bvt/parser/deser/date/DateParseTest9.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/deser/date/DateParseTest9.java
@@ -22,12 +22,15 @@ public class DateParseTest9 extends TestCase {
     @Override
     public void setUp() {
         int index = random.nextInt(zoneIds.length);
-        TimeZone.setDefault(TimeZone.getTimeZone(zoneIds[index]));
+        TimeZone timeZone = TimeZone.getTimeZone(zoneIds[index]);
+        TimeZone.setDefault(timeZone);
+        JSON.defaultTimeZone = timeZone;
     }
 
     @Override
     public void tearDown () {
         TimeZone.setDefault(original);
+        JSON.defaultTimeZone = original;
     }
 
     public void test_date() throws Exception {

--- a/src/test/java/com/alibaba/json/bvt/parser/deser/date/DateParseTest9.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/deser/date/DateParseTest9.java
@@ -2,29 +2,45 @@ package com.alibaba.json.bvt.parser.deser.date;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Random;
 import java.util.TimeZone;
 
 import junit.framework.TestCase;
 
-import org.junit.Assert;
-
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.parser.JSONToken;
 import com.alibaba.fastjson.serializer.CalendarCodec;
+import com.alibaba.fastjson.serializer.SerializerFeature;
 
 
 public class DateParseTest9 extends TestCase {
+
+    private static Random random = new Random();
+    private TimeZone original = TimeZone.getDefault();
+    private String[] zoneIds = TimeZone.getAvailableIDs();
+
+    @Override
+    public void setUp() {
+        int index = random.nextInt(zoneIds.length);
+        TimeZone.setDefault(TimeZone.getTimeZone(zoneIds[index]));
+    }
+
+    @Override
+    public void tearDown () {
+        TimeZone.setDefault(original);
+    }
+
     public void test_date() throws Exception {
         String text = "\"/Date(1242357713797+0800)/\"";
         Date date = JSON.parseObject(text, Date.class);
-        Assert.assertEquals(date.getTime(), 1242357713797L);
+        assertEquals(date.getTime(), 1242357713797L);
         
-        Assert.assertEquals(JSONToken.LITERAL_INT, CalendarCodec.instance.getFastMatchToken());
+        assertEquals(JSONToken.LITERAL_INT, CalendarCodec.instance.getFastMatchToken());
 
         text = "\"/Date(1242357713797+0545)/\"";
         date = JSON.parseObject(text, Date.class);
-        Assert.assertEquals(date.getTime(), 1242357713797L);
-        Assert.assertEquals(JSONToken.LITERAL_INT, CalendarCodec.instance.getFastMatchToken());
+        assertEquals(date.getTime(), 1242357713797L);
+        assertEquals(JSONToken.LITERAL_INT, CalendarCodec.instance.getFastMatchToken());
     }
     
     public void test_error() throws Exception {
@@ -34,7 +50,7 @@ public class DateParseTest9 extends TestCase {
         } catch (Exception ex) {
             error = ex;
         }
-        Assert.assertNotNull(error);
+        assertNotNull(error);
     }
     
     public void test_error_1() throws Exception {
@@ -44,11 +60,11 @@ public class DateParseTest9 extends TestCase {
         } catch (Exception ex) {
             error = ex;
         }
-        Assert.assertNotNull(error);
+        assertNotNull(error);
     }
 
     public void test_dates_different_timeZones() {
-        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("IST"));
+        Calendar cal = Calendar.getInstance();
         Date now = cal.getTime();
 
         VO vo = new VO();
@@ -56,6 +72,11 @@ public class DateParseTest9 extends TestCase {
 
         String json = JSON.toJSONString(vo);
         VO result = JSON.parseObject(json, VO.class);
+        assertEquals(vo.date, result.date);
+
+        // with iso-format
+        json = JSON.toJSONString(vo, SerializerFeature.UseISO8601DateFormat);
+        result = JSON.parseObject(json, VO.class);
         assertEquals(vo.date, result.date);
     }
 


### PR DESCRIPTION
This is a continuation of PR #2320 
* Adds tests to validate date serialization & deserialization in ISO format
* Adds support to pick timezone randomly in the date related tests
* Fixes failing test for `LocalDateTime` in some timeZones