### PR TITLE
issue #1780 （支持org.json.JSONObject ）的两种解决方案

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -593,6 +593,13 @@
             <version>4.8.42</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20180130</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/src/main/java/com/alibaba/fastjson/serializer/JSONObjectCodec.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JSONObjectCodec.java
@@ -1,0 +1,30 @@
+package com.alibaba.fastjson.serializer;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+
+public class JSONObjectCodec implements ObjectSerializer {
+	public final static JSONObjectCodec instance = new JSONObjectCodec();
+
+	@Override
+	public void write(JSONSerializer serializer, Object object, Object fieldName, Type fieldType, int features)
+			throws IOException {
+		SerializeWriter out = serializer.out;
+		MapSerializer mapSerializer = MapSerializer.instance;
+
+		try {
+			Field mapField = object.getClass().getDeclaredField("map");
+			if (Modifier.isPrivate(mapField.getModifiers())) {
+				mapField.setAccessible(true);
+			}
+
+			Object map = mapField.get(object);
+			mapSerializer.write(serializer, map, fieldName, fieldType, features);
+
+		} catch (Exception e) {
+			out.writeNull();
+		}
+	}
+}

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
@@ -58,7 +58,8 @@ public class SerializeConfig {
     private static boolean                                springfoxError  = false;
     private static boolean                                guavaError      = false;
     private static boolean                                jsonnullError   = false;
-
+    private static boolean                                jsonobjectError = false;
+    
     private static boolean                                jodaError       = false;
 
     private boolean                                       asm             = !ASMUtils.IS_ANDROID;
@@ -695,6 +696,16 @@ public class SerializeConfig {
                         jsonnullError = true;
                     }
                 }
+                
+				if (!jsonobjectError && className.equals("org.json.JSONObject")) {
+					try {
+						put(Class.forName("org.json.JSONObject"), writer = JSONObjectCodec.instance);
+						return writer;
+					} catch (ClassNotFoundException e) {
+						// skip
+						jsonobjectError = true;
+					}
+				}
 
                 if ((!jodaError) && className.startsWith("org.joda.")) {
                     try {

--- a/src/test/java/com/alibaba/json/bvt/issue_1700/Issue1780_JSONObject.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1700/Issue1780_JSONObject.java
@@ -1,0 +1,15 @@
+package com.alibaba.json.bvt.issue_1700;
+
+import org.junit.Assert;
+import com.alibaba.fastjson.JSON;
+import junit.framework.TestCase;
+
+public class Issue1780_JSONObject extends TestCase {
+
+	public void test_for_issue() {
+		org.json.JSONObject req = new org.json.JSONObject();
+		req.put("id", 1111);
+		req.put("name", "name11");
+		Assert.assertEquals("{\"name\":\"name11\",\"id\":1111}", JSON.toJSONString(req));
+	}
+}

--- a/src/test/java/com/alibaba/json/bvt/issue_1700/Issue1780_Module.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1700/Issue1780_Module.java
@@ -1,0 +1,54 @@
+package com.alibaba.json.bvt.issue_1700;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+import org.junit.Assert;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.parser.ParserConfig;
+import com.alibaba.fastjson.parser.deserializer.ObjectDeserializer;
+import com.alibaba.fastjson.serializer.JSONSerializer;
+import com.alibaba.fastjson.serializer.ObjectSerializer;
+import com.alibaba.fastjson.serializer.SerializeConfig;
+import com.alibaba.fastjson.spi.Module;
+
+import junit.framework.TestCase;
+
+public class Issue1780_Module extends TestCase {
+
+	public void test_for_issue() {
+		org.json.JSONObject req = new org.json.JSONObject();
+
+		SerializeConfig config = new SerializeConfig();
+		config.register(new myModule());
+		req.put("id", 1111);
+		req.put("name", "name11");
+		Assert.assertEquals("{\"name\":\"name11\",\"id\":1111}", JSON.toJSONString(req, config));
+	}
+
+	public class myModule implements Module {
+
+		@SuppressWarnings("rawtypes")
+		@Override
+		public ObjectDeserializer createDeserializer(ParserConfig config, Class type) {
+			return null;
+		}
+
+		@SuppressWarnings("rawtypes")
+		@Override
+		public ObjectSerializer createSerializer(SerializeConfig config, Class type) {
+			return new ObjectSerializer() {
+
+				@Override
+				public void write(JSONSerializer serializer, Object object, Object fieldName, Type fieldType,
+						int features) throws IOException {
+					System.out.println("-------------myModule.createSerializer-------------------");
+					org.json.JSONObject req = (org.json.JSONObject) object;
+					serializer.out.write(req.toString());
+				}
+			};
+		}
+
+	}
+}


### PR DESCRIPTION
关于issue #1780，感觉有两个思路

1.  fastjson内部支持org.json.JSONObject序列化，添加相应的Codec，涉及的文件有：  
`pom.xml`  
`src/main/java/com/alibaba/fastjson/serializer/JSONObjectCodec.java`  
`src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java`  
测试用例是：  
`src/test/java/com/alibaba/json/bvt/issue_1700/Issue1780_JSONObject.java`

2.   使用现有的`Module`功能来自定义解析器，而不是框架去兼容，只要修改：  
`pom.xml`添加 org.json.JSONObject支持   
使用示例是：    
`src/test/java/com/alibaba/json/bvt/issue_1700/Issue1780_Module.java`  

个人建议这种特殊场景让用户自定义就好了，采用方案二  0-0
@wenshao PTAL