### PR TITLE
fix issue 2606 [TypeUtils.castToDate(Object value)高低版本不兼容问题]

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -453,6 +453,8 @@ public class TypeUtils{
                             && strVal.charAt(26) == ':'
                             && strVal.charAt(28) == '0') {
                         format = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+                    } else if (strVal.length() == 23 && strVal.charAt(19) == ',') {
+                        format = "yyyy-MM-dd HH:mm:ss,SSS";
                     } else {
                         format = "yyyy-MM-dd HH:mm:ss.SSS";
                     }

--- a/src/test/java/com/alibaba/json/bvt/issue_2600/Issue2606.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2600/Issue2606.java
@@ -1,19 +1,25 @@
 package com.alibaba.json.bvt.issue_2600;
 
 import com.alibaba.fastjson.JSON;
-import com.alibaba.fastjson.JSONObject;
-import com.alibaba.fastjson.JSONPath;
 import com.alibaba.fastjson.util.TypeUtils;
 import junit.framework.TestCase;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
-public class Issue2606 extends TestCase  {
+public class Issue2606 extends TestCase {
+    protected void setUp() throws Exception {
+        JSON.defaultTimeZone = TimeZone.getTimeZone("Asia/Shanghai");
+        JSON.defaultLocale = Locale.CHINA;
+    }
+
     public void test_for_issue() throws Exception {
         String str = "2019-07-03 19:34:22,547";
         Date d = TypeUtils.castToDate(str);
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
+        sdf.setTimeZone(TimeZone.getTimeZone("Asia/Shanghai"));
         assertEquals(str, sdf.format(d));
     }
 }

--- a/src/test/java/com/alibaba/json/bvt/issue_2600/Issue2606.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2600/Issue2606.java
@@ -1,0 +1,19 @@
+package com.alibaba.json.bvt.issue_2600;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.JSONPath;
+import com.alibaba.fastjson.util.TypeUtils;
+import junit.framework.TestCase;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class Issue2606 extends TestCase  {
+    public void test_for_issue() throws Exception {
+        String str = "2019-07-03 19:34:22,547";
+        Date d = TypeUtils.castToDate(str);
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
+        assertEquals(str, sdf.format(d));
+    }
+}


### PR DESCRIPTION
fix issue #2606 [TypeUtils.castToDate(Object value)高低版本不兼容问题]， add support for date format:yyyy-MM-dd HH:mm:ss,SSS.

本Issue解决有2个方案：
方案1： 如PR所示，增加逻辑判断，处理format:yyyy-MM-dd HH:mm:ss,SSS的场景；
方案2： JSONScanner Line 558增加判断如 
>  if (dot == '.'  || **_dot == ','_**)
此方案中的[,]属于特殊场景，而非标准时间的pattern。

因此建议使用第一种方案