### PR TITLE
修复以$和_开头的属性名无法正确序列化和反序列化的问题

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
@@ -579,11 +579,11 @@ public class JavaBeanInfo {
                         if (!methodName.startsWith(withPrefix)) {
                             continue;
                         }
-    
+
                         if (methodName.length() <= withPrefix.length()) {
                             continue;
                         }
-    
+                        
                         properNameBuilder = new StringBuilder(methodName.substring(withPrefix.length()));
                     }
                 }
@@ -709,6 +709,7 @@ public class JavaBeanInfo {
             char c3 = methodName.charAt(3);
 
             String propertyName;
+            Field field = null;
             if (Character.isUpperCase(c3) //
                     || c3 > 512 // for unicode method name
                     ) {
@@ -719,15 +720,31 @@ public class JavaBeanInfo {
                 }
             } else if (c3 == '_') {
                 propertyName = methodName.substring(4);
+                field = TypeUtils.getField(clazz, propertyName, declaredFields);
+                if (field == null) {
+                    String temp = propertyName;
+                    propertyName = methodName.substring(3);
+                    field = TypeUtils.getField(clazz, propertyName, declaredFields);
+                    if (field == null) {
+                        propertyName = temp; //减少修改代码带来的影响
+                    }
+                }
             } else if (c3 == 'f') {
                 propertyName = methodName.substring(3);
             } else if (methodName.length() >= 5 && Character.isUpperCase(methodName.charAt(4))) {
                 propertyName = TypeUtils.decapitalize(methodName.substring(3));
             } else {
-                continue;
+                propertyName = methodName.substring(3);
+                field = TypeUtils.getField(clazz, propertyName, declaredFields);
+                if (field == null) {
+                    continue;
+                }
             }
 
-            Field field = TypeUtils.getField(clazz, propertyName, declaredFields);
+            if (field == null) {
+                field = TypeUtils.getField(clazz, propertyName, declaredFields);
+            }
+
             if (field == null && types[0] == boolean.class) {
                 String isFieldName = "is" + Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
                 field = TypeUtils.getField(clazz, isFieldName, declaredFields);

--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -1876,6 +1876,7 @@ public class TypeUtils{
                 }
                 char c3 = methodName.charAt(3);
                 String propertyName;
+                Field field = null;
                 if(Character.isUpperCase(c3) //
                         || c3 > 512 // for unicode method name
                         ){
@@ -1887,19 +1888,36 @@ public class TypeUtils{
                     propertyName = getPropertyNameByCompatibleFieldName(fieldCacheMap, methodName, propertyName, 3);
                 } else if(c3 == '_'){
                     propertyName = methodName.substring(4);
+                    field = fieldCacheMap.get(propertyName);
+                    if (field == null) {
+                        String temp = propertyName;
+                        propertyName = methodName.substring(3);
+                        field = ParserConfig.getFieldFromCache(propertyName, fieldCacheMap);
+                        if (field == null) {
+                            propertyName = temp; //减少修改代码带来的影响
+                        }
+                    }
                 } else if(c3 == 'f'){
                     propertyName = methodName.substring(3);
                 } else if(methodName.length() >= 5 && Character.isUpperCase(methodName.charAt(4))){
                     propertyName = decapitalize(methodName.substring(3));
                 } else{
-                    continue;
+                    propertyName = methodName.substring(3);
+                    field = ParserConfig.getFieldFromCache(propertyName, fieldCacheMap);
+                    if (field == null) {
+                        continue;
+                    }
                 }
                 boolean ignore = isJSONTypeIgnore(clazz, propertyName);
                 if(ignore){
                     continue;
                 }
-                //假如bean的field很多的情况一下，轮询时将大大降低效率
-                Field field = ParserConfig.getFieldFromCache(propertyName, fieldCacheMap);
+
+                if (field == null) {
+                    // 假如bean的field很多的情况一下，轮询时将大大降低效率
+                    field = ParserConfig.getFieldFromCache(propertyName, fieldCacheMap);
+                }
+                
                 if(field == null && propertyName.length() > 1){
                     char ch = propertyName.charAt(1);
                     if(ch >= 'A' && ch <= 'Z'){
@@ -1955,6 +1973,7 @@ public class TypeUtils{
                 }
                 char c2 = methodName.charAt(2);
                 String propertyName;
+                Field field = null;
                 if(Character.isUpperCase(c2)){
                     if(compatibleWithJavaBean){
                         propertyName = decapitalize(methodName.substring(2));
@@ -1964,16 +1983,33 @@ public class TypeUtils{
                     propertyName = getPropertyNameByCompatibleFieldName(fieldCacheMap, methodName, propertyName, 2);
                 } else if(c2 == '_'){
                     propertyName = methodName.substring(3);
+                    field = fieldCacheMap.get(propertyName);
+                    if (field == null) {
+                        String temp = propertyName;
+                        propertyName = methodName.substring(2);
+                        field = ParserConfig.getFieldFromCache(propertyName, fieldCacheMap);
+                        if (field == null) {
+                            propertyName = temp;
+                        }
+                    }
                 } else if(c2 == 'f'){
                     propertyName = methodName.substring(2);
                 } else{
-                    continue;
+                    propertyName = methodName.substring(2);
+                    field = ParserConfig.getFieldFromCache(propertyName, fieldCacheMap);
+                    if (field == null) {
+                        continue;
+                    }
                 }
                 boolean ignore = isJSONTypeIgnore(clazz, propertyName);
                 if(ignore){
                     continue;
                 }
-                Field field = ParserConfig.getFieldFromCache(propertyName, fieldCacheMap);
+                
+                if(field == null) {
+                    field = ParserConfig.getFieldFromCache(propertyName, fieldCacheMap);
+                }
+                
                 if(field == null){
                     field = ParserConfig.getFieldFromCache(methodName, fieldCacheMap);
                 }

--- a/src/test/java/com/alibaba/json/bvt/issue_2400/Issue2488.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2400/Issue2488.java
@@ -1,0 +1,92 @@
+package com.alibaba.json.bvt.issue_2400;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import junit.framework.TestCase;
+
+public class Issue2488 extends TestCase {
+    public void testForIssue_1() {
+        String a = "{\"$a_b\":\"a1_b2\",\"_c_d\":\"c3_d4\",\"aaaa\":\"CC\",\"__flag\":\"true\",\"$flag\":\"true\"}";
+        JSONObject obj = (JSONObject) JSONObject.parse(a);
+        TestJsonObj2 stu = JSONObject.toJavaObject(obj, TestJsonObj2.class);
+        assertEquals("TestJsonObj2{$a_b=\"a1_b2\",_c_d=\"c3_d4\",aaaa=\"CC\",__flag=true,$flag=true}", stu.toString());
+    }
+
+    public void testForIssue_2() {
+        String a = "{\"$a_b\":\"aa3_bb4\",\"_c_d\":\"cc1_dd2\",\"aaaa\":\"BB\",\"__flag\":\"true\",\"$flag\":\"true\"}";
+        TestJsonObj2 stu = JSON.parseObject(a, TestJsonObj2.class);
+        assertEquals("TestJsonObj2{$a_b=\"aa3_bb4\",_c_d=\"cc1_dd2\",aaaa=\"BB\",__flag=true,$flag=true}",
+                stu.toString());
+    }
+
+    public void testForIssue_3() {
+        TestJsonObj2 vo = new TestJsonObj2("aa_bb", "cc_dd", "AA", true, true);
+        String text = JSON.toJSONString(vo);
+        assertEquals("{\"$a_b\":\"aa_bb\",\"$flag\":true,\"__flag\":true,\"_c_d\":\"cc_dd\",\"aaaa\":\"AA\"}", text);
+    }
+
+    public static class TestJsonObj2 {
+        private String $a_b;
+        private String _c_d;
+        private String aaaa;
+        private boolean __flag;
+        private boolean $flag;
+
+        public TestJsonObj2() {
+        }
+
+        public TestJsonObj2(String $a_b, String _c_d, String aaaa, boolean __flag, boolean $flag) {
+            this.$a_b = $a_b;
+            this._c_d = _c_d;
+            this.aaaa = aaaa;
+            this.__flag = __flag;
+            this.$flag = $flag;
+        }
+
+        public String get$a_b() {
+            return $a_b;
+        }
+
+        public void set$a_b(String $a_b) {
+            this.$a_b = $a_b;
+        }
+
+        public String get_c_d() {
+            return _c_d;
+        }
+
+        public void set_c_d(String _c_d) {
+            this._c_d = _c_d;
+        }
+
+        public String getaaaa() {
+            return aaaa;
+        }
+
+        public void setaaaa(String aaaa) {
+            this.aaaa = aaaa;
+        }
+
+        public boolean is__flag() {
+            return __flag;
+        }
+
+        public void set__flag(boolean __flag) {
+            this.__flag = __flag;
+        }
+
+        public boolean is$flag() {
+            return $flag;
+        }
+
+        public void set$flag(boolean $flag) {
+            this.$flag = $flag;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("TestJsonObj2{$a_b=\"%s\",_c_d=\"%s\",aaaa=\"%s\",__flag=%b,$flag=%b}", this.$a_b,
+                    this._c_d, this.aaaa, this.__flag, this.$flag);
+        }
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/parser/DefaultExtJSONParserTest.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/DefaultExtJSONParserTest.java
@@ -547,7 +547,7 @@ public class DefaultExtJSONParserTest extends TestCase {
         }
 
         public void setage(int age) {
-            throw new UnsupportedOperationException();
+            this.age = age;
         }
 
         public void set(int age) {


### PR DESCRIPTION
fix #2488 #2385 #2722 

修复两个问题
1. 以美元符号（$）开头的属性，序列化和反序列都不解析，因为当前的逻辑是通过get/set/is方法名来解析propertyName，其中只对大写字母开头、'\_'开头和'f'开头的属性做了特殊判断，但没有考虑到去掉get/set/is前缀后方法名与属性名称相同的场景，比如`setage()`对应age属性（此前只能识别`setAge()`)
修复方案：在所有解析propertyName的逻辑中，若匹配大写字母开头、'_'开头和'f'开头失败时（进入else分支），尝试直接去掉get\set\is前缀，并且不做任何大小写转换去获取field

2. 以下划线符号（\_）开头，序列化出来的字符串丢失了下划线符号（_），因为解析propertyName逻辑中为了支持`get_set_Test.java`用例中的特殊下划线场景，直接去掉了下划线。
修复方案：在下划线开头的特殊处理分支中增加逻辑，如果去掉下划线获取不到field,就尝试加上下划线去获取（如果还是获取不到就还原回去掉下划线的属性名，以减少本次改动带来的影响）