### PR TITLE
Fix issue2689 （反序列化特殊字符串引发OOM异常）

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/JSONLexerBase.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONLexerBase.java
@@ -973,6 +973,10 @@ public abstract class JSONLexerBase implements JSONLexer, Closeable {
                         char x1 = ch = next();
                         char x2 = ch = next();
 
+                        if (!isHexChar(x1) || !isHexChar(x2)) {
+                            throw new JSONException("invalid escape character \\x" + x1 + x2);
+                        }
+
                         int x_val = digits[x1] * 16 + digits[x2];
                         char x_char = (char) x_val;
                         putChar(x_char);
@@ -5031,6 +5035,10 @@ public abstract class JSONLexerBase implements JSONLexer, Closeable {
 
         token = LITERAL_STRING;
         this.next();
+    }
+
+    private boolean isHexChar(char ch) {
+        return ((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F'));
     }
 
     /**

--- a/src/test/java/com/alibaba/json/bvt/issue_2600/Issue2689.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2600/Issue2689.java
@@ -1,0 +1,27 @@
+package com.alibaba.json.bvt.issue_2600;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONException;
+import junit.framework.TestCase;
+
+import java.net.URLDecoder;
+
+public class Issue2689 extends TestCase {
+    
+    final String DEATH_STRING = "{\"a\":\"\\x";
+
+    public void test_OOM() throws Exception {
+
+        String line = new String("[{\\x22a\\x22:\\x22a\\xB1ph.\\xCD\\x86\\xBEI\\xBA\\xC3\\xBCiM+\\xCE\\xCE\\x1E\\xDF7\\x1E\\xD9z\\xD9Q\\x8A}\\xD4\\xB2\\xD5\\xA0y\\x98\\x08@\\xE1!\\xA8\\xEF^\\x0D\\x7F\\xECX!\\xFF\\x06IP\\xEC\\x9F[\\x85;\\x02\\x817R\\x87\\xFB\\x1Ch\\xCB\\xC7\\xC6\\x06\\x8F\\xE2Z\\xDA^J\\xEB\\xBCF\\xA6\\xE6\\xF4\\xF7\\xC1\\xE3\\xA4T\\x89\\xC6\\xB2\\x5Cx]");
+        line = line.replaceAll("\\\\x", "%");
+        String decodeLog = URLDecoder.decode(line, "UTF-8");
+        System.out.println(decodeLog);
+        try {
+            Object obj = JSON.parse(decodeLog);
+            obj = JSON.parse(DEATH_STRING);
+        } catch (Exception e) {
+            assertEquals(e.getClass(), JSONException.class);
+            assertTrue(e.getMessage().contains("invalid escape character \\x"));
+        }
+    }
+}


### PR DESCRIPTION
fix issue #2689 
原因是fastjson在处理\x转义字符时，没有进行格式判断，正常情况下格式应该为\xHH，其中H为16进制字符（0到或a到f或A到F），如果输入字符串没有遵从这个格式，应该报错（参考Jackson的处理方式），但fastjson此前的处理逻辑是不管接下来两个字符是否为16进制字符，仍然继续往下读，如果此时达到了字符串的尾部，则不会触发反序列化结束条件，而是不断地读取EOF字符，不断地申请空间存储这些EOF，最终导致OOM。
因此，在读取\x特殊字符时，做一个参数校验即可，如果\x格式不正常，则正常地抛出JSONException。