### PR TITLE
Fix issue2464（byte[] 反序列化出错）

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
+++ b/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
@@ -848,8 +848,12 @@ public class DefaultJSONParser implements Closeable {
                     if (i == types.length - 1) {
                         if (type instanceof Class) {
                             Class<?> clazz = (Class<?>) type;
-                            isArray = clazz.isArray();
-                            componentType = clazz.getComponentType();
+                            //如果最后一个type是字节数组，且当前token为字符串类型，不应该当作可变长参数进行处理
+                            //而是作为一个整体的Base64字符串进行反序列化
+                            if (!((clazz == byte[].class || clazz == char[].class) && lexer.token() == LITERAL_STRING)) {
+                                isArray = clazz.isArray();
+                                componentType = clazz.getComponentType();
+                            }
                         }
                     }
 

--- a/src/test/java/com/alibaba/json/bvt/issue_2400/Issue2464.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2400/Issue2464.java
@@ -1,0 +1,36 @@
+package com.alibaba.json.bvt.issue_2400;
+
+import com.alibaba.fastjson.JSON;
+import junit.framework.TestCase;
+
+public class Issue2464 extends TestCase {
+    public void test1() throws Exception {
+        String json = "[\"Mjg4NDd8MXxjb20uY2Fpbmlhby5pc2ltdS5xLndvcmtmbG93LmNvbGxlY3Quc2NoZWR1bGUuaW1wbC5UYXNrU3RvcENvbGxlY3RDYWxsQmFja0hhbmRsZXJJbXBsfDB8\",1]";
+        Object result =  JSON.parseArray(json,new Class[]{byte[].class,Integer.class});
+        assertEquals(json, JSON.toJSONString(result));
+
+        result = JSON.parseArray(json,new Class[]{char[].class,Integer.class});
+        assertEquals(json, JSON.toJSONString(result));
+    }
+
+    public void test2() throws Exception {
+        String json = "[1,\"Mjg4NDd8MXxjb20uY2Fpbmlhby5pc2ltdS5xLndvcmtmbG93LmNvbGxlY3Quc2NoZWR1bGUuaW1wbC5UYXNrU3RvcENvbGxlY3RDYWxsQmFja0hhbmRsZXJJbXBsfDB8\"]";
+        Object result =  JSON.parseArray(json,new Class[]{Integer.class,byte[].class});
+        assertEquals(json, JSON.toJSONString(result));
+
+        result = JSON.parseArray(json,new Class[]{Integer.class, char[].class});
+        assertEquals(json, JSON.toJSONString(result));
+    }
+
+    public void test3() throws Exception {
+        String json = "[1,\"aaa\",\"bbb\",\"ccc\"]";
+        Object result = JSON.parseArray(json, new Class[]{Integer.class, String[].class});
+        assertEquals("[1,[\"aaa\",\"bbb\",\"ccc\"]]", JSON.toJSONString(result));
+    }
+
+    public void test4() throws Exception {
+        String json = "[1,97,98,99]";
+        Object result = JSON.parseArray(json, new Class[]{Integer.class, byte[].class});
+        assertEquals("[1,\"YWJj\"]", JSON.toJSONString(result));
+    }
+}


### PR DESCRIPTION
Fix issue #2464  
原因是`DefaultJsonParser.parseArray()`方法中判断Class数组最后一个元素时，若该元素也为数组，则会将它当成可变长变量来做处理。如果此时用户需要将String转换为byte[]，就会出错，因为byte[]会被当成可变长变量，而不是一个单独的变量。
推测了一下，对char[]数组的转换也会出现类似问题，所以对这两种类型做一次判断即可。