### PR TITLE
fixed issue2355（serialzeFeatures=SerializerFeature.WriteBigDecimalAsPlain不生效）

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/BigDecimalCodec.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/BigDecimalCodec.java
@@ -45,7 +45,8 @@ public class BigDecimalCodec implements ObjectSerializer, ObjectDeserializer {
             int scale = val.scale();
 
             String outText;
-            if (out.isEnabled(SerializerFeature.WriteBigDecimalAsPlain) && scale >= -100 && scale < 100) {
+            if (SerializerFeature.isEnabled(features, out.features, SerializerFeature.WriteBigDecimalAsPlain)
+                    && scale >= -100 && scale < 100) {
                 outText = val.toPlainString();
             } else {
                 outText = val.toString();

--- a/src/test/java/com/alibaba/json/bvt/issue_2300/Issue2355.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2300/Issue2355.java
@@ -1,0 +1,33 @@
+package com.alibaba.json.bvt.issue_2300;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import junit.framework.TestCase;
+
+import java.math.BigDecimal;
+
+public class Issue2355 extends TestCase {
+    public void test_for_issue() throws Exception {
+        VO vo = new VO();
+        BigDecimal num = new BigDecimal("0.00000001");
+        vo.setNum(num);
+        String json = JSON.toJSONString(vo);
+
+        assertEquals("{\"num\":0.00000001}", json);
+    }
+
+    static class VO {
+
+        @JSONField(serialzeFeatures = {SerializerFeature.WriteBigDecimalAsPlain})
+        private BigDecimal num;
+
+        public BigDecimal getNum() {
+            return num;
+        }
+
+        public void setNum(BigDecimal num) {
+            this.num = num;
+        }
+    }
+}


### PR DESCRIPTION
fix issue #2355 [JSONField注解指定serialzeFeatures=SerializerFeature.WriteBigDecimalAsPlain不生效]。
`BigDecimalCodec`在处理BigDecimal格式的时候没有比较从注解中获取到的serialzeFeatures。
基于issue #2355 补充的测试用例已经通过。