### PR TITLE
Fix issue #2579 (合法jsonString调整属性先后顺序解析出错)

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
+++ b/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
@@ -340,19 +340,7 @@ public class DefaultJSONParser implements Closeable {
                             Object instance = null;
                             ObjectDeserializer deserializer = this.config.getDeserializer(clazz);
                             if (deserializer instanceof JavaBeanDeserializer) {
-                                JavaBeanDeserializer javaBeanDeserializer = (JavaBeanDeserializer) deserializer;
-                                instance = javaBeanDeserializer.createInstance(this, clazz);
-
-                                for (Object o : map.entrySet()) {
-                                    Map.Entry entry = (Map.Entry) o;
-                                    Object entryKey = entry.getKey();
-                                    if (entryKey instanceof String) {
-                                        FieldDeserializer fieldDeserializer = javaBeanDeserializer.getFieldDeserializer((String) entryKey);
-                                        if (fieldDeserializer != null) {
-                                            fieldDeserializer.setValue(instance, entry.getValue());
-                                        }
-                                    }
-                                }
+                            	instance = TypeUtils.cast(object, clazz, this.config);
                             }
 
                             if (instance == null) {
@@ -384,6 +372,7 @@ public class DefaultJSONParser implements Closeable {
 
                     if (object.size() > 0) {
                         Object newObj = TypeUtils.cast(object, clazz, this.config);
+                        this.setResolveStatus(NONE);
                         this.parseObject(newObj);
                         return newObj;
                     }

--- a/src/test/java/com/alibaba/json/bvt/issue_2500/Issue2579.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2500/Issue2579.java
@@ -1,0 +1,207 @@
+package com.alibaba.json.bvt.issue_2500;
+
+import java.awt.Point;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import org.junit.Assert;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.annotation.JSONType;
+import com.alibaba.fastjson.parser.Feature;
+
+import junit.framework.TestCase;
+
+public class Issue2579 extends TestCase {
+
+	// 场景：走ASM
+	public void test_for_issue1() throws Exception {
+		run_test("MyPoint1");
+	}
+
+	// 场景：不走ASM,通过JSONType（asm=false），关闭了ASM
+	public void test_for_issue2() throws Exception {
+		run_test("MyPoint2");
+	}
+
+	// 场景：随机顺序组合JSON字符串测试2000次
+	private void run_test(String className) {
+		String begin = "{";
+		String end = "}";
+		String jsonString;
+		for (int i = 1; i < 2000; i++) {
+			jsonString = getString(i, className);
+			jsonString = begin + jsonString + end;
+			try {
+				Object obj = JSON.parse(jsonString, Feature.SupportAutoType);
+				if ("MyPoint1".equals(className)) {
+					Assert.assertEquals(i, ((MyPoint1) obj).getBatchNumber());
+				} else {
+					Assert.assertEquals(i, ((MyPoint2) obj).getBatchNumber());
+				}
+			} catch (JSONException e) {
+				System.out.println(jsonString);
+				e.printStackTrace();
+				Assert.assertTrue(false);
+			}
+		}
+	}
+
+	private static String getString(int batchNumber, String className) {
+		List<String> list = new ArrayList<String>();
+		list.add("\"@type\":\"com.alibaba.json.bvt.issue_2500.Issue2579$" + className + "\"");
+		list.add("\"date\":1563867975335");
+		list.add("\"id\":\"0f075036-9e52-4821-800a-9c51761a7227b\"");
+		list.add("\"location\":{\"@type\":\"java.awt.Point\",\"x\":11,\"y\":1}");
+		list.add("\"point\":{\"@type\":\"java.awt.Point\",\"x\":9,\"y\":1}");
+		list.add(
+				"\"pointArr\":[{\"@type\":\"java.awt.Point\",\"x\":4,\"y\":6},{\"@type\":\"java.awt.Point\",\"x\":7,\"y\":8}]");
+		list.add("\"strArr\":[\"te-st\",\"tes-t2\"]");
+		list.add("\"x\":2.0D");
+		list.add("\"y\":3.0D");
+		list.add("\"batchNumber\":" + batchNumber);
+
+		Iterator<String> it = list.iterator();
+		StringBuffer buffer = new StringBuffer();
+		int len;
+		int index;
+		while (it.hasNext()) {
+			len = list.size();
+			index = getRandomIndex(len);
+			buffer.append(list.get(index));
+			buffer.append(",");
+			list.remove(index);
+		}
+		buffer.deleteCharAt(buffer.length() - 1);
+		return buffer.toString();
+	}
+
+	private static int getRandomIndex(int length) {
+		Random random = new Random();
+		return random.nextInt(length);
+	}
+
+	@SuppressWarnings("serial")
+	public static class MyPoint1 extends Point {
+		private UUID id;
+		private int batchNumber;
+		private Point point = new Point();
+		private String[] strArr = { "te-st", "tes-t2" };
+		private Date date = new Date();
+		private Point[] pointArr = { new Point(), new Point() };
+
+		public UUID getId() {
+			return id;
+		}
+
+		public void setId(UUID id) {
+			this.id = id;
+		}
+
+		public int getBatchNumber() {
+			return batchNumber;
+		}
+
+		public void setBatchNumber(int batchNumber) {
+			this.batchNumber = batchNumber;
+		}
+
+		public Point getPoint() {
+			return point;
+		}
+
+		public void setPoint(Point point) {
+			this.point = point;
+		}
+
+		public String[] getStrArr() {
+			return strArr;
+		}
+
+		public void setStrArr(String[] strArr) {
+			this.strArr = strArr;
+		}
+
+		public Date getDate() {
+			return date;
+		}
+
+		public void setDate(Date date) {
+			this.date = date;
+		}
+
+		public Point[] getPointArr() {
+			return pointArr;
+		}
+
+		public void setPointArr(Point[] pointArr) {
+			this.pointArr = pointArr;
+		}
+
+	}
+
+	@SuppressWarnings("serial")
+	@JSONType(asm = false)
+	public static class MyPoint2 extends Point {
+		private UUID id;
+		private int batchNumber;
+		private Point point = new Point();
+		private String[] strArr = { "te-st", "tes-t2" };
+		private Date date = new Date();
+		private Point[] pointArr = { new Point(), new Point() };
+
+		public UUID getId() {
+			return id;
+		}
+
+		public void setId(UUID id) {
+			this.id = id;
+		}
+
+		public int getBatchNumber() {
+			return batchNumber;
+		}
+
+		public void setBatchNumber(int batchNumber) {
+			this.batchNumber = batchNumber;
+		}
+
+		public Point getPoint() {
+			return point;
+		}
+
+		public void setPoint(Point point) {
+			this.point = point;
+		}
+
+		public String[] getStrArr() {
+			return strArr;
+		}
+
+		public void setStrArr(String[] strArr) {
+			this.strArr = strArr;
+		}
+
+		public Date getDate() {
+			return date;
+		}
+
+		public void setDate(Date date) {
+			this.date = date;
+		}
+
+		public Point[] getPointArr() {
+			return pointArr;
+		}
+
+		public void setPointArr(Point[] pointArr) {
+			this.pointArr = pointArr;
+		}
+
+	}
+}


### PR DESCRIPTION
Fix issue #2579 
经过测试用例发现有两种场景会导致报错
1.当@type在字符串最后时，会进入DefaultJSONParser.parseObject(final Map object, Object fieldName) line:342,循环通过fieldDeserializer.setValue来转换类型，但是调用这个方法一定要确保value类型和field是一致的，而在这里没有去这个处理，导致转换保持
解决方式：fieldDeserializer.setValue方式不合适，改用TypeUtils.cast方法最合适

2.当@type在字符串中部，会进入DefaultJSONParser.parseObject(final Map object, Object fieldName) line:373行左右的 `if(object.size >0)`分支，在转换完类型后，继续下面字段的解析，没有还原处理状态，导致进入`this.parseObject(newbj)`中，若获取到的是MiscCdec解析器，就会错误进入`MiscCdec.java line:246`行分支，导致解析逻辑混乱，最终报错。
解决方式：在DefaultJSONParser.parseObject(final Map object, Object fieldName) line:373行左右的 `if(object.size >0)`分支中，转换玩类型后吧处理状态还原