### PR TITLE
fix issue2447, JSON.toJSON方法序列化不支持@JSONField(unwrapped=true)

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
@@ -771,7 +771,17 @@ public class JavaBeanSerializer extends SerializeFilterable implements ObjectSer
                 continue;
             }
 
-            map.put(getter.fieldInfo.name, getter.getPropertyValue(object));
+            if (getter.fieldInfo.unwrapped) {
+                Object unwrappedValue = getter.getPropertyValue(object);
+                Object map1 = JSON.toJSON(unwrappedValue);
+                if (map1 instanceof Map) {
+                    map.putAll((Map) map1);
+                } else {
+                    map.put(getter.fieldInfo.name, getter.getPropertyValue(object));
+                }
+            } else {
+                map.put(getter.fieldInfo.name, getter.getPropertyValue(object));
+            }
         }
 
         return map;

--- a/src/test/java/com/alibaba/json/bvt/issue_2400/Issue2447.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2400/Issue2447.java
@@ -1,0 +1,59 @@
+package com.alibaba.json.bvt.issue_2400;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import junit.framework.TestCase;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class Issue2447 extends TestCase {
+
+    public void test_for_issue() {
+        VO vo = new VO();
+        vo.id = 123;
+        vo.location = new Location(127, 37);
+
+        Object obj = JSON.toJSON(vo);
+        String json = JSON.toJSONString(vo);
+        assertEquals("{\"latitude\":37,\"id\":123,\"longitude\":127}", obj.toString());
+    }
+
+    public void test_for_issue2() {
+        VO2 vo = new VO2();
+        vo.id = 123;
+        vo.properties.put("latitude", 37);
+        vo.properties.put("longitude", 127);
+
+        Object obj = JSON.toJSON(vo);
+        assertEquals("{\"latitude\":37,\"id\":123,\"longitude\":127}", obj.toString());
+    }
+
+    public static class VO {
+
+        public int id;
+
+        @JSONField(unwrapped = true)
+        public Location location;
+    }
+
+    public static class VO2 {
+        public int id;
+
+        @JSONField(unwrapped = true)
+        public Map<String, Object> properties = new LinkedHashMap<String, Object>();
+    }
+
+
+    public static class Location {
+        public int longitude;
+        public int latitude;
+
+        public Location() {}
+
+        public Location(int longitude, int latitude) {
+            this.longitude = longitude;
+            this.latitude = latitude;
+        }
+    }
+}


### PR DESCRIPTION
在`JavaBeanSerializer`类的`getFieldValuesMap()`方法中新增了对unwrapped注解配置情况的判断和采取的相应措施。
由于`JSONPath`类的`paths()`接口也使用了`getFieldValuesMap()`方法，所以unwrap属性也将会在`JSONPath`中生效。
由于`JSON.toJSON()`方法内由局部变量JSONObject处理键值对，而JSONObject内存储的键值对默认是无序的，因此`JSON.toJSON()`与`JSON.toJSONString`返回的结果中键值对的顺序不一致