### PR TITLE
fix issue2673(原始类和Builder类中都包含set方法时，使用@JSONType(builder=)注解会报错)

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
@@ -698,7 +698,7 @@ public class JavaBeanInfo {
                 }
             }
 
-            if (annotation == null && !methodName.startsWith("set")) { // TODO "set"的判断放在 JSONField 注解后面，意思是允许非 setter 方法标记 JSONField 注解？
+            if (annotation == null && !methodName.startsWith("set") || builderClass != null) { // TODO "set"的判断放在 JSONField 注解后面，意思是允许非 setter 方法标记 JSONField 注解？
                 continue;
             }
 

--- a/src/test/java/com/alibaba/json/bvt/builder/BuilderTest2.java
+++ b/src/test/java/com/alibaba/json/bvt/builder/BuilderTest2.java
@@ -21,7 +21,15 @@ public class BuilderTest2 extends TestCase {
     public static class VO {
         private int id;
         private String name;
-        
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
         public int getId() {
             return id;
         }


### PR DESCRIPTION
fix issue #2673 
当使用了builder类之后，应该使用builder类中的set方法、get方法以及它们对应的注解（而不是原始类的），所以在JavaBeanInfo的build方法逻辑中，当存在builder类时，应该跳过对原始类set方法、get方法处理的逻辑。