### PR TITLE
fix issue 2300 [JSONObject的toJavaObject(Class<T> clazz)方法不支持日期格式的unixtime]

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -421,6 +421,9 @@ public class TypeUtils{
 
         if(value instanceof Number){
             longValue = ((Number) value).longValue();
+            if ("unixtime".equals(format)) {
+                longValue *= 1000;
+            }
             return new Date(longValue);
         }
 

--- a/src/test/java/com/alibaba/json/bvt/issue_2300/Issue2300.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2300/Issue2300.java
@@ -1,0 +1,36 @@
+package com.alibaba.json.bvt.issue_2300;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.annotation.JSONField;
+import junit.framework.TestCase;
+
+import java.util.Date;
+
+public class Issue2300 extends TestCase {
+    public void test_for_issue() throws Exception {
+        String text = "{\"createTime\":1548166745}";
+
+        Order o = JSON.parseObject(text, Order.class);
+        assertEquals(1548166745000L, o.createTime.getTime());
+
+        String json = JSON.toJSONString(o);
+        assertEquals("{\"createTime\":1548166745}", json);
+
+        //新增校验1
+        JSONObject jsonObject = JSONObject.parseObject(text);
+        Order order1 = JSONObject.toJavaObject(jsonObject, Order.class);
+        //校验不通过
+        assertEquals(1548166745000L, order1.createTime.getTime());
+
+        //新增校验2
+        Order order2 = jsonObject.toJavaObject(Order.class);
+        //校验不通过
+        assertEquals(1548166745000L, order2.createTime.getTime());
+    }
+
+    public static class Order {
+        @JSONField(format = "unixtime")
+        public Date createTime;
+    }
+}


### PR DESCRIPTION
fix issue #2300 [JSONObject的toJavaObject(Class<T> clazz)方法不支持日期格式的unixtime]

当format = unixtime时，new Date(longValue);中的longValue需要乘以 1000，进行毫秒的转换。

补充测试用例，已测试通过。