### PR TITLE
Fix issue2703（对JSONObject调用boJavaObject方法返回null值）

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -1337,6 +1337,10 @@ public class TypeUtils{
                 return (T) map.toString();
             }
 
+            if (clazz == JSON.class && map instanceof JSONObject) {
+                return (T) map;
+            }
+
             if (clazz == LinkedHashMap.class && map instanceof JSONObject) {
                 JSONObject jsonObject = (JSONObject) map;
                 Map innerMap = jsonObject.getInnerMap();

--- a/src/test/java/com/alibaba/json/bvt/issue_2700/Issue2703.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2700/Issue2703.java
@@ -1,0 +1,19 @@
+package com.alibaba.json.bvt.issue_2700;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import junit.framework.TestCase;
+
+public class Issue2703 extends TestCase {
+    public void test_for_issue() {
+        Object a = JSON.toJavaObject(new JSONObject(), JSON.class);
+        assertTrue(a instanceof JSONObject);
+
+        Object b = new JSONObject().toJavaObject(JSON.class);
+        assertTrue(b instanceof JSONObject);
+
+        Object c = JSON.toJavaObject(new JSONArray(), JSON.class);
+        assertTrue(c instanceof JSONArray);
+    }
+}


### PR DESCRIPTION
fix issue #2703 
正常情况下当目标类为当前类的父类时，会直接进行类型转换并返回。但当目标类为JSON类，当前类为JSONObject类时会出现返回null的情况。
原因是`TypeUtils`类的`cast()`方法里在判断目标类是否为当前类的父类之前，会先对Map和Array类型进行处理，而JSONObject属于Map类，会先走Map类处理的逻辑，也就是`castToJavaBean()`方法。这个方法中针对String和LinkedHashMap类做了判断，针对JSON.class也作一次判断即可。