### PR TITLE
fix issue #1821 (当Base64字符串中的斜杠`/`被转义为`\/`后，解析为`byte[]`有问题)

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
@@ -124,7 +124,7 @@ public final class JSONScanner extends JSONLexerBase {
             return bytes;
         }
 
-        return IOUtils.decodeBase64(text, np + 1, sp);
+        return IOUtils.decodeBase64( stringVal() );
     }
 
     /**

--- a/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
@@ -124,7 +124,12 @@ public final class JSONScanner extends JSONLexerBase {
             return bytes;
         }
 
-        return IOUtils.decodeBase64( stringVal() );
+        if (!hasSpecial) {
+            return IOUtils.decodeBase64(text, np + 1, sp);
+        } else {
+            String escapedText = new String(sbuf, 0, sp);
+            return IOUtils.decodeBase64(escapedText);
+        }
     }
 
     /**

--- a/src/test/java/com/alibaba/json/bvt/issue_1800/Issue1821.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1800/Issue1821.java
@@ -8,17 +8,29 @@ import junit.framework.TestCase;
 public class Issue1821 extends TestCase {
     public void test_for_issue() throws Exception {
         String str = "{\"type\":800,\"data\":\"HuYgMIxwfqdtvOJNv6kK025g5fh3yFHI2kaByO7udKk6FOBC3PGRWkGfwV0\\/vWQW6roN5ftKDHFZ3PWl0715OYue0rZj\\/VwrNsMvIL4MqTUNBBUGFU9SgZu87ss7RqmyijH6\\/sM968cK1Dv5U7Rrw79idl\\/hW8SILLn1YXvUa60=\"}";
+        String expectStr = "{\"type\":800,\"data\":\"HuYgMIxwfqdtvOJNv6kK025g5fh3yFHI2kaByO7udKk6FOBC3PGRWkGfwV0/vWQW6roN5ftKDHFZ3PWl0715OYue0rZj/VwrNsMvIL4MqTUNBBUGFU9SgZu87ss7RqmyijH6/sM968cK1Dv5U7Rrw79idl/hW8SILLn1YXvUa60=\"}";
         Model m = JSON.parseObject(str, Model.class);
-        
+        assertEquals(expectStr, JSON.toJSONString(m));
+
+        str = "{\"type\":800,\"data\":\"Y29tLmFsaWJhYmEuZmFzdGpzb24=\"}";
+        m = JSON.parseObject(str, Model.class);
+        assertEquals(str, JSON.toJSONString(m));
+        assertEquals("com.alibaba.fastjson", new String(m.data));
+
+        expectStr = str;
+        str = "{\"type\":800,\"data\":\"\\u005929tLmFsaWJ\\u0068YmEuZmFzdGpzb24\\u003d\"}";
+        m = JSON.parseObject(str, Model.class);
+        assertEquals(expectStr, JSON.toJSONString(m));
+        assertEquals("com.alibaba.fastjson", new String(m.data));
 
     }
 
     @JSONType
     public static class Model {
-        @JSONField(name="type")
+        @JSONField(name="type", ordinal = 1)
         public int type;
 
-        @JSONField(name="data")
+        @JSONField(name="data", ordinal = 2)
         public byte[] data;
     }
 


### PR DESCRIPTION
fix #1821 and add testcase

```ObjectArrayCodec```进行反序列化时，对于```[]byte```类型，```bytesValue()```函数中在进行Base64解码之前应该使用转义处理过的字符串，而不是原始的JSON串中的子串。