### PR TITLE
完善issue#978中对java.sql.Date的支持

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/FieldSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/FieldSerializer.java
@@ -27,7 +27,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
-import java.util.Date;
 
 /**
  * @author wenshao[szujobs@hotmail.com]
@@ -157,7 +156,7 @@ public class FieldSerializer implements Comparable<FieldSerializer> {
     public Object getPropertyValue(Object object) throws InvocationTargetException, IllegalAccessException {
         Object propertyValue =  fieldInfo.get(object);
         if (format != null && propertyValue != null) {
-            if (fieldInfo.fieldClass == Date.class) {
+            if (fieldInfo.fieldClass == java.util.Date.class || fieldInfo.fieldClass == java.sql.Date.class) {
                 SimpleDateFormat dateFormat = new SimpleDateFormat(format, JSON.defaultLocale);
                 dateFormat.setTimeZone(JSON.defaultTimeZone);
                 return dateFormat.format(propertyValue);

--- a/src/test/java/com/alibaba/json/bvt/bug/Issue978.java
+++ b/src/test/java/com/alibaba/json/bvt/bug/Issue978.java
@@ -20,7 +20,15 @@ public class Issue978 extends TestCase {
 
     public void test_for_issue() throws Exception {
         Model model = new Model();
-        model.date = new Date(1483413683714L);
+        model.date = new java.util.Date(1483413683714L);
+
+        JSONObject obj = (JSONObject) JSON.toJSON(model);
+        assertEquals("{\"date\":\"2017-01-03 11:21:23\"}", obj.toJSONString());
+    }
+
+    public void test_for_issue2() throws Exception {
+        Model model = new Model();
+        model.date = new java.sql.Date(1483413683714L);
 
         JSONObject obj = (JSONObject) JSON.toJSON(model);
         assertEquals("{\"date\":\"2017-01-03 11:21:23\"}", obj.toJSONString());


### PR DESCRIPTION
在`FieldSerializer.java`的`getPropertyValue()`方法中判断Date类型时新增了对java.sql.Date的判断