### PR TITLE
Fix issue2602 (SerializeWriter类的writeHex方法中chars数组越界)

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
@@ -627,7 +627,7 @@ public final class SerializeWriter extends Writer {
         int newcount = count + bytes.length * 2 + 3;
         if (newcount > buf.length) {
             if (writer != null) {
-                char[] chars = new char[bytes.length + 3];
+                char[] chars = new char[bytes.length * 2 + 3];
                 int pos = 0;
                 chars[pos++] = 'x';
                 chars[pos++] = '\'';


### PR DESCRIPTION
fixed the array out of bound exception mentioned in #2602 by enlarging the "chars" array to an appropriate size