### PR TITLE
Fix issue1816(添加对@JSONField(defaultValue = "默认值")的支持)

### DIFF
--- a/src/main/java/com/alibaba/fastjson/annotation/JSONField.java
+++ b/src/main/java/com/alibaba/fastjson/annotation/JSONField.java
@@ -79,4 +79,11 @@ public @interface JSONField {
      * @since 1.2.31
      */
     boolean unwrapped() default false;
+    
+	/**
+	 * Only support Object
+	 * 
+	 * @since 1.2.60
+	 */
+	String defaultValue() default "";
 }

--- a/src/main/java/com/alibaba/fastjson/annotation/JSONField.java
+++ b/src/main/java/com/alibaba/fastjson/annotation/JSONField.java
@@ -83,7 +83,7 @@ public @interface JSONField {
 	/**
 	 * Only support Object
 	 * 
-	 * @since 1.2.60
+	 * @since 1.2.61
 	 */
 	String defaultValue() default "";
 }

--- a/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
@@ -336,13 +336,13 @@ public class JavaBeanSerializer extends SerializeFilterable implements ObjectSer
                             propertyValue = false;
                         }
                     } else if (fieldClass == String.class) {
-                    	int defaultMask = SerializerFeature.WriteNullStringAsEmpty.mask;
+                        int defaultMask = SerializerFeature.WriteNullStringAsEmpty.mask;
                         final int mask = defaultMask | SerializerFeature.WriteMapNullValue.mask;
-						if ((!writeAsArray) && (serialzeFeatures & mask) == 0 && (out.features & mask) == 0) {
-							continue;
-						} else if ((serialzeFeatures & defaultMask) != 0 || (out.features & defaultMask) != 0) {
-							propertyValue = "";
-						}
+                        if ((!writeAsArray) && (serialzeFeatures & mask) == 0 && (out.features & mask) == 0) {
+                            continue;
+                        } else if ((serialzeFeatures & defaultMask) != 0 || (out.features & defaultMask) != 0) {
+                            propertyValue = "";
+                        }
                     } else if (Number.class.isAssignableFrom(fieldClass)) {
                         int defaultMask = SerializerFeature.WriteNullNumberAsZero.mask;
                         final int mask = defaultMask | SerializerFeature.WriteMapNullValue.mask;

--- a/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
@@ -320,11 +320,14 @@ public class JavaBeanSerializer extends SerializeFilterable implements ObjectSer
 
                 if (propertyValue == null) {
                     int serialzeFeatures = fieldInfo.serialzeFeatures;
+                    JSONField jsonField = fieldInfo.getAnnotation();
                     if (beanInfo.jsonType != null) {
                         serialzeFeatures |= SerializerFeature.of(beanInfo.jsonType.serialzeFeatures());
                     }
                     // beanInfo.jsonType
-                    if (fieldClass == Boolean.class) {
+                    if (jsonField != null && !"".equals(jsonField.defaultValue())) {
+                        propertyValue = jsonField.defaultValue();
+                    } else if (fieldClass == Boolean.class) {
                         int defaultMask = SerializerFeature.WriteNullBooleanAsFalse.mask;
                         final int mask = defaultMask | SerializerFeature.WriteMapNullValue.mask;
                         if ((!writeAsArray) && (serialzeFeatures & mask) == 0 && (out.features & mask) == 0) {
@@ -333,13 +336,13 @@ public class JavaBeanSerializer extends SerializeFilterable implements ObjectSer
                             propertyValue = false;
                         }
                     } else if (fieldClass == String.class) {
-                        int defaultMask = SerializerFeature.WriteNullStringAsEmpty.mask;
+                    	int defaultMask = SerializerFeature.WriteNullStringAsEmpty.mask;
                         final int mask = defaultMask | SerializerFeature.WriteMapNullValue.mask;
-                        if ((!writeAsArray) && (serialzeFeatures & mask) == 0 && (out.features & mask) == 0) {
-                            continue;
-                        } else if ((serialzeFeatures & defaultMask) != 0 || (out.features & defaultMask) != 0) {
-                            propertyValue = "";
-                        }
+						if ((!writeAsArray) && (serialzeFeatures & mask) == 0 && (out.features & mask) == 0) {
+							continue;
+						} else if ((serialzeFeatures & defaultMask) != 0 || (out.features & defaultMask) != 0) {
+							propertyValue = "";
+						}
                     } else if (Number.class.isAssignableFrom(fieldClass)) {
                         int defaultMask = SerializerFeature.WriteNullNumberAsZero.mask;
                         final int mask = defaultMask | SerializerFeature.WriteMapNullValue.mask;

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
@@ -236,6 +236,11 @@ public class SerializeConfig {
     			    asm = false;
     			    break;
                 }
+                
+				if (annotation.defaultValue() != null && !"".equals(annotation.defaultValue())) {
+					asm = false;
+					break;
+				}
     		}
 		}
 		

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
@@ -236,11 +236,10 @@ public class SerializeConfig {
     			    asm = false;
     			    break;
                 }
-                
-				if (annotation.defaultValue() != null && !"".equals(annotation.defaultValue())) {
-					asm = false;
-					break;
-				}
+                if (annotation.defaultValue() != null && !"".equals(annotation.defaultValue())) {
+                    asm = false;
+                    break;
+                }
     		}
 		}
 		

--- a/src/test/java/com/alibaba/json/bvt/JSONFieldDefaultValueTest.java
+++ b/src/test/java/com/alibaba/json/bvt/JSONFieldDefaultValueTest.java
@@ -1,0 +1,257 @@
+package com.alibaba.json.bvt;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import junit.framework.TestCase;
+
+public class JSONFieldDefaultValueTest extends TestCase {
+	public void test_default_value() throws Exception {
+		Model m = new Model();
+		String s = JSON.toJSONString(m);
+		System.out.println(s);
+		Model m2 = JSON.parseObject(s, Model.class);
+		assertEquals("string", m2.getString());
+		assertEquals(false, m2.getaBoolean());
+		assertEquals(true, m2.getaBoolean2().booleanValue());
+		assertEquals(0, m2.getAnInt());
+		assertEquals(888, m2.getInteger().intValue());
+		assertEquals(0, m2.getaShort());
+		assertEquals(88, m2.getaShort2().shortValue());
+		assertEquals('\u0000', m2.getaChar());
+		assertEquals('J', m2.getCharacter().charValue());
+		assertEquals(0, m2.getaByte());
+		assertEquals(8, m2.getaByte2().byteValue());
+		assertEquals(0, m2.getaLong());
+		assertEquals(8888, m2.getaLong2().longValue());
+		assertEquals("0.0", "" + m2.getaFloat());
+		assertEquals("8.8", "" + m2.getaFloat2());
+		assertEquals("0.0", "" + m2.getaDouble());
+		assertEquals("88.88", "" + m2.getaDouble2());
+	}
+
+	public void test_not_null() throws Exception {
+		Model m = new Model("test", true, 888, (short)88, 'J', (byte)8, 8888L, 8.8F, 88.88, false, 999, (short)99, 'C', (byte)9, 9999L, 9.9F, 99.99);
+		String s = JSON.toJSONString(m);
+		System.out.println(s);
+		Model m2 = JSON.parseObject(s, Model.class);
+		assertEquals("test", m2.getString());
+		assertEquals(true, m2.getaBoolean());
+		assertEquals(false, m2.getaBoolean2().booleanValue());
+		assertEquals(888, m2.getAnInt());
+		assertEquals(999, m2.getInteger().intValue());
+		assertEquals(88, m2.getaShort());
+		assertEquals(99, m2.getaShort2().shortValue());
+		assertEquals('J', m2.getaChar());
+		assertEquals('C', m2.getCharacter().charValue());
+		assertEquals(8, m2.getaByte());
+		assertEquals(9, m2.getaByte2().byteValue());
+		assertEquals(8888, m2.getaLong());
+		assertEquals(9999, m2.getaLong2().longValue());
+		assertEquals("8.8", "" + m2.getaFloat());
+		assertEquals("9.9", "" + m2.getaFloat2());
+		assertEquals("88.88", "" + m2.getaDouble());
+		assertEquals("99.99", "" + m2.getaDouble2());
+	}
+
+	public static class Model {
+		@JSONField(defaultValue = "string")
+		private String string;
+
+		@JSONField(defaultValue = "true") //shouldn't work
+		private boolean aBoolean;
+		@JSONField(defaultValue = "888") //shouldn't work
+		private int anInt;
+		@JSONField(defaultValue = "88") //shouldn't work
+		private short aShort;
+		@JSONField(defaultValue = "J") //shouldn't work
+		private char aChar;
+		@JSONField(defaultValue = "8") //shouldn't work
+		private byte aByte;
+		@JSONField(defaultValue = "8888") //shouldn't work
+		private long aLong;
+		@JSONField(defaultValue = "8.8") //shouldn't work
+		private float aFloat;
+		@JSONField(defaultValue = "88.88") //shouldn't work
+		private double aDouble;
+
+		@JSONField(defaultValue = "true")
+		private Boolean aBoolean2;
+		@JSONField(defaultValue = "888")
+		private Integer integer;
+		@JSONField(defaultValue = "88")
+		private Short aShort2;
+		@JSONField(defaultValue = "J")
+		private Character character;
+		@JSONField(defaultValue = "8")
+		private Byte aByte2;
+		@JSONField(defaultValue = "8888")
+		private Long aLong2;
+		@JSONField(defaultValue = "8.8")
+		private Float aFloat2;
+		@JSONField(defaultValue = "88.88")
+		private Double aDouble2;
+
+		public Model(String string, boolean aBoolean, int anInt, short aShort, char aChar,
+					 byte aByte, long aLong, float aFloat, double aDouble,
+					 Boolean aBoolean2, Integer integer, Short aShort2, Character character,
+					 Byte aByte2, Long aLong2, Float aFloat2, Double aDouble2) {
+			this.string = string;
+			this.aBoolean = aBoolean;
+			this.anInt = anInt;
+			this.aShort = aShort;
+			this.aChar = aChar;
+			this.aByte = aByte;
+			this.aLong = aLong;
+			this.aFloat = aFloat;
+			this.aDouble = aDouble;
+			this.aBoolean2 = aBoolean2;
+			this.integer = integer;
+			this.aShort2 = aShort2;
+			this.character = character;
+			this.aByte2 = aByte2;
+			this.aLong2 = aLong2;
+			this.aFloat2 = aFloat2;
+			this.aDouble2 = aDouble2;
+		}
+
+		public Model() {
+		}
+
+		public String getString() {
+			return string;
+		}
+
+		public void setString(String string) {
+			this.string = string;
+		}
+
+		public boolean getaBoolean() {
+			return aBoolean;
+		}
+
+		public void setaBoolean(boolean aBoolean) {
+			this.aBoolean = aBoolean;
+		}
+
+		public int getAnInt() {
+			return anInt;
+		}
+
+		public void setAnInt(int anInt) {
+			this.anInt = anInt;
+		}
+
+		public short getaShort() {
+			return aShort;
+		}
+
+		public void setaShort(short aShort) {
+			this.aShort = aShort;
+		}
+
+		public char getaChar() {
+			return aChar;
+		}
+
+		public void setaChar(char aChar) {
+			this.aChar = aChar;
+		}
+
+		public byte getaByte() {
+			return aByte;
+		}
+
+		public void setaByte(byte aByte) {
+			this.aByte = aByte;
+		}
+
+		public long getaLong() {
+			return aLong;
+		}
+
+		public void setaLong(long aLong) {
+			this.aLong = aLong;
+		}
+
+		public float getaFloat() {
+			return aFloat;
+		}
+
+		public void setaFloat(float aFloat) {
+			this.aFloat = aFloat;
+		}
+
+		public double getaDouble() {
+			return aDouble;
+		}
+
+		public void setaDouble(double aDouble) {
+			this.aDouble = aDouble;
+		}
+
+		public Boolean getaBoolean2() {
+			return aBoolean2;
+		}
+
+		public void setaBoolean2(Boolean aBoolean2) {
+			this.aBoolean2 = aBoolean2;
+		}
+
+		public Integer getInteger() {
+			return integer;
+		}
+
+		public void setInteger(Integer integer) {
+			this.integer = integer;
+		}
+
+		public Short getaShort2() {
+			return aShort2;
+		}
+
+		public void setaShort2(Short aShort2) {
+			this.aShort2 = aShort2;
+		}
+
+		public Character getCharacter() {
+			return character;
+		}
+
+		public void setCharacter(Character character) {
+			this.character = character;
+		}
+
+		public Byte getaByte2() {
+			return aByte2;
+		}
+
+		public void setaByte2(Byte aByte2) {
+			this.aByte2 = aByte2;
+		}
+
+		public Long getaLong2() {
+			return aLong2;
+		}
+
+		public void setaLong2(Long aLong2) {
+			this.aLong2 = aLong2;
+		}
+
+		public Float getaFloat2() {
+			return aFloat2;
+		}
+
+		public void setaFloat2(Float aFloat2) {
+			this.aFloat2 = aFloat2;
+		}
+
+		public Double getaDouble2() {
+			return aDouble2;
+		}
+
+		public void setaDouble2(Double aDouble2) {
+			this.aDouble2 = aDouble2;
+		}
+
+	}
+}


### PR DESCRIPTION
Fix issue #1816 
当被注解的属性值为**null**时，可以将该属性序列化为默认值。
注意事项:
1. 对基本数据类型无效（但对他们的包装类有效），因为基本数据类型不存在值为null的情况（jvm总会给它们赋一些初始值）
2. defaultValue只在序列化过程中生效（对反序列化无效）
3. 使用时需要考虑类型一致的问题，以避免出现无法反序列化的情况。（比如给Boolean类型指定了默认值"yes"，能够正常序列化，但会导致无法反序列化）

本地构建测试全部通过