### PR TITLE
解决Long类型数据转换成Integer的bug

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/ListSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/ListSerializer.java
@@ -106,12 +106,8 @@ public final class ListSerializer implements ObjectSerializer {
                         out.writeInt(((Integer) item).intValue());
                     } else if (clazz == Long.class) {
                         long val = ((Long) item).longValue();
-                        if (writeClassName) {
                             out.writeLong(val);
                             out.write('L');
-                        } else {
-                            out.writeLong(val);
-                        }
                     } else {
                         if ((SerializerFeature.DisableCircularReferenceDetect.mask & features) != 0){
                             itemSerializer = serializer.getObjectWriter(item.getClass());

--- a/src/test/java/com/alibaba/json/bvt/issue_2700/Issue2750.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2700/Issue2750.java
@@ -1,0 +1,28 @@
+package com.alibaba.json.bvt.issue_2700;
+
+import com.alibaba.fastjson.JSON;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Description:  <br>
+ *
+ * @author byw
+ * @create 2019/10/4
+ */
+public class Issue2750 extends TestCase {
+    public void test_01(){
+        List list = new ArrayList<Long>();
+        list.add(5678901L);
+        Map<String, List> param = new HashMap<String, List>();
+        param.put("list", list);
+        Map<String, List> map = JSON.parseObject(JSON.toJSONString(param), Map.class);
+        List listTmp = map.get("list");
+        Assert.assertTrue(listTmp.get(0).getClass().toString().equals("class java.lang.Long"));
+    }
+}


### PR DESCRIPTION
#2750  我尝试着解决了这个bug。 如果有时间的话请审阅。
说实话在处理的过程中我尝试去理解下面这个判断的逻辑但是很遗憾并没有弄清楚作者要做什么
if (writeClassName)
但是经过思考后我认为Long类型的数据在任何时候最后都要有‘L’ 这样可以保证其他人在处理这个数据的时候始终以Long类型来处理，避免很多运算上面的问题。
如果我理解的不对，还希望指出，将不胜感激，谢谢。