### PR TITLE
Enable SerializeFeature.MapSortField for deterministic order

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/jsonp/JSONPParseTest2.java
+++ b/src/test/java/com/alibaba/json/bvt/jsonp/JSONPParseTest2.java
@@ -21,7 +21,7 @@ public class JSONPParseTest2 extends TestCase {
         assertEquals(1, param.get("id"));
         assertEquals("idonans", param.get("name"));
 
-        String json = JSON.toJSONString(jsonpObject);
-        assertEquals("parent.callback({\"name\":\"idonans\",\"id\":1})", json);
+        String json = JSON.toJSONString(jsonpObject, SerializerFeature.MapSortField);
+        assertEquals("parent.callback({\"id\":1,\"name\":\"idonans\"})", json);
     }
 }


### PR DESCRIPTION
`test_f()` in [JSONPParseTest2.java](https://github.com/alibaba/fastjson/blob/e550a4d5e55a55d6b9c8aaa4adec1a7f034aeec4/src/test/java/com/alibaba/json/bvt/jsonp/JSONPParseTest2.java) parses a text to a `JSONPObject` and compare the `toJSONString` representation to see if it is same as a hard-coded string. The underlying inner map of jsonpObject is using a HashMap. 

As you may tell from the test itself, the original input is 
`"parent.callback ({'id':1, 'name':'idonans'} );   /**/ ";` 
but the test assertion is asserting 
`"parent.callback({\"name\":\"idonans\",\"id\":1})"`

However, HashMap does not guarantee any specific order of entries. Therefore, the assertions in those test cases will fail if the order is different.

This PR proposes to enable  `SerializerFeature.MapSortField` to make the order deterministic and modify the corresponding test assertions. We believe this will make the test more stable.
