### PR TITLE
修复TypeUtils中判断字符串是否存在逗号的逻辑

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -365,7 +365,7 @@ public class TypeUtils{
                     || "NULL".equals(strVal)){
                 return null;
             }
-            if(strVal.indexOf(',') != 0){
+            if(strVal.indexOf(',') != -1){
                 strVal = strVal.replaceAll(",", "");
             }
             return Float.parseFloat(strVal);
@@ -387,7 +387,7 @@ public class TypeUtils{
                     || "NULL".equals(strVal)){
                 return null;
             }
-            if(strVal.indexOf(',') != 0){
+            if(strVal.indexOf(',') != -1){
                 strVal = strVal.replaceAll(",", "");
             }
             return Double.parseDouble(strVal);
@@ -701,7 +701,7 @@ public class TypeUtils{
                     || "NULL".equals(strVal)){
                 return null;
             }
-            if(strVal.indexOf(',') != 0){
+            if(strVal.indexOf(',') != -1){
                 strVal = strVal.replaceAll(",", "");
             }
             try{
@@ -811,7 +811,7 @@ public class TypeUtils{
                     || "NULL".equals(strVal)){
                 return null;
             }
-            if(strVal.indexOf(',') != 0){
+            if(strVal.indexOf(',') != -1){
                 strVal = strVal.replaceAll(",", "");
             }
             return Integer.parseInt(strVal);


### PR DESCRIPTION
当前的字符串去逗号逻辑可能会导致当解析的数字为字符串形式时，如果第0位出现逗号，会解析失败的情况。