### PR TITLE
JSONArray 复杂List的构造方法

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONArray.java
+++ b/src/main/java/com/alibaba/fastjson/JSONArray.java
@@ -58,6 +58,20 @@ public class JSONArray extends JSON implements List<Object>, Cloneable, RandomAc
         this.list = list;
     }
 
+    public JSONArray(Collection<?> collection) {
+        if (collection == null){
+            this.list = new ArrayList<Object>();
+        } else {
+            this.list = new ArrayList<Object>(collection.size());
+            Iterator<?> iter = collection.iterator();
+
+            while (iter.hasNext()){
+                Object o = iter.next();
+                list.add(JSON.toJSON(o));
+            }
+        }
+    }
+
     public JSONArray(int initialCapacity){
         this.list = new ArrayList<Object>(initialCapacity);
     }

--- a/src/test/java/com/alibaba/json/bvt/JSONArrayTest.java
+++ b/src/test/java/com/alibaba/json/bvt/JSONArrayTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
@@ -191,6 +192,20 @@ public class JSONArrayTest extends TestCase {
         JSONArray array = JSON.parseArray("[{id:123, name:'aaa'}]");
         Assert.assertEquals(1, array.size());
         Assert.assertEquals(123, array.getObject(0, User.class).getId());
+    }
+
+    public void test_newConstructor(){
+        List<Map<String,Object>> list = new ArrayList<Map<String, Object>>();
+
+        for (int i = 0;i < 5;i++){
+            Map<String,Object> map = new HashMap<String, Object>();
+            map.put("name","Lucy_" + i);
+            map.put("age",18 + i);
+            list.add(map);
+        }
+
+        JSONArray jsonArray = new JSONArray(list);
+        System.out.println(jsonArray);
     }
 
     public static class User {


### PR DESCRIPTION
Hi，在使用fastjson前，我使用的是org.json第三方库，因为经常使用new JSONArray("传入复杂List对象")，所以在切换到fastjson时，我感觉在通过List构造JSONArray时不是很友好。

我有一个数据类型为List<Map<String,Object>>的容器，使用new JSONArray()构造成一个JSONArray对象时，由于JSONArray中传入List构造方法签名是List<Object>，则需要手动将List<Map<String,Object>>转为List<Object>才能直接new出一个JSONArray对象，我觉得太过繁琐了（包括使用JSON.toJSON(Object)强转类型也是），所以新增了一个JSONArray(Collection<?> collection)的构造方法。

我修改了：

1. com.alibaba.fastjson.JSONArray
2.com.alibaba.json.bvt.JSONArrayTest