### PR TITLE
fixed issue #1903 （全接口对象@Transient失效）

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
@@ -253,7 +253,7 @@ public class JavaBeanSerializer extends SerializeFilterable implements ObjectSer
                 Class<?> fieldClass = fieldInfo.fieldClass;
 
                 if (skipTransient) {
-                    if (field != null) {
+                    if (fieldInfo != null) {
                         if (fieldInfo.fieldTransient) {
                             continue;
                         }
@@ -758,11 +758,20 @@ public class JavaBeanSerializer extends SerializeFilterable implements ObjectSer
 
     public Map<String, Object> getFieldValuesMap(Object object) throws Exception {
         Map<String, Object> map = new LinkedHashMap<String, Object>(sortedGetters.length);
-        
+        boolean skipTransient = true;
+        FieldInfo fieldInfo = null;
+
         for (FieldSerializer getter : sortedGetters) {
+            skipTransient = SerializerFeature.isEnabled(getter.features, SerializerFeature.SkipTransientField);
+            fieldInfo = getter.fieldInfo;
+
+            if (skipTransient && fieldInfo != null && fieldInfo.fieldTransient) {
+                continue;
+            }
+
             map.put(getter.fieldInfo.name, getter.getPropertyValue(object));
         }
-        
+
         return map;
     }
 

--- a/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
@@ -133,7 +133,7 @@ public class FieldInfo implements Comparable<FieldInfo> {
                     || TypeUtils.isTransient(method);
         } else {
             fieldAccess = false;
-            fieldTransient = false;
+            fieldTransient = TypeUtils.isTransient(method);
         }
         
         if (label != null && label.length() > 0) { 

--- a/src/test/java/com/alibaba/json/bvt/issue_1900/Issue1903.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1900/Issue1903.java
@@ -10,6 +10,9 @@ import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Assert;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.serializer.SerializerFeature;
 public class Issue1903 extends TestCase {
     public void test_issue() throws Exception {
         MapHandler mh = new MapHandler();
@@ -22,10 +25,13 @@ public class Issue1903 extends TestCase {
 
         System.out.println(JSON.toJSON(issues).toString()); //正确结果: {"age":20}
         System.out.println(JSON.toJSONString(issues));  //正确结果: {"age":20}
+        Assert.assertEquals("{\"age\":20}", JSON.toJSON(issues).toString());
+        Assert.assertEquals("{\"age\":20}", JSON.toJSONString(issues));
     }
 
     interface Issues1903{
         @Transient
+        @JSONField(serialzeFeatures = { SerializerFeature.SkipTransientField })
         public String getName();
         public void setName(String name);
 


### PR DESCRIPTION
修复 #1903 中方法使用@Transient注解不起作用的问题
原因是当对象没定义属性，只定义了Get方法时，Transient的注解情况只根据属性上的注解来计算，而没有考虑get方法上的注解。
1.`FieldInfo.java`136行，新增逻辑：在对象属性{没有正式定义，但存在Get方法}的场景下，fieldTransient可以通过Get方法注解来计算  
2.`JavaBeanSerializer.java`256行，判断是否为有`@Transient`注解时，直接查看fieldInfo中计算的值  
3.`JavaBeanSerializer.java`759~771行 增加针对方法的`@Transient`注解判断，给JSON.toJSON接口增加`Transient`处理