### PR TITLE
Fix issue2736(JSONObject.keySet()中可能包含非String键)

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
+++ b/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
@@ -199,7 +199,8 @@ public class DefaultJSONParser implements Closeable {
 
        ParseContext context = this.context;
         try {
-            Map map = object instanceof JSONObject ? ((JSONObject) object).getInnerMap() : object;
+            boolean isJsonObjectMap = object instanceof JSONObject;
+            Map map = isJsonObjectMap ? ((JSONObject) object).getInnerMap() : object;
 
             boolean setContextFlag = false;
             for (;;) {
@@ -264,7 +265,7 @@ public class DefaultJSONParser implements Closeable {
                         } else {
                             key = lexer.decimalValue(true);
                         }
-                        if (lexer.isEnabled(Feature.NonStringKeyAsString)) {
+                        if (lexer.isEnabled(Feature.NonStringKeyAsString) || isJsonObjectMap) {
                             key = key.toString();
                         }
                     } catch (NumberFormatException e) {

--- a/src/test/java/com/alibaba/json/bvt/issue_2700/Issue2736.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2700/Issue2736.java
@@ -1,0 +1,13 @@
+package com.alibaba.json.bvt.issue_2700;
+
+import com.alibaba.fastjson.JSONObject;
+import junit.framework.TestCase;
+
+public class Issue2736 extends TestCase {
+    public void test_for_issue() throws Exception {
+        JSONObject s = JSONObject.parseObject("{1:2,3:4}");
+        for(String s1 : s.keySet()){
+            System.out.println(s1);
+        }
+    }
+}


### PR DESCRIPTION
fix #2736 

`JSONObject.innerMap`的泛型参数为<String, Object>，而`DefaultJSONParser.parseObject()`方法中的map没有指定泛型参数，往里put键值对也没有做类型检查，可能会put进非String类型的key。
当前的`parseObject()`逻辑中如果开启了NonStringKeyAsString这个特性，则会将key转为String类型。可以直接在这个判断条件后面新增一个对JSONObject的判断。

The parameterType of `JSONObject.innerMap` is <String, Object>, while in the method `DefaultJSONParser.parseObject()`, non-String key might be put into this map, resulting in unexpected outcome.
Currently, the type of key will be converted to String only when the feature `NonStringKeyAsString` is enabled. Therefore, an additional statement which determines whether current object is a JSONObject can be added after that to suit the case here.