### PR TITLE
修复在属性上使用@JSONField设置DateFormat无效的问题

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/JSONSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JSONSerializer.java
@@ -344,7 +344,7 @@ public class JSONSerializer extends SerializeFilterable {
                 return;
             }
             DateFormat dateFormat = this.getDateFormat();
-            if (dateFormat == null) {
+            if (format != null && !format.isEmpty()) {
                 try {
                     dateFormat = new SimpleDateFormat(format, locale);
                 } catch (IllegalArgumentException e) {

--- a/src/test/java/com/alibaba/json/bvt/issue_1800/Issue1868.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1800/Issue1868.java
@@ -1,0 +1,69 @@
+package com.alibaba.json.bvt.issue_1800;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.support.config.FastJsonConfig;
+import com.alibaba.fastjson.support.spring.FastJsonHttpMessageConverter;
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Date;
+
+
+public class Issue1868 extends TestCase {
+    public void test() throws Exception {
+        FastJsonConfig config = new FastJsonConfig();
+        config.setDateFormat("yyyy-MM-dd HH:mm:ss");
+
+        FastJsonHttpMessageConverter converter = new FastJsonHttpMessageConverter();
+        converter.setFastJsonConfig(config);
+
+        converter.canRead(VO.class, MediaType.APPLICATION_JSON_UTF8);
+        converter.canWrite(VO.class, MediaType.APPLICATION_JSON_UTF8);
+
+        final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+        HttpOutputMessage out = new HttpOutputMessage() {
+            public HttpHeaders getHeaders() {
+                return new HttpHeaders() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public MediaType getContentType() {
+                        return MediaType.APPLICATION_JSON;
+                    }
+                };
+            }
+
+          public OutputStream getBody() throws IOException {
+                return byteOut;
+          }
+        };
+
+        Date date = new Date();
+        VO vo = new VO();
+        vo.setDate(date);
+        converter.write(vo, VO.class, MediaType.APPLICATION_JSON_UTF8, out);
+
+        byte[] bytes = byteOut.toByteArray();
+        Assert.assertEquals(JSON.toJSONString(vo), new String(bytes, "UTF-8"));
+    }
+
+    public static class VO {
+        @JSONField(format = "yyyy-MM-dd")
+        private Date date;
+
+        public Date getDate() {
+            return date;
+        }
+
+        public void setDate(Date date) {
+            this.date = date;
+        }
+    }
+}


### PR DESCRIPTION
修复了多个issue中提到的JSONField设置DateFormat无效的问题 （#1868 #2029 #1968）
原因在于`JSONSerializer.java`的`writeWithFormat`方法中的逻辑判断：
```Java
            DateFormat dateFormat = this.getDateFormat();
            if (dateFormat == null) { //这个条件分支永远不会进入
                try {
                    dateFormat = new SimpleDateFormat(format, locale);  //本来应该执行的操作
                } catch (IllegalArgumentException e) {
                    String format2 = format.replaceAll("T", "'T'");
                    dateFormat = new SimpleDateFormat(format2, locale);
                }
                dateFormat.setTimeZone(timeZone);
```
由于`getDateFormat`的返回值永远不为null:
```Java
    public DateFormat getDateFormat() {
        if (dateFormat == null) {
            if (dateFormatPattern != null) {
                dateFormat = new SimpleDateFormat(dateFormatPattern, locale);
                dateFormat.setTimeZone(timeZone);
            }
        }

        return dateFormat;
    }
```
所以修改了判断条件，改为对函数入参`format`进行判断