### PR TITLE
fixed issue #2711, Deserializer unwrapped field NPE

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
@@ -847,7 +847,8 @@ public class JavaBeanDeserializer implements ObjectDeserializer {
                         }
                     }
                 } else {
-                    boolean match = parseField(parser, key, object, type, fieldValues, setFlags);
+                    boolean match = parseField(parser, key, object, type,
+                            fieldValues == null ? new HashMap<String, Object>(this.fieldDeserializers.length) : fieldValues, setFlags);
 
                     if (!match) {
                         if (lexer.token() == JSONToken.RBRACE) {

--- a/src/test/java/com/alibaba/fastjson/deserializer/issue2711/PageRequest.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issue2711/PageRequest.java
@@ -1,0 +1,34 @@
+package com.alibaba.fastjson.deserializer.issue2711;
+
+import com.alibaba.fastjson.annotation.JSONField;
+
+public class PageRequest<T> {
+    @JSONField(unwrapped = true)
+    T data;
+    int from = 0;
+    int size = 10;
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+
+    public int getFrom() {
+        return from;
+    }
+
+    public void setFrom(int from) {
+        this.from = from;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issue2711/TestIssue.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issue2711/TestIssue.java
@@ -1,0 +1,21 @@
+package com.alibaba.fastjson.deserializer.issue2711;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.TypeReference;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestIssue {
+    @Test
+    public void testDeserializeGenericsUnwrapped() {
+        PageRequest<User> req = new PageRequest<User>();
+        req.setData(new User(1L, "jack"));
+        req.setFrom(10);
+        req.setSize(20);
+        String s = JSON.toJSONString(req);
+        System.out.println(s);
+
+        PageRequest<User> newReq = JSON.parseObject(s, new TypeReference<PageRequest<User>>() {});
+        Assert.assertNotNull(newReq);
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issue2711/User.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issue2711/User.java
@@ -1,0 +1,35 @@
+package com.alibaba.fastjson.deserializer.issue2711;
+
+public class User {
+    Long id;
+    String name;
+
+    public User(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}


### PR DESCRIPTION
fixed issue #2711 , 反序列化含有@JSONField(unwrapped = true)的对象时，解析属性传入了一个null，而在处理的时候却把它当成了一个非空的map，从而会造成空指针。