### PR TITLE
Fix default constructor accessible

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
@@ -274,6 +274,11 @@ public class JavaBeanInfo {
 
                 computeFields(clazz, type, propertyNamingStrategy, fieldList, fields);
             }
+
+            if (defaultConstructor != null) {
+                TypeUtils.setAccessible(defaultConstructor);
+            }
+
             return new JavaBeanInfo(clazz, builderClass, defaultConstructor, null, factoryMethod, buildMethod, jsonType, fieldList);
         }
 

--- a/src/test/java/com/alibaba/json/bvt/FieldBasedTest.java
+++ b/src/test/java/com/alibaba/json/bvt/FieldBasedTest.java
@@ -1,0 +1,37 @@
+package com.alibaba.json.bvt;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.parser.ParserConfig;
+import com.alibaba.fastjson.serializer.SerializeConfig;
+import junit.framework.TestCase;
+
+/**
+ * @author TimAndy
+ */
+public class FieldBasedTest extends TestCase {
+    public void test_filed_based_parse() {
+        Student student = new Student("123", "你好世界", 60);
+        String json = JSON.toJSONString(student, new SerializeConfig(true));
+        Student result = JSON.parseObject(json, Student.class, new ParserConfig(true));
+
+        assertNotNull(result);
+        assertEquals("123", result.id);
+        assertEquals("你好世界", result.name);
+        assertEquals(60, result.score);
+    }
+
+    static final class Student {
+        private String id;
+        private String name;
+        private int score;
+
+        Student() {
+        }
+
+        Student(String id, String name, int score) {
+            this.id = id;
+            this.name = name;
+            this.score = score;
+        }
+    }
+}


### PR DESCRIPTION
如果 ParserConfig 启用了 fieldBased 参数, 反序列化报错,无法访问默认构造函数.