### PR TITLE
Fix issue2430 (反序列化guava的ArrayListMultimap失败)

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/GuavaCodec.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/GuavaCodec.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
 import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
@@ -27,7 +28,12 @@ public class GuavaCodec implements ObjectSerializer, ObjectDeserializer {
     }
 
     public <T> T deserialze(DefaultJSONParser parser, Type type, Object fieldName) {
-        if (type == ArrayListMultimap.class) {
+        Type rawType = type;
+        if (type instanceof ParameterizedType) {
+            rawType = ((ParameterizedType) type).getRawType();
+        }
+
+        if (rawType == ArrayListMultimap.class) {
             ArrayListMultimap multimap = ArrayListMultimap.create();
             JSONObject object = parser.parseObject();
             for (Map.Entry entry : object.entrySet()) {

--- a/src/test/java/com/alibaba/json/bvt/issue_2400/Issue2430.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2400/Issue2430.java
@@ -1,0 +1,55 @@
+package com.alibaba.json.bvt.issue_2400;
+
+import com.alibaba.fastjson.JSON;
+import com.google.common.collect.ArrayListMultimap;
+
+import junit.framework.TestCase;
+
+public class Issue2430 extends TestCase {
+	public void testForIssue() {
+		ArrayListMultimap<String, String> multimap = ArrayListMultimap.create();
+		multimap.put("a", "1");
+		multimap.put("a", "2");
+		multimap.put("a", "3");
+		multimap.put("b", "1");
+
+		VO vo = new VO();
+		vo.setMap(multimap);
+		vo.setName("zhangsan");
+
+		assertEquals("{\"map\":{\"a\":[\"1\",\"2\",\"3\"],\"b\":[\"1\"]},\"name\":\"zhangsan\"}",
+				JSON.toJSONString(vo));
+	}
+
+	public void testForIssue2() {
+		String jsonString = "{\"map\":{\"a\":[\"1\",\"2\",\"3\"],\"b\":[\"1\"]},\"name\":\"zhangsan\"}";
+		VO vo = JSON.parseObject(jsonString, VO.class);
+		assertEquals("VO:{name->zhangsan,map->{a=[1, 2, 3], b=[1]}}", vo.toString());
+	}
+
+	public static class VO {
+		private String name;
+		private ArrayListMultimap<String, String> map;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public ArrayListMultimap<String, String> getMap() {
+			return map;
+		}
+
+		public void setMap(ArrayListMultimap<String, String> map) {
+			this.map = map;
+		}
+
+		@Override
+		public String toString() {
+			return String.format("VO:{name->%s,map->%s}", this.name, this.map.toString());
+		}
+	}
+}


### PR DESCRIPTION
fix issue #2430 
原因是在对ArrayListMultiMap的类型做判断时，如果用户指定了泛型类型，则直接用`==ArrayListMultimap.class`的方式会返回False，需要先通过`getRawType()`方法获得原始类型后再做比较