### PR TITLE
Fix issue2428 (嵌套对象序列化成JSONObject时snake_case对内层对象不生效)

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -1092,7 +1092,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             try {
                 Map<String, Object> values = javaBeanSerializer.getFieldValuesMap(javaObject);
                 for (Map.Entry<String, Object> entry : values.entrySet()) {
-                    json.put(entry.getKey(), toJSON(entry.getValue()));
+                    json.put(entry.getKey(), toJSON(entry.getValue(), config));
                 }
             } catch (Exception e) {
                 throw new JSONException("toJSON error", e);

--- a/src/test/java/com/alibaba/json/bvt/issue_2400/Issue2428.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2400/Issue2428.java
@@ -1,0 +1,34 @@
+package com.alibaba.json.bvt.issue_2400;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.PropertyNamingStrategy;
+import com.alibaba.fastjson.serializer.SerializeConfig;
+import junit.framework.TestCase;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Data
+public class Issue2428 extends TestCase {
+    private String myName;
+    private NestedBean nestedBean;
+
+    @AllArgsConstructor
+    @Data
+    public static class NestedBean {
+        private String myId;
+    }
+
+    public void test_for_issue() {
+        Issue2428 demoBean = new Issue2428();
+        demoBean.setMyName("test name");
+        demoBean.setNestedBean(new NestedBean("test id"));
+        assertEquals("{\"nestedBean\":{\"myId\":\"test id\"},\"myName\":\"test name\"}", JSON.toJSON(demoBean).toString());
+
+        SerializeConfig serializeConfig = new SerializeConfig();
+        serializeConfig.propertyNamingStrategy = PropertyNamingStrategy.SnakeCase;
+
+        assertEquals("{\"my_name\":\"test name\",\"nested_bean\":{\"my_id\":\"test id\"}}", JSON.toJSON(demoBean, serializeConfig).toString());
+    }
+}


### PR DESCRIPTION
fix issue #2428 
原因是往JSONObject的内部Map里put键值对时，值会使用`JSON.toJSON()`方法创建，而此前该方法没有传入SerializeConfig，而是默认使用了全局的SerializeConfig，所以出现和用户设置不一致的情况。因此只要将包含了用户配置信息的SerializeConfig一同传入`JSON.toJSON()`方法即可。