### PR TITLE
JSONArray构造方法中，由null List会引发的NPE问题

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONArray.java
+++ b/src/main/java/com/alibaba/fastjson/JSONArray.java
@@ -55,6 +55,9 @@ public class JSONArray extends JSON implements List<Object>, Cloneable, RandomAc
     }
 
     public JSONArray(List<Object> list){
+        if (list == null){
+            throw new IllegalArgumentException("list is null.");
+        }
         this.list = list;
     }
 


### PR DESCRIPTION
在创建JSONArray时，如果传入是null类型的List，JSONArray会被正常创建，但在调用add方法时会抛出NullPointException，所以我在创建JSONArray时，添加了List是否等于null的判断。