### PR TITLE
fix issue #2678(使用@JSONField注解指定属性序列化使用单引号后不生效)

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/FieldSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/FieldSerializer.java
@@ -129,7 +129,8 @@ public class FieldSerializer implements Comparable<FieldSerializer> {
         SerializeWriter out = serializer.out;
 
         if (out.quoteFieldNames) {
-            if (out.useSingleQuotes) {
+            boolean useSingleQuotes = SerializerFeature.isEnabled(out.features, fieldInfo.serialzeFeatures, SerializerFeature.UseSingleQuotes);
+            if (useSingleQuotes) {
                 if (single_quoted_fieldPrefix == null) {
                     single_quoted_fieldPrefix = '\'' + fieldInfo.name + "\':";
                 }

--- a/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
@@ -237,7 +237,6 @@ public class JavaBeanSerializer extends SerializeFilterable implements ObjectSer
             char seperator = commaFlag ? ',' : '\0';
 
             final boolean writeClassName = out.isEnabled(SerializerFeature.WriteClassName);
-            final boolean directWritePrefix = out.quoteFieldNames && !out.useSingleQuotes;
             char newSeperator = this.writeBefore(serializer, object, seperator);
             commaFlag = newSeperator == ',';
 
@@ -251,6 +250,9 @@ public class JavaBeanSerializer extends SerializeFilterable implements ObjectSer
                 FieldInfo fieldInfo = fieldSerializer.fieldInfo;
                 String fieldInfoName = fieldInfo.name;
                 Class<?> fieldClass = fieldInfo.fieldClass;
+
+                final boolean fieldUseSingleQuotes = SerializerFeature.isEnabled(out.features, fieldInfo.serialzeFeatures, SerializerFeature.UseSingleQuotes);
+                final boolean directWritePrefix = out.quoteFieldNames && !fieldUseSingleQuotes;
 
                 if (skipTransient) {
                     if (field != null) {
@@ -437,7 +439,7 @@ public class JavaBeanSerializer extends SerializeFilterable implements ObjectSer
                             } else {
                                 String propertyValueString = (String) propertyValue;
 
-                                if (out.useSingleQuotes) {
+                                if (fieldUseSingleQuotes) {
                                     out.writeStringWithSingleQuote(propertyValueString);
                                 } else {
                                     out.writeStringWithDoubleQuote(propertyValueString, (char) 0);

--- a/src/test/java/com/alibaba/json/bvt/issue_2600/Issue2678.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2600/Issue2678.java
@@ -1,0 +1,80 @@
+package com.alibaba.json.bvt.issue_2600;
+
+import com.alibaba.fastjson.JSON;
+import junit.framework.TestCase;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+
+public class Issue2678 extends TestCase {
+    public void test_field() throws Exception {
+        Person person = new Person();
+        person.setName("Ariston");
+        person.setAge(23);
+        String json = JSON.toJSONString(person);
+        assertEquals("{\"age\":23,'name':'Ariston'}", json);
+    }
+
+    public void test_getter() throws Exception {
+        Person2 person = new Person2();
+        person.setName("Ariston");
+        person.setAge(23);
+        String json = JSON.toJSONString(person);
+        assertEquals("{\"age\":23,'name':'Ariston'}", json);
+    }
+
+    static class Person {
+
+        @JSONField(serialzeFeatures = SerializerFeature.UseSingleQuotes)
+        private String name;
+
+        private int age;
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public void setName( String name )
+        {
+            this.name = name;
+        }
+
+        public int getAge()
+        {
+            return age;
+        }
+
+        public void setAge( int age )
+        {
+            this.age = age;
+        }
+    }
+
+    static class Person2 {
+
+        private String name;
+
+        private int age;
+
+        @JSONField(serialzeFeatures = SerializerFeature.UseSingleQuotes)
+        public String getName()
+        {
+            return name;
+        }
+
+        public void setName( String name )
+        {
+            this.name = name;
+        }
+
+        public int getAge()
+        {
+            return age;
+        }
+
+        public void setAge( int age )
+        {
+            this.age = age;
+        }
+    }
+}


### PR DESCRIPTION
fix issue #2678
原因是在`JavaBeanSerializer.java`的`write`方法和`FieldSerializer.java`的`writePrefix`方法中判断{*是否使用单引号*}时只与类上配置的注解有关，而与属性或方法上配置的注解（存储在fieldInfo中）无关。
所以在判断的时候把fieldInfo中配置的特性加进来一同判断即可。