### PR TITLE
修复使用@JSONField开启WriteNonStringKeyAsString/WriteNonStringValueAsString 特性无效的问题

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/ASMSerializerFactory.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/ASMSerializerFactory.java
@@ -1904,7 +1904,7 @@ public class ASMSerializerFactory implements Opcodes {
                            "(L" + JSONSerializer  + ";" //
                                                                           + desc(BeanContext.class) //
                                                                           + "Ljava/lang/Object;Ljava/lang/String;" //
-                                                                          + valueDesc + ")Ljava/lang/Object;");
+                                                                          + valueDesc + ")Ljava/lang/Object;Ljava/lang/Integer;");
 
         mw.visitVarInsn(ASTORE, Context.processValue);
 

--- a/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
@@ -316,7 +316,7 @@ public class JavaBeanSerializer extends SerializeFilterable implements ObjectSer
 
                 Object originalValue = propertyValue;
                 propertyValue = this.processValue(serializer, fieldSerializer.fieldContext, object, fieldInfoName,
-                                                        propertyValue);
+                                                        propertyValue, features);
 
                 if (propertyValue == null) {
                     int serialzeFeatures = fieldInfo.serialzeFeatures;

--- a/src/main/java/com/alibaba/fastjson/serializer/MapSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/MapSerializer.java
@@ -197,12 +197,12 @@ public class MapSerializer extends SerializeFilterable implements ObjectSerializ
 
                 {
                     if (entryKey == null || entryKey instanceof String) {
-                        value = this.processValue(serializer, null, object, (String) entryKey, value);
+                        value = this.processValue(serializer, null, object, (String) entryKey, value, features);
                     } else {
                         boolean objectOrArray = entryKey instanceof Map || entryKey instanceof Collection;
                         if (!objectOrArray) {
                             String strKey = JSON.toJSONString(entryKey);
-                            value = this.processValue(serializer, null, object, strKey, value);
+                            value = this.processValue(serializer, null, object, strKey, value, features);
                         }
                     }
                 }
@@ -229,7 +229,8 @@ public class MapSerializer extends SerializeFilterable implements ObjectSerializ
                         out.write(',');
                     }
 
-                    if (out.isEnabled(NON_STRINGKEY_AS_STRING) && !(entryKey instanceof Enum)) {
+                    if ((out.isEnabled(NON_STRINGKEY_AS_STRING) || SerializerFeature.isEnabled(features, SerializerFeature.WriteNonStringKeyAsString))
+                            && !(entryKey instanceof Enum)) {
                         String strEntryKey = JSON.toJSONString(entryKey);
                         serializer.write(strEntryKey);
                     } else {

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeFilterable.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeFilterable.java
@@ -198,10 +198,11 @@ public abstract class SerializeFilterable {
                                BeanContext beanContext,
                                Object object, //
                                String key, //
-                               Object propertyValue) {
+                               Object propertyValue, //
+                               int features) {
 
         if (propertyValue != null) {
-            if ((jsonBeanDeser.out.writeNonStringValueAsString //
+            if ((SerializerFeature.isEnabled(jsonBeanDeser.out.features, features, SerializerFeature.WriteNonStringValueAsString)  //
                     || (beanContext != null && (beanContext.getFeatures() & SerializerFeature.WriteNonStringValueAsString.mask) != 0))
                     && (propertyValue instanceof Number || propertyValue instanceof Boolean)) {
                 String format = null;

--- a/src/test/java/com/alibaba/json/bvt/serializer/JSONFieldTest6.java
+++ b/src/test/java/com/alibaba/json/bvt/serializer/JSONFieldTest6.java
@@ -1,0 +1,121 @@
+package com.alibaba.json.bvt.serializer;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+
+import java.util.HashMap;
+import java.util.Map;
+import junit.framework.TestCase;
+
+public class JSONFieldTest6 extends TestCase {
+
+    public void test_for_issue1()
+    {
+        NonStringMap nonStringMap = new NonStringMap();
+        Map<Integer, Integer> map1 = new HashMap();
+        map1.put( 111,666 );
+        nonStringMap.setMap1( map1 );
+        String json = JSON.toJSONString( nonStringMap );
+        assertEquals( "{\"map1\":{\"111\":666}}", json );
+    }
+
+    public void test_for_issue2()
+    {
+        NonStringMap nonStringMap = new NonStringMap();
+        Map<Integer, Integer> map2 = new HashMap();
+        map2.put( 222,888 );
+        nonStringMap.setMap2( map2 );
+        String json = JSON.toJSONString( nonStringMap );
+        assertEquals( "{\"map2\":{222:\"888\"}}", json );
+    }
+
+    public void test_for_issue3()
+    {
+        NonStringMap nonStringMap = new NonStringMap();
+        Map<Integer, Integer> map3 = new HashMap();
+        map3.put( 333,999 );
+        nonStringMap.setMap3( map3 );
+        String json = JSON.toJSONString( nonStringMap );
+        assertEquals( "{\"map3\":{\"333\":\"999\"}}", json );
+    }
+
+    public void test_for_issue4()
+    {
+        NonStringMap nonStringMap = new NonStringMap();
+        Bean person = new Bean();
+        person.setAge( 23 );
+        nonStringMap.setPerson( person );
+        String json = JSON.toJSONString( nonStringMap );
+        assertEquals( "{\"person\":{\"age\":\"23\"}}", json );
+    }
+
+    class NonStringMap
+    {
+        @JSONField( serialzeFeatures = {SerializerFeature.WriteNonStringKeyAsString} )
+        private Map map1;
+
+        public Map getMap1()
+        {
+            return map1;
+        }
+
+        public void setMap1( Map map1 )
+        {
+            this.map1 = map1;
+        }
+
+        @JSONField( serialzeFeatures = {SerializerFeature.WriteNonStringValueAsString} )
+        private Map map2;
+
+        public Map getMap2()
+        {
+            return map2;
+        }
+
+        public void setMap2( Map map2 )
+        {
+            this.map2 = map2;
+        }
+
+        @JSONField( serialzeFeatures = {SerializerFeature.WriteNonStringKeyAsString, SerializerFeature.WriteNonStringValueAsString} )
+        private Map map3;
+
+        public Map getMap3()
+        {
+        return map3;
+        }
+
+        public void setMap3( Map map3 )
+        {
+            this.map3 = map3;
+        }
+
+        @JSONField( serialzeFeatures = {SerializerFeature.WriteNonStringValueAsString} )
+        private Bean person;
+
+        public Bean getPerson()
+        {
+            return person;
+        }
+
+        public void setPerson( Bean person )
+        {
+            this.person = person;
+        }
+    }
+
+    class Bean {
+        private int age;
+
+        public int getAge()
+        {
+            return age;
+        }
+
+        public void setAge( int age )
+        {
+            this.age = age;
+        }
+    }
+}


### PR DESCRIPTION
**WriteNonStringKeyAsString** 修复思路：目前来说，序列化过程中，key值为非String类型只会出现在Map中，因此在MapSerializer中对key进行判断是否需要进行WriteNonStringKeyAsString 处理的时候，将属性上注解中的值也进行判断。

**WriteNonStringValueAsString** 修复思路：如果配置了WriteNonStringValueAsString， SerializeFilterable中的processValue函数会对非String的value值进行处理，而当前对是否配置了WriteNonStringValueAsString 属性取的是全局的features，并没有取属性注解中配置的features。将属性中配置的features传入processValue函数，并增加对注解中属性的判断。