### PR TITLE
fix issue #2606 [TypeUtils.castToDate(Object value)高低版本不兼容问题]， add support for date format:yyyy-MM-dd HH:mm:ss,SSS.

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -453,6 +453,8 @@ public class TypeUtils{
                             && strVal.charAt(26) == ':'
                             && strVal.charAt(28) == '0') {
                         format = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+                    } else if (strVal.length() == 23 && strVal.charAt(19) == ',') {
+                        format = "yyyy-MM-dd HH:mm:ss,SSS";
                     } else {
                         format = "yyyy-MM-dd HH:mm:ss.SSS";
                     }
@@ -1009,7 +1011,7 @@ public class TypeUtils{
         }
 
         if(clazz.isEnum()){
-            return (T) castToEnum(obj, clazz, config);
+            return castToEnum(obj, clazz, config);
         }
 
         if(Calendar.class.isAssignableFrom(clazz)){
@@ -1126,7 +1128,7 @@ public class TypeUtils{
             return null;
         }
         if(type instanceof Class){
-            return (T) cast(obj, (Class<T>) type, mapping);
+            return cast(obj, (Class<T>) type, mapping);
         }
         if(type instanceof ParameterizedType){
             return (T) cast(obj, (ParameterizedType) type, mapping);
@@ -1308,7 +1310,7 @@ public class TypeUtils{
                 ObjectDeserializer deserializer = config.getDeserializers().get(clazz);
                 if(deserializer != null){
                     String json = JSON.toJSONString(object);
-                    return (T) JSON.parseObject(json, clazz);
+                    return JSON.parseObject(json, clazz);
                 }
                 return (T) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
                         new Class<?>[]{clazz}, object);
@@ -2184,9 +2186,7 @@ public class TypeUtils{
             }
         }
         if(clazz.getSuperclass() != Object.class && clazz.getSuperclass() != null){
-            if(isJSONTypeIgnore(clazz.getSuperclass(), propertyName)){
-                return true;
-            }
+            return isJSONTypeIgnore(clazz.getSuperclass(), propertyName);
         }
         return false;
     }
@@ -2306,7 +2306,7 @@ public class TypeUtils{
         if(name.length() > 1 && Character.isUpperCase(name.charAt(1)) && Character.isUpperCase(name.charAt(0))){
             return name;
         }
-        char chars[] = name.toCharArray();
+        char[] chars = name.toCharArray();
         chars[0] = Character.toLowerCase(chars[0]);
         return new String(chars);
     }

--- a/src/test/java/com/alibaba/json/bvt/issue_2600/Issue2606.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2600/Issue2606.java
@@ -1,0 +1,26 @@
+package com.alibaba.json.bvt.issue_2600;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.util.TypeUtils;
+import junit.framework.TestCase;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class Issue2606 extends TestCase {
+    @Override
+    public void setUp() throws Exception {
+        JSON.defaultTimeZone = TimeZone.getDefault();
+        JSON.defaultLocale = Locale.CHINA;
+    }
+
+    public void test_for_issue() throws Exception {
+        String str = "2019-07-03 19:34:22,547";
+        Date d = TypeUtils.castToDate(str);
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
+        sdf.setTimeZone(TimeZone.getDefault());
+        assertEquals(str, sdf.format(d));
+    }
+}


### PR DESCRIPTION
fix issue #2606 [TypeUtils.castToDate(Object value)高低版本不兼容问题]， add support for date format:yyyy-MM-dd HH:mm:ss,SSS.

本Issue解决有2个方案：
方案1： 如PR所示，增加逻辑判断，处理format:yyyy-MM-dd HH:mm:ss,SSS的场景；
方案2： JSONScanner Line 558增加判断如 
>  if (dot == '.'  || **_dot == ','_**)
此方案中的[,]属于特殊场景，而非标准时间的pattern。

因此建议使用第一种方案