### PR TITLE
修复boolean型key与String型key冲突的问题

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -165,10 +165,10 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         if (text == null) {
             return null;
         }
-
+        System.out.println(" Object parse " + text);
         DefaultJSONParser parser = new DefaultJSONParser(text, config, features);
         Object value = parser.parse();
-
+        System.out.println(" Object parse value :" + value);
         parser.handleResovleTask(value);
 
         parser.close();

--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -168,7 +168,6 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
 
         DefaultJSONParser parser = new DefaultJSONParser(text, config, features);
         Object value = parser.parse();
-        
         parser.handleResovleTask(value);
 
         parser.close();

--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -165,8 +165,10 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         if (text == null) {
             return null;
         }
+
         DefaultJSONParser parser = new DefaultJSONParser(text, config, features);
         Object value = parser.parse();
+        
         parser.handleResovleTask(value);
 
         parser.close();

--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -165,10 +165,8 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         if (text == null) {
             return null;
         }
-        System.out.println(" Object parse " + text);
         DefaultJSONParser parser = new DefaultJSONParser(text, config, features);
         Object value = parser.parse();
-        System.out.println(" Object parse value :" + value);
         parser.handleResovleTask(value);
 
         parser.close();

--- a/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
+++ b/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
@@ -290,6 +290,13 @@ public class DefaultJSONParser implements Closeable {
                     }
 
                     key = lexer.scanSymbolUnQuoted(symbolTable);
+                    if(key.equals("true")) {
+                        key = true;
+                    }
+                    if(key.equals("false")) {
+                        key = false;
+                    }
+
                     lexer.skipWhitespace();
                     ch = lexer.getCurrent();
                     if (ch != ':') {

--- a/src/test/java/com/alibaba/json/bvt/issue_2800/Issue2831.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2800/Issue2831.java
@@ -1,12 +1,13 @@
-package com.alibaba;
+package com.alibaba.json.bvt.issue_2800;
 
 import com.alibaba.fastjson.JSONObject;
+import junit.framework.TestCase;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class main {
-    public static  void main(String[] args) {
+public class Issue2831 extends TestCase {
+    public void test_for_issue() throws Exception {
         //System.out.println(1);
         Map<Object, Object> map = new HashMap();
         map.put(1, "1");
@@ -14,11 +15,9 @@ public class main {
         map.put(Boolean.valueOf("false"), "fa");
         map.put("false", "lse");
         String s = JSONObject.toJSONString(map);
-        System.out.println(s);
         JSONObject j = JSONObject.parseObject(s);
         j.put("3", null);
-        System.out.println(j.keySet());
-        System.out.println(j.containsValue(null));
+        assertEquals(5, j.size());
     }
 
 }

--- a/src/test/java/com/alibaba/main.java
+++ b/src/test/java/com/alibaba/main.java
@@ -1,0 +1,24 @@
+package com.alibaba;
+
+import com.alibaba.fastjson.JSONObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class main {
+    public static  void main(String[] args) {
+        //System.out.println(1);
+        Map<Object, Object> map = new HashMap();
+        map.put(1, "1");
+        map.put(2, 2);
+        map.put(Boolean.valueOf("false"), "fa");
+        map.put("false", "lse");
+        String s = JSONObject.toJSONString(map);
+        System.out.println(s);
+        JSONObject j = JSONObject.parseObject(s);
+        j.put("3", null);
+        System.out.println(j.keySet());
+        System.out.println(j.containsValue(null));
+    }
+
+}


### PR DESCRIPTION
这个问题本质上是没有在解析key值时对true和false时做针对处理。
所以算法走的时默认的解析步骤 scanSymbolUnQuoted。然而此函数的返回值固定为String。
所以Boolean.true 就会变转化为 "true"。
解决方式有两种
一为增加特定的scanBoolean函数。
二为在scanSymbolUnQuoted函数中增加一部分数据转换。
本修改选择的时第二种。
提交了相应的测试。
#2831 