### PR TITLE
fix issue 2679

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/MapDeserializer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/MapDeserializer.java
@@ -1,17 +1,17 @@
 package com.alibaba.fastjson.parser.deserializer;
 
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.parser.*;
 import com.alibaba.fastjson.parser.DefaultJSONParser.ResolveTask;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class MapDeserializer implements ObjectDeserializer {
     public static MapDeserializer instance = new MapDeserializer();
@@ -198,7 +198,20 @@ public class MapDeserializer implements ObjectDeserializer {
                     value = parser.parseObject(valueType, key);
                 }
 
-                map.put(key, value);
+                boolean ref = false;
+                if ("$ref".equals(key)) {
+                    Object obj = parser.resolveReference(value.toString());
+                    if (obj != null) {
+                        if (obj instanceof Map) {
+                            ref = true;
+                            map = (Map) obj;
+                        }
+                    }
+                }
+                if (!ref) {
+                    map.put(key, value);
+                }
+
                 parser.checkMapResolve(map, key);
 
                 parser.setContext(context, value, key);

--- a/src/test/java/com/alibaba/fastjson/deserializer/issue2679/Issue2679Test.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issue2679/Issue2679Test.java
@@ -1,0 +1,50 @@
+package com.alibaba.fastjson.deserializer.issue2679;
+
+import com.alibaba.fastjson.JSON;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Issue2679Test {
+
+    static class Foo {
+        private Map<String, String> mapData;
+
+        public Map<String, String> getMapData() {
+            return mapData;
+        }
+
+        public void setMapData(Map<String, String> mapData) {
+            this.mapData = mapData;
+        }
+    }
+
+    @Test
+    public void issue2679() {
+        List<Foo> fooList = new ArrayList<Foo>();
+        HashMap<String, String> mapData = new HashMap<String, String>();
+        mapData.put("key1", "val1");
+
+        Foo foo = new Foo();
+        foo.setMapData(mapData);
+
+        Foo foo2 = new Foo();
+        foo2.setMapData(mapData);
+
+        fooList.add(foo);
+        fooList.add(foo2);
+
+        String fooListJson = JSON.toJSONString(fooList);
+
+        List<Foo> fooListJsonParseRet = JSON.parseArray(fooListJson, Foo.class);
+        Assert.assertTrue(fooListJsonParseRet.get(0).getMapData() == fooListJsonParseRet.get(1).getMapData());
+
+        String json = "[{\"mapData\":{\"key1\":\"val1\"}},{\"mapData\":{\"$ref\":\"ref\"}}]";
+        fooListJsonParseRet = JSON.parseArray(json, Foo.class);
+        Assert.assertEquals("ref", fooListJsonParseRet.get(1).getMapData().get("$ref"));
+    }
+}


### PR DESCRIPTION
修复 #2679  中提到的属性类型为 Map 时， 反序列化时循环引用表达式未被解析，并添加相应的测试
