### PR TITLE
Fix issue2743(json的key中有逗号取不到值 )

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONPath.java
+++ b/src/main/java/com/alibaba/fastjson/JSONPath.java
@@ -663,6 +663,8 @@ public class JSONPath implements JSONAware {
         private char         ch;
         private int          level;
         private boolean      hasRefSegment;
+        private static final String strArrayRegex = "\'\\s*,\\s*\'";
+        private static final Pattern strArrayPatternx = Pattern.compile(strArrayRegex);
 
         public JSONPathParser(String path){
             this.path = path;
@@ -1683,18 +1685,13 @@ public class JSONPath implements JSONAware {
 
             if (indexText.length() > 2 && firstChar == '\'' && lastChar == '\'') {
 
-                if (commaIndex == -1) {
-                    String propertyName = indexText.substring(1, indexTextLen - 1);
+                String propertyName = indexText.substring(1, indexTextLen - 1);
+
+                if (!strArrayPatternx.matcher(indexText).find()) {
                     return new PropertySegment(propertyName, false);
                 }
 
-                String[] indexesText = indexText.split(",");
-                String[] propertyNames = new String[indexesText.length];
-                for (int i = 0; i < indexesText.length; ++i) {
-                    String indexesTextItem = indexesText[i];
-                    propertyNames[i] = indexesTextItem.substring(1, indexesTextItem.length() - 1);
-                }
-
+                String[] propertyNames = propertyName.split(strArrayRegex);
                 return new MultiPropertySegment(propertyNames);
             }
 

--- a/src/test/java/com/alibaba/json/bvt/issue_2700/Issue2743.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2700/Issue2743.java
@@ -1,0 +1,50 @@
+package com.alibaba.json.bvt.issue_2700;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.util.regex.Pattern;
+
+import com.alibaba.fastjson.JSONPath;
+
+import junit.framework.TestCase;
+
+public class Issue2743 extends TestCase {
+
+    // 场景：验证字符串数组，楼主提供的用例
+    public void test_0() throws Exception {
+        String json = "{\"info\":{\"com.xxx.service.xxxServiceForOrder@queryGoodsV2(Long,Long,Long)\":[{\"method\":\"queryPrepayGoodsV2\"}]}}";
+        Object obj = JSONPath.extract(json,
+                "$['info']['com.xxx.service.xxxServiceForOrder@queryGoodsV2(Long,Long,Long)']");
+        assertEquals("[{\"method\":\"queryPrepayGoodsV2\"}]", obj.toString());
+    }
+
+    // 场景：验证数字数组
+    public void test_1() throws Exception {
+        String json = "[10,11,12,13,14,15,16,17,18,19,20]";
+        Object obj = JSONPath.extract(json, "$[3,4]");
+        assertEquals("[13,14]", obj.toString());
+    }
+
+    // 场景：验证修复bug用的正则表达式
+    public void test_2() throws Exception {
+        String strArrayRegex = "\'\\s*,\\s*\'";
+        Pattern strArrayPattern = Pattern.compile(strArrayRegex);
+
+        assertFalse(
+                strArrayPattern.matcher("'com.xxx.service.xxxServiceForOrder@queryGoodsV2(Long,Long,Long)'").find());
+        assertTrue(strArrayPattern.matcher("'id','name'").find());
+        assertTrue(strArrayPattern.matcher("'id'    ,    'name'").find());
+        assertTrue(strArrayPattern.matcher("'id',    'name'").find());
+        assertTrue(strArrayPattern.matcher("'id'    ,'name'").find());
+
+        String[] strs = { "'com.xxx.service.xxxServiceForOrder@queryGoodsV2(Long,Long,Long)'" };
+        assertArrayEquals(strs, strs[0].split(strArrayRegex));
+
+        strs = new String[] { "'id", "name'" };
+        assertArrayEquals(strs, "'id','name'".split(strArrayRegex));
+        assertArrayEquals(strs, "'id'    ,    'name'".split(strArrayRegex));
+        assertArrayEquals(strs, "'id'    ,'name'".split(strArrayRegex));
+        assertArrayEquals(strs, "'id',    'name'".split(strArrayRegex));
+    }
+
+}


### PR DESCRIPTION
fix issue #2743 
原本的逻辑中split字符串数组使用的是逗号，如果数组中某个元素包含了逗号，会导致截取出错。

改为使用引号+逗号来split则不会有这个问题（因为引号标志了字符串的结束）。

考虑到逗号和引号之间可能存在空格字符，这里用了正则匹配的方式。

这么做还有一个好处，就是只需要在split之前把字符串数组的头尾两个引号去掉，就可以保证split出来的元素为不包含引号的propertyNames（不再需要对每个元素进行substring操作来去除引号）。