### PR TITLE
将数值Pattern抽取成一个static字段，提高性能

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -60,6 +60,7 @@ import java.util.regex.Pattern;
  * @author wenshao[szujobs@hotmail.com]
  */
 public class TypeUtils{
+    private static final Pattern NUMBER_WITH_TRAILING_ZEROS_PATTERN = Pattern.compile("\\.0*$");
 
     public static boolean compatibleWithJavaBean = false;
     /** 根据field name的大小写输出输入数据 */
@@ -817,7 +818,7 @@ public class TypeUtils{
                 strVal = strVal.replaceAll(",", "");
             }
             
-            Matcher matcher = Pattern.compile("\\.0*$").matcher(strVal);
+            Matcher matcher = NUMBER_WITH_TRAILING_ZEROS_PATTERN.matcher(strVal);
             if(matcher.find()) {
                 strVal = matcher.replaceAll("");
             }
@@ -825,7 +826,7 @@ public class TypeUtils{
         }
 
         if(value instanceof Boolean){
-            return ((Boolean) value).booleanValue() ? 1 : 0;
+            return (Boolean) value ? 1 : 0;
         }
         if(value instanceof Map){
             Map map = (Map) value;


### PR DESCRIPTION
参见 https://github.com/alibaba/fastjson/commit/5c6d6fd471ea1fab59f0df2dd31e0b936806780d

在上述commit中，作者使用了一个每次都需要重新编译的正则表达式，
对性能有不利影响。这个commit将该Pattern提取成了一个预先编译好的
static字段，可以提高运行时的性能。

另外还做了一个改进：移除没有必要的booleanValue()方法调用。