### PR TITLE
完善DateFormat配置优先级

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -35,7 +35,6 @@ import com.alibaba.fastjson.parser.deserializer.FieldTypeResolver;
 import com.alibaba.fastjson.parser.deserializer.ParseProcess;
 import com.alibaba.fastjson.serializer.*;
 import com.alibaba.fastjson.util.IOUtils;
-import com.alibaba.fastjson.util.IdentityHashMap;
 import com.alibaba.fastjson.util.TypeUtils;
 
 /**
@@ -829,6 +828,42 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         }
     }
 
+    /**
+     * Use the date format in FastJsonConfig to serialize JSON
+     *
+     * @param  dateFormat the date format in FastJsonConfigs
+     * @since 1.2.55
+     */
+    public static byte[] toJSONBytesWithFastJsonConfig(Charset charset, //
+                                     Object object, //
+                                     SerializeConfig config, //
+                                     SerializeFilter[] filters, //
+                                     String dateFormat, //
+                                     int defaultFeatures, //
+                                     SerializerFeature... features) {
+        SerializeWriter out = new SerializeWriter(null, defaultFeatures, features);
+
+        try {
+            JSONSerializer serializer = new JSONSerializer(out, config);
+
+            if (dateFormat != null && dateFormat.length() != 0) {
+                serializer.setFastJsonConfigDateFormatPattern(dateFormat);
+                serializer.config(SerializerFeature.WriteDateUseDateFormat, true);
+            }
+
+            if (filters != null) {
+                for (SerializeFilter filter : filters) {
+                    serializer.addFilter(filter);
+                }
+            }
+
+            serializer.write(object);
+            return out.toBytes(charset);
+        } finally {
+            out.close();
+        }
+    }
+
     public static String toJSONString(Object object, boolean prettyFormat) {
         if (!prettyFormat) {
             return toJSONString(object);
@@ -941,6 +976,39 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             
             serializer.write(object);
             
+            int len = writer.writeToEx(os, charset);
+            return len;
+        } finally {
+            writer.close();
+        }
+    }
+
+    public static final int writeJSONStringWithFastJsonConfig(OutputStream os, //
+                                            Charset charset, //
+                                            Object object, //
+                                            SerializeConfig config, //
+                                            SerializeFilter[] filters, //
+                                            String dateFormat, //
+                                            int defaultFeatures, //
+                                            SerializerFeature... features) throws IOException {
+        SerializeWriter writer = new SerializeWriter(null, defaultFeatures, features);
+
+        try {
+            JSONSerializer serializer = new JSONSerializer(writer, config);
+
+            if (dateFormat != null && dateFormat.length() != 0) {
+                serializer.setFastJsonConfigDateFormatPattern(dateFormat);
+                serializer.config(SerializerFeature.WriteDateUseDateFormat, true);
+            }
+
+            if (filters != null) {
+                for (SerializeFilter filter : filters) {
+                    serializer.addFilter(filter);
+                }
+            }
+
+            serializer.write(object);
+
             int len = writer.writeToEx(os, charset);
             return len;
         } finally {

--- a/src/main/java/com/alibaba/fastjson/serializer/DateCodec.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/DateCodec.java
@@ -79,7 +79,13 @@ public class DateCodec extends AbstractDateDeserializer implements ObjectSeriali
         if (out.isEnabled(SerializerFeature.WriteDateUseDateFormat)) {
             DateFormat format = serializer.getDateFormat();
             if (format == null) {
-                format = new SimpleDateFormat(JSON.DEFFAULT_DATE_FORMAT, serializer.locale);
+                // 如果是通过FastJsonConfig进行设置，优先从FastJsonConfig获取
+                String dateFormatPattern = serializer.getFastJsonConfigDateFormatPattern();
+                if(dateFormatPattern == null) {
+                    dateFormatPattern = JSON.DEFFAULT_DATE_FORMAT;
+                }
+
+                format = new SimpleDateFormat(dateFormatPattern, serializer.locale);
                 format.setTimeZone(serializer.timeZone);
             }
             String text = format.format(date);

--- a/src/main/java/com/alibaba/fastjson/serializer/JSONSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JSONSerializer.java
@@ -39,8 +39,16 @@ public class JSONSerializer extends SerializeFilterable {
     private int                                      indentCount = 0;
     private String                                   indent      = "\t";
 
+    /**
+     * #1868 为了区分全局配置（FastJsonConfig）的日期格式配置以及toJSONString传入的日期格式配置
+     * 建议使用以下调整：
+     * 1. dateFormatPattern、dateFormat只作为toJSONString传入配置使用；
+     * 2. 新增fastJsonConfigDateFormatPattern，用于存储通过（FastJsonConfig）配置的日期格式
+     */
     private String                                   dateFormatPattern;
     private DateFormat                               dateFormat;
+
+    private String                                   fastJsonConfigDateFormatPattern;
 
     protected IdentityHashMap<Object, SerialContext> references  = null;
     protected SerialContext                          context;
@@ -75,10 +83,16 @@ public class JSONSerializer extends SerializeFilterable {
     public DateFormat getDateFormat() {
         if (dateFormat == null) {
             if (dateFormatPattern != null) {
-                dateFormat = new SimpleDateFormat(dateFormatPattern, locale);
-                dateFormat.setTimeZone(timeZone);
+                dateFormat = this.generateDateFormat( dateFormatPattern );
             }
         }
+
+        return dateFormat;
+    }
+
+    private DateFormat generateDateFormat(String dateFormatPattern) {
+        DateFormat dateFormat = new SimpleDateFormat(dateFormatPattern, locale);
+        dateFormat.setTimeZone(timeZone);
 
         return dateFormat;
     }
@@ -95,6 +109,19 @@ public class JSONSerializer extends SerializeFilterable {
         if (this.dateFormat != null) {
             this.dateFormat = null;
         }
+    }
+
+    /**
+     * Set global date format pattern in FastJsonConfig
+     *
+     * @param dateFormatPattern global date format pattern
+     */
+    public void setFastJsonConfigDateFormatPattern(String dateFormatPattern) {
+        this.fastJsonConfigDateFormatPattern = dateFormatPattern;
+    }
+
+    public String getFastJsonConfigDateFormatPattern() {
+        return this.fastJsonConfigDateFormatPattern;
     }
 
     public SerialContext getContext() {
@@ -345,13 +372,18 @@ public class JSONSerializer extends SerializeFilterable {
             }
             DateFormat dateFormat = this.getDateFormat();
             if (dateFormat == null) {
-                try {
-                    dateFormat = new SimpleDateFormat(format, locale);
-                } catch (IllegalArgumentException e) {
-                    String format2 = format.replaceAll("T", "'T'");
-                    dateFormat = new SimpleDateFormat(format2, locale);
+                if (format != null) {
+                    try {
+                        dateFormat = this.generateDateFormat(format);
+                    } catch (IllegalArgumentException e) {
+                        String format2 = format.replaceAll("T", "'T'");
+                        dateFormat = this.generateDateFormat(format2);
+                    }
+                } else if (fastJsonConfigDateFormatPattern != null) {
+                    dateFormat = this.generateDateFormat(fastJsonConfigDateFormatPattern);
+                } else {
+                    dateFormat = this.generateDateFormat(JSON.DEFFAULT_DATE_FORMAT);
                 }
-                dateFormat.setTimeZone(timeZone);
             }
             String text = dateFormat.format((Date) object);
             out.writeString(text);

--- a/src/main/java/com/alibaba/fastjson/support/jaxrs/FastJsonProvider.java
+++ b/src/main/java/com/alibaba/fastjson/support/jaxrs/FastJsonProvider.java
@@ -361,7 +361,7 @@ public class FastJsonProvider //
         }
 
         try {
-            JSON.writeJSONString(entityStream, //
+            JSON.writeJSONStringWithFastJsonConfig(entityStream, //
                     fastJsonConfig.getCharset(), //
                     obj, //
                     fastJsonConfig.getSerializeConfig(), //

--- a/src/main/java/com/alibaba/fastjson/support/retrofit/Retrofit2ConverterFactory.java
+++ b/src/main/java/com/alibaba/fastjson/support/retrofit/Retrofit2ConverterFactory.java
@@ -240,7 +240,7 @@ public class Retrofit2ConverterFactory extends Converter.Factory {
 
         public RequestBody convert(T value) throws IOException {
             try {
-                byte[] content = JSON.toJSONBytes(fastJsonConfig.getCharset()
+                byte[] content = JSON.toJSONBytesWithFastJsonConfig(fastJsonConfig.getCharset()
                         , value
                         , fastJsonConfig.getSerializeConfig()
                         , fastJsonConfig.getSerializeFilters()

--- a/src/main/java/com/alibaba/fastjson/support/spring/FastJsonHttpMessageConverter.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/FastJsonHttpMessageConverter.java
@@ -309,7 +309,7 @@ public class FastJsonHttpMessageConverter extends AbstractHttpMessageConverter<O
             }
 
 
-            int len = JSON.writeJSONString(outnew, //
+            int len = JSON.writeJSONStringWithFastJsonConfig(outnew, //
                     fastJsonConfig.getCharset(), //
                     value, //
                     fastJsonConfig.getSerializeConfig(), //

--- a/src/main/java/com/alibaba/fastjson/support/spring/FastJsonJsonView.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/FastJsonJsonView.java
@@ -297,7 +297,7 @@ public class FastJsonJsonView extends AbstractView {
 
         ByteArrayOutputStream outnew = new ByteArrayOutputStream();
 
-        int len = JSON.writeJSONString(outnew, //
+        int len = JSON.writeJSONStringWithFastJsonConfig(outnew, //
                 fastJsonConfig.getCharset(), //
                 value, //
                 fastJsonConfig.getSerializeConfig(), //

--- a/src/main/java/com/alibaba/fastjson/support/spring/FastJsonRedisSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/FastJsonRedisSerializer.java
@@ -34,7 +34,7 @@ public class FastJsonRedisSerializer<T> implements RedisSerializer<T> {
             return new byte[0];
         }
         try {
-            return JSON.toJSONBytes(
+            return JSON.toJSONBytesWithFastJsonConfig(
                     fastJsonConfig.getCharset(),
                     t,
                     fastJsonConfig.getSerializeConfig(),

--- a/src/main/java/com/alibaba/fastjson/support/spring/messaging/MappingFastJsonMessageConverter.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/messaging/MappingFastJsonMessageConverter.java
@@ -84,7 +84,7 @@ public class MappingFastJsonMessageConverter extends AbstractMessageConverter {
             if (payload instanceof String && JSON.isValid((String) payload)) {
                 obj = ((String) payload).getBytes(fastJsonConfig.getCharset());
             } else {
-                obj = JSON.toJSONBytes(fastJsonConfig.getCharset(), payload, fastJsonConfig.getSerializeConfig(), fastJsonConfig.getSerializeFilters(),
+                obj = JSON.toJSONBytesWithFastJsonConfig(fastJsonConfig.getCharset(), payload, fastJsonConfig.getSerializeConfig(), fastJsonConfig.getSerializeFilters(),
                         fastJsonConfig.getDateFormat(), JSON.DEFAULT_GENERATE_FEATURE, fastJsonConfig.getSerializerFeatures());
             }
         } else {

--- a/src/test/java/com/alibaba/json/bvt/date/DateFormatPriorityTest.java
+++ b/src/test/java/com/alibaba/json/bvt/date/DateFormatPriorityTest.java
@@ -1,0 +1,181 @@
+package com.alibaba.json.bvt.date;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import com.alibaba.fastjson.support.config.FastJsonConfig;
+import com.alibaba.fastjson.support.spring.FastJsonHttpMessageConverter;
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Calendar;
+import java.util.Date;
+
+
+public class DateFormatPriorityTest extends TestCase {
+    Calendar calendar = Calendar.getInstance();
+
+    protected void setUp() {
+        calendar.set(1995, Calendar.OCTOBER, 26);
+    }
+
+    public void test_for_fastJsonConfig() throws IOException {
+        FastJsonConfig config = new FastJsonConfig();
+        config.setDateFormat("yyyy-MM.dd");
+
+        FastJsonHttpMessageConverter converter = new FastJsonHttpMessageConverter();
+        converter.setFastJsonConfig(config);
+
+        converter.canRead(VO.class, MediaType.APPLICATION_JSON_UTF8);
+        converter.canWrite(VO.class, MediaType.APPLICATION_JSON_UTF8);
+
+        final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+        HttpOutputMessage out = new HttpOutputMessage() {
+            public HttpHeaders getHeaders() {
+                return new HttpHeaders() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public MediaType getContentType() {
+                        return MediaType.APPLICATION_JSON;
+                    }
+                };
+            }
+
+            public OutputStream getBody() throws IOException {
+                return byteOut;
+            }
+        };
+
+        VO vo = new VO();
+        vo.setDate(calendar.getTime());
+        converter.write(vo, VO.class, MediaType.APPLICATION_JSON_UTF8, out);
+
+        byte[] bytes = byteOut.toByteArray();
+        String jsonString = new String(bytes, "UTF-8");
+
+        Assert.assertEquals("{\"date\":\"1995-10.26\"}", jsonString);
+    }
+
+    public void test_for_toJSONStringWithDateFormat() {
+        VO vo = new VO();
+        vo.setDate(calendar.getTime());
+
+        String jsonString = JSON.toJSONStringWithDateFormat(vo, "yyyy.MM.dd");
+
+        assertEquals("{\"date\":\"1995.10.26\"}", jsonString);
+    }
+
+    public void test_for_Annotation() {
+        VO2 vo2 = new VO2();
+        vo2.setDate(calendar.getTime());
+
+        String jsonString = JSON.toJSONString(vo2);
+
+        assertEquals("{\"date\":\"1995.10-26\"}", jsonString);
+    }
+
+    public void test_for_DEFFAULT_DATE_FORMAT() {
+        String defaultDateFormat = JSON.DEFFAULT_DATE_FORMAT;
+
+        JSON.DEFFAULT_DATE_FORMAT = "MM-dd";
+        VO vo = new VO();
+        vo.setDate(calendar.getTime());
+
+        String jsonString = JSON.toJSONString(vo, SerializerFeature.WriteDateUseDateFormat);
+        JSON.DEFFAULT_DATE_FORMAT = defaultDateFormat;
+
+        assertEquals("{\"date\":\"10-26\"}", jsonString);
+    }
+
+    //Annotation + FastJsonConfig （Annotation优先)
+    public void test_priority_01() throws Exception {
+        //FastJsonConfig
+        FastJsonConfig config = new FastJsonConfig();
+        config.setDateFormat("yyyy-MM.dd");
+        FastJsonHttpMessageConverter converter = new FastJsonHttpMessageConverter();
+        converter.setFastJsonConfig(config);
+        converter.canRead(VO.class, MediaType.APPLICATION_JSON_UTF8);
+        converter.canWrite(VO.class, MediaType.APPLICATION_JSON_UTF8);
+        final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+        HttpOutputMessage out = new HttpOutputMessage() {
+            public HttpHeaders getHeaders() {
+                return new HttpHeaders() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public MediaType getContentType() {
+                        return MediaType.APPLICATION_JSON;
+                    }
+                };
+            }
+            public OutputStream getBody() throws IOException {
+                return byteOut;
+            }
+        };
+
+        VO2 vo = new VO2();
+        vo.setDate(calendar.getTime());
+        converter.write(vo, VO.class, MediaType.APPLICATION_JSON_UTF8, out);
+
+        byte[] bytes = byteOut.toByteArray();
+        String jsonString = new String(bytes, "UTF-8");
+
+        assertEquals("{\"date\":\"1995.10-26\"}", jsonString);
+    }
+
+    //toJSONStringWithDateFormat + Annotation (toJSONStringWithDateFormat优先)
+    public void test_priority_02() throws Exception {
+        VO2 vo = new VO2();
+        vo.setDate(calendar.getTime());
+
+        String jsonString = JSON.toJSONStringWithDateFormat(vo, "yyyy.MM.dd");
+
+        assertEquals("{\"date\":\"1995.10.26\"}", jsonString);
+    }
+
+    //Annotation + DEFFAULT_DATE_FORMAT (Annotation优先)
+    public void test_priority_03() throws Exception {
+        String defaultDateFormat = JSON.DEFFAULT_DATE_FORMAT;
+
+        JSON.DEFFAULT_DATE_FORMAT = "MM-dd";
+        VO2 vo = new VO2();
+        vo.setDate(calendar.getTime());
+
+        String jsonString = JSON.toJSONString(vo, SerializerFeature.WriteDateUseDateFormat);
+        JSON.DEFFAULT_DATE_FORMAT = defaultDateFormat;
+
+        assertEquals("{\"date\":\"1995.10-26\"}", jsonString);
+    }
+
+    public static class VO {
+        private Date date;
+
+        public Date getDate() {
+            return date;
+        }
+
+        public void setDate(Date date) {
+            this.date = date;
+        }
+    }
+
+    public static class VO2 {
+        @JSONField(format = "yyyy.MM-dd")
+        private Date date;
+
+        public Date getDate() {
+            return date;
+        }
+
+        public void setDate(Date date) {
+            this.date = date;
+        }
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/serializer/JSONSerializerTest1.java
+++ b/src/test/java/com/alibaba/json/bvt/serializer/JSONSerializerTest1.java
@@ -1,10 +1,16 @@
 package com.alibaba.json.bvt.serializer;
 
+import com.alibaba.fastjson.JSON;
 import org.junit.Assert;
 import junit.framework.TestCase;
 
 import com.alibaba.fastjson.serializer.JSONSerializer;
 import com.alibaba.fastjson.serializer.SerializeWriter;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
 
 public class JSONSerializerTest1 extends TestCase {
     public void test_0 () throws Exception {
@@ -21,5 +27,44 @@ public class JSONSerializerTest1 extends TestCase {
         Assert.assertEquals(0, serializer.getPropertyFilters().size());
         
         serializer.writeWithFormat("123", null);
+    }
+
+    public void test_1() throws Exception {
+        SerializeWriter out = new SerializeWriter();
+        JSONSerializer serializer = new JSONSerializer(out);
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.clear();
+        calendar.set(2019, Calendar.SEPTEMBER, 5);
+        Date date = calendar.getTime();
+
+        String dateFormatPattern = "yyyy/MM/dd";
+        SimpleDateFormat sdf = new SimpleDateFormat(dateFormatPattern);
+
+        serializer.writeWithFormat(date, dateFormatPattern);
+
+        assertEquals("\"" + sdf.format(date) + "\"", serializer.out.toString());
+    }
+
+    public void test_2() throws Exception {
+        SerializeWriter out = new SerializeWriter();
+        JSONSerializer serializer = new JSONSerializer(out);
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.clear();
+        calendar.set(2019, Calendar.SEPTEMBER, 5);
+        Date date = calendar.getTime();
+
+        String dateFormatPattern = "yyyy.MM.dd";
+        String temp = JSON.DEFFAULT_DATE_FORMAT;
+        JSON.DEFFAULT_DATE_FORMAT = dateFormatPattern;
+
+        SimpleDateFormat sdf = new SimpleDateFormat(JSON.DEFFAULT_DATE_FORMAT);
+        //传入null时调用JSON.DEFFAULT_DATE_FORMAT
+        serializer.writeWithFormat(date, null);
+
+        JSON.DEFFAULT_DATE_FORMAT = temp;
+
+        assertEquals("\"" + sdf.format(date) + "\"", serializer.out.toString());
     }
 }


### PR DESCRIPTION
fix issue #1868 #1968 #2029 #2452
正常的配置优先级应该是从小到大的，目前fastjson支持四种方式配置dateFormat，按照优先级从高到低分别为：
1. 通过JSON.toJSONStringWithDateFormat()函数传参
2. 通过在属性上添加@JSONField(format="yyyy-MM-dd")注解
3. 通过xml配置<property name="dateFormat" value="yyyy-MM-dd" />或FastJsonConfig.setDateFormat()函数传参
4. 通过修改JSON.DEFFAULT_DATE_FORMAT变量值

但是目前通过1和3方式配置的dateFormat存储到同一个变量里的，导致提升方式2的优先级时会同时覆盖1和3的优先级。所以用了不同的变量`fastJsonConfigDateFormatPattern`来存储方式3配置的dateFormat，并把与FastJsonConfig相关的setDateFormat方法统一到了这个变量上。

另外为了避免冲突， 场景3中使用FastJsonConfig设置的dateFormat的一些方法进行了调整，并已全部通过测试。