### PR TITLE
开启@JSONField的unwrapped功能使序列化后的属性名丢失

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JavaBeanSerializer.java
@@ -417,7 +417,9 @@ public class JavaBeanSerializer extends SerializeFilterable implements ObjectSer
                     serializer.write(propertyValue);
                 } else {
                     if (!writeAsArray) {
-                        if (writeClassName || !fieldInfo.unwrapped) {
+                        boolean isMap = Map.class.isAssignableFrom(fieldClass);
+                        boolean isJavaBean = !fieldClass.isPrimitive() && !fieldClass.getName().startsWith("java.") || fieldClass == Object.class;
+                        if (writeClassName || !fieldInfo.unwrapped || !(isMap || isJavaBean)) {
                             if (directWritePrefix) {
                                 out.write(fieldInfo.name_chars, 0, fieldInfo.name_chars.length);
                             } else {

--- a/src/test/java/com/alibaba/json/bvt/serializer/JSONFieldTest_unwrapped_6.java
+++ b/src/test/java/com/alibaba/json/bvt/serializer/JSONFieldTest_unwrapped_6.java
@@ -1,0 +1,55 @@
+package com.alibaba.json.bvt.serializer;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class JSONFieldTest_unwrapped_6 extends TestCase {
+
+    public void test_jsonField() throws Exception {
+        Health vo = new Health();
+        List<String> cities = new ArrayList<String>();
+        cities.add("Beijing");
+        cities.add("Shanghai");
+        vo.id = 123;
+        vo.cities = cities;
+
+        String text = JSON.toJSONString(vo);
+        Assert.assertEquals("{\"cities\":[\"Beijing\",\"Shanghai\"],\"id\":123}", text);
+
+        Health vo2 = JSON.parseObject(text, Health.class);
+        assertNotNull(vo2.cities);
+        assertEquals("Beijing", vo2.cities.get(0));
+        assertEquals("Shanghai", vo2.cities.get(1));
+
+    }
+
+    public void test_null() throws Exception {
+        Health vo = new Health();
+        vo.id = 123;
+        vo.cities = null;
+
+        String text = JSON.toJSONString(vo);
+        Assert.assertEquals("{\"id\":123}", text);
+    }
+
+    public void test_empty() throws Exception {
+        Health vo = new Health();
+        vo.id = 123;
+
+        String text = JSON.toJSONString(vo);
+        Assert.assertEquals("{\"id\":123}", text);
+    }
+
+    public static class Health {
+        @JSONField(unwrapped = true)
+        public int id;
+
+        @JSONField(unwrapped = true)
+        public List<String> cities;
+    }
+}


### PR DESCRIPTION
简单的复现用例：
```java
    public void test_empty() throws Exception {
        Health vo = new Health();
        vo.id = 123;

        String text = JSON.toJSONString(vo);
        Assert.assertEquals("{\"id\":123}", text);  //输出"{123}"，属性名"id"丢失
    }

    public static class Health {
        @JSONField(unwrapped = true)
        public int id;
    }
```

目前已知unwrap只应该作用于map和javabean，所以在`JavaBeanSerializer.write()`方法中写属性名的地方加了一条判断