### PR TITLE
修复反序列化BigInteger类属性值不一致的问题

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/JSONLexerBase.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONLexerBase.java
@@ -3810,10 +3810,17 @@ public abstract class JSONLexerBase implements JSONLexer, Closeable {
         BigInteger value;
         if (chLocal >= '0' && chLocal <= '9') {
             long intVal = chLocal - '0';
+            boolean overflow = false;
+            long temp;
             for (;;) {
                 chLocal = charAt(bp + (offset++));
                 if (chLocal >= '0' && chLocal <= '9') {
-                    intVal = intVal * 10 + (chLocal - '0');
+                    temp = intVal * 10 + (chLocal - '0');
+                    if (temp < intVal) {
+                        overflow = true;
+                        break;
+                    }
+                    intVal = temp;
                     continue;
                 } else {
                     break;
@@ -3835,7 +3842,7 @@ public abstract class JSONLexerBase implements JSONLexer, Closeable {
                 count = bp + offset - start - 1;
             }
 
-            if (count < 20 || (negative && count < 21)) {
+            if (!overflow && (count < 20 || (negative && count < 21))) {
                 value = BigInteger.valueOf(negative ? -intVal : intVal);
             } else {
 

--- a/src/test/java/com/alibaba/json/bvt/issue_2600/Issue2628.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2600/Issue2628.java
@@ -1,0 +1,39 @@
+package com.alibaba.json.bvt.issue_2600;
+
+import com.alibaba.fastjson.JSON;
+import junit.framework.TestCase;
+
+import java.math.BigInteger;
+
+public class Issue2628 extends TestCase {
+    public void test_for_issue() throws Exception {
+        long MAX_LONG = Long.MAX_VALUE; //9223372036854775807
+        long MIN_LONG = Long.MIN_VALUE; //-9223372036854775808
+
+        String s1 = "9423372036854775807"; //-9423372036854775808
+        BigInteger bi1 = JSON.parseObject(s1, BigInteger.class); //没问题
+        assertEquals("9423372036854775807", bi1.toString());
+
+        BigInteger bi2 = new BigInteger(s1); //没问题
+        assertEquals("9423372036854775807", bi2.toString());
+
+        Tobject tobj1 = new Tobject();
+        tobj1.setBi(bi2); //没问题
+        assertEquals("9423372036854775807", tobj1.getBi().toString());;
+
+        String s2 = JSON.toJSONString(tobj1);
+        Tobject tobj2 = JSON.parseObject(s2, Tobject.class);  //有问题
+        assertEquals("9423372036854775807", tobj2.getBi().toString());
+    }
+
+    static class Tobject {
+        private BigInteger bi;
+
+        public BigInteger getBi() {
+            return bi;
+        }
+        public void setBi(BigInteger bi) {
+            this.bi = bi;
+        }
+    }
+}


### PR DESCRIPTION
fix issue #2628 
原因是在`JSONLexerBase`类的`scanFieldBigInteger()`方法中用于临时存储BigInteger值的变量为long类型，而在对这个变量的值做累加的时候，值可能会溢出（BigInteger能存储的值比long类型大得多）。
所以添加了一个boolean临时变量，用于指示是否存在溢出情况，如果溢出，则使用`substring()`的方法进行BigInteger对象的创建，无溢出则直接调用`BigInteger.valueOf()`方法进行对象创建，保证值的一致性。