### PR TITLE
Fix issue #2346（不支持javaBean为Builder模式的链式编程）

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
@@ -530,7 +530,7 @@ public class JavaBeanInfo {
                 withPrefix = builderAnno.withPrefix();
             }
 
-            if (withPrefix == null || withPrefix.length() == 0) {
+            if (withPrefix == null) {
                 withPrefix = "with";
             }
 
@@ -573,19 +573,23 @@ public class JavaBeanInfo {
                 if (methodName.startsWith("set") && methodName.length() > 3) {
                     properNameBuilder = new StringBuilder(methodName.substring(3));
                 } else {
-                    if (!methodName.startsWith(withPrefix)) {
-                        continue;
+                    if (withPrefix.length() == 0){
+                        properNameBuilder = new StringBuilder(methodName);
+                    } else {
+                        if (!methodName.startsWith(withPrefix)) {
+                            continue;
+                        }
+    
+                        if (methodName.length() <= withPrefix.length()) {
+                            continue;
+                        }
+    
+                        properNameBuilder = new StringBuilder(methodName.substring(withPrefix.length()));
                     }
-
-                    if (methodName.length() <= withPrefix.length()) {
-                        continue;
-                    }
-
-                    properNameBuilder = new StringBuilder(methodName.substring(withPrefix.length()));
                 }
 
                 char c0 = properNameBuilder.charAt(0);
-                if (!Character.isUpperCase(c0)) {
+                if (withPrefix.length() != 0 && !Character.isUpperCase(c0)) {
                     continue;
                 }
 

--- a/src/test/java/com/alibaba/json/bvt/issue_2300/Issue2346.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2300/Issue2346.java
@@ -27,4 +27,57 @@ public class Issue2346 extends TestCase {
 
         }
     }
+
+    @JSONType(builder = TestEntity2.TestEntity2Builder.class)
+    @Getter
+    public static class TestEntity2 {
+        private String name;
+
+        private int age;
+
+        @JSONPOJOBuilder(withPrefix = "www")
+        public static class TestEntity2Builder{
+            private TestEntity2 testEntity2 = new TestEntity2();
+
+            public TestEntity2 build(){
+                return testEntity2;
+            }
+
+            public TestEntity2Builder wwwAge(int age) {
+                testEntity2.age = age;
+                return this;
+            }
+
+            public TestEntity2Builder wwwName(String name) {
+                testEntity2.name = name;
+                return this;
+            }
+        }
+    }
+
+    @JSONType(builder = TestEntity3.TestEntity3Builder.class)
+    @Getter
+    public static class TestEntity3 {
+        private String name;
+
+        private int age;
+
+        public static class TestEntity3Builder{
+            private TestEntity3 testEntity3 = new TestEntity3();
+
+            public TestEntity3 build(){
+                return testEntity3;
+            }
+
+            public TestEntity3Builder withAge(int age) {
+                testEntity3.age = age;
+                return this;
+            }
+
+            public TestEntity3Builder withName(String name) {
+                testEntity3.name = name;
+                return this;
+            }
+        }
+    }
 }

--- a/src/test/java/com/alibaba/json/bvt/issue_2300/Issue2346.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2300/Issue2346.java
@@ -1,0 +1,30 @@
+package com.alibaba.json.bvt.issue_2300;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONPOJOBuilder;
+import com.alibaba.fastjson.annotation.JSONType;
+import junit.framework.TestCase;
+import lombok.Builder;
+import lombok.Getter;
+
+public class Issue2346 extends TestCase {
+    public void test_for_issue() throws Exception {
+        String jsonStr = "{\"age\":1,\"name\":\"aa\"}";
+        TestEntity testEntity = JSON.parseObject(jsonStr, TestEntity.class);
+        assertEquals(jsonStr, JSON.toJSONString(testEntity));
+    }
+
+    @Builder(builderClassName = "TestEntityBuilder")
+    @Getter
+    @JSONType(builder = TestEntity.TestEntityBuilder.class)
+    public static class TestEntity {
+        private String name;
+
+        private int age;
+
+        @JSONPOJOBuilder(withPrefix = "")
+        public static class TestEntityBuilder{
+
+        }
+    }
+}


### PR DESCRIPTION
fix issue #2346

解决这个问题有两个方法
1. lombok社区中广泛采用的通过使用lombok自带的`@NoArgsConstructor`注解叠加`@AllArgsConstructor`注解的解决方案
2. 参考Jackson中通过`@JsonDeserialize`和`JsonPOJOBuilder`注解来配合lombok的`@Builder`注解使用的解决方案，参考链接：https://www.thecuriousdev.org/lombok-builder-with-jackson/

在fastjson中lombok的`@Builder`也可以配合fastjson的`@JSONPOJOBuilder`和`@JSONType`注解来实现需要的效果。

具体使用步骤为：
1. 在`@Builder`修饰的类上添加`@JSONType(builder = 类名.{类名+Builder}.class)`注解
2. 在`@Builder`修饰的类内部声明一个名为`{类名+Builder}`的静态空白类，并以`@JSONPOJOBuilder(withPrefix = "")`加以注释。

```java
@Builder
@Getter
@Setter
@JSONType(builder = TestEntity.TestEntityBuilder.class)
public static class TestEntity {
	private String name;

	private int age;

	@JSONPOJOBuilder(withPrefix = "") //由于Builder类中生成的get方法名与属性名完全相同（没有"get"或"with"这样的前缀）
	public static class TestEntityBuilder {
	}
}

public void test_for_issue() throws Exception {
	String jsonStr = "{\"age\":1,\"name\":\"aa\"}";

	TestEntity testEntity = JSON.parseObject(jsonStr, TestEntity.class);
}
```
实现思路：
Lombok的`@Builder`注解的实现原理是在修饰类内部生成一个Builder类，并在其中添加与修饰类的属性一一对应的get方法（这些get方法函数名与对应的属性名完全相同，无前缀），在构造对象的时候可供构造方使用。
这里可以通过手动声明Builder类，并用`@JSONPOJOBuilder`加以注释，来供fastjson反序列化时使用。
由于Builder类中的get方法与原本属性名完全相同（没有前缀字符串），所以`withPrefix`需要配置为空。
而目前fastjson中当`withPrefix`前缀字符串为空时会默认转换成"with"前缀，因此对`JavaBeanInfo.java`中的逻辑做了小改动，使前缀字符串为空时能够保留空字符串。

**本质上这个pr中修改的内容只是添加了对withPrefix为空字符串的支持**