### PR TITLE
修复 仅依靠字符串长度判断long边界值bug

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/JSONLexerBase.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONLexerBase.java
@@ -3830,15 +3830,8 @@ public abstract class JSONLexerBase implements JSONLexer, Closeable {
                 count = bp + offset - start - 1;
             }
 
-            if (count < 20 || (negative && count < 21)) {
-                value = BigInteger.valueOf(negative ? -intVal : intVal);
-            } else {
-
-//            char[] chars = this.sub_chars(negative ? start + 1 : start, count);
-//            value = new BigInteger(chars, )
                 String strVal = this.subString(start, count);
                 value = new BigInteger(strVal);
-            }
         } else if (chLocal == 'n' &&
                    charAt(bp + offset) == 'u' &&
                    charAt(bp + offset + 1) == 'l' &&

--- a/src/test/java/com/alibaba/json/bvt/bug/bug2019/Bug20190903_for_BigInteger.java
+++ b/src/test/java/com/alibaba/json/bvt/bug/bug2019/Bug20190903_for_BigInteger.java
@@ -1,0 +1,60 @@
+package com.alibaba.json.bvt.bug.bug2019;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import junit.framework.TestCase;
+import lombok.AllArgsConstructor;
+import org.junit.Assert;
+
+import java.math.BigInteger;
+
+public class Bug20190903_for_BigInteger extends TestCase
+{
+    public void test_for_issue() throws Exception {
+        System.out.println(Long.MAX_VALUE);
+            String rawStr = "-9223372036854775808";
+            StringTest a = new StringTest(rawStr);
+            String jsonStr = JSON.toJSONString(a);
+            IntegerTest b = JSONObject.parseObject(jsonStr,IntegerTest.class);
+            Assert.assertEquals(new BigInteger(a.getValue()), b.getValue());
+    }
+
+
+
+    public static class IntegerTest {
+        BigInteger value;
+
+        public BigInteger getValue() {
+            return value;
+        }
+
+        public void setValue(BigInteger value) {
+            this.value = value;
+        }
+
+        public IntegerTest() {
+        }
+    }
+
+
+
+    public class StringTest{
+        String value;
+
+        public StringTest(String value) {
+            this.value = value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public StringTest() {
+        }
+    }
+}
+


### PR DESCRIPTION
超过Long.MAX_VALUE数值的字符串会导致intVal溢出 。