### PR TITLE
set ci environment clearly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - openjdk8


### PR DESCRIPTION
oracle jdk8 默认不再预装在 Xenial. 并且无法从 oracle 获取.

当被分配到 xenial 构建时会导致失败, 所以明确指定构建环境.

https://github.com/travis-ci/travis-ci/issues/10290