### PR TITLE
Fix issue 2779 ASM生成的跳转目标可能溢出

### DIFF
--- a/src/main/java/com/alibaba/fastjson/asm/MethodWriter.java
+++ b/src/main/java/com/alibaba/fastjson/asm/MethodWriter.java
@@ -204,7 +204,8 @@ public class MethodWriter implements MethodVisitor {
              * needed).
              */
             code.putByte(opcode);
-            label.put(this, code, code.length - 1);
+            // Currently, GOTO_W is the only supported wide reference
+            label.put(this, code, code.length - 1, opcode == Opcodes.GOTO_W);
         }
     }
 

--- a/src/main/java/com/alibaba/fastjson/asm/Opcodes.java
+++ b/src/main/java/com/alibaba/fastjson/asm/Opcodes.java
@@ -134,6 +134,6 @@ public interface Opcodes {
     
     int    IFNULL              = 198;                    // visitJumpInsn
     int    IFNONNULL           = 199;                    // -
-    // int GOTO_W = 200; // -
+    int    GOTO_W              = 200;                    // visitJumpInsn
     // int JSR_W = 201; // -
 }

--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/ASMDeserializerFactory.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/ASMDeserializerFactory.java
@@ -658,14 +658,21 @@ public class ASMDeserializerFactory implements Opcodes {
         mw.visitLdcInsn(Feature.SortFeidFastMatch.mask);
         mw.visitMethodInsn(INVOKEVIRTUAL, JSONLexerBase, "isEnabled", "(I)Z");
 
-        mw.visitJumpInsn(IFEQ, super_);
+        Label continue_ = new Label();
+        mw.visitJumpInsn(IFNE, continue_);
+        mw.visitJumpInsn(GOTO_W, super_);
+        mw.visitLabel(continue_);
 
         mw.visitVarInsn(ALOAD, context.var("lexer"));
         mw.visitLdcInsn(context.clazz.getName());
         mw.visitMethodInsn(INVOKEVIRTUAL, JSONLexerBase, "scanType", "(Ljava/lang/String;)I");
 
         mw.visitLdcInsn(com.alibaba.fastjson.parser.JSONLexerBase.NOT_MATCH);
-        mw.visitJumpInsn(IF_ICMPEQ, super_);
+
+        Label continue_2 = new Label();
+        mw.visitJumpInsn(IF_ICMPNE, continue_2);
+        mw.visitJumpInsn(GOTO_W, super_);
+        mw.visitLabel(continue_2);
 
         mw.visitVarInsn(ALOAD, 1); // parser
         mw.visitMethodInsn(INVOKEVIRTUAL, DefaultJSONParser, "getContext", "()" + desc(ParseContext.class));

--- a/src/test/java/com/alibaba/fastjson/deserializer/issue2779/Issue2779Test.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issue2779/Issue2779Test.java
@@ -1,0 +1,12 @@
+package com.alibaba.fastjson.deserializer.issue2779;
+
+import com.alibaba.fastjson.JSON;
+import org.junit.Test;
+
+// https://github.com/alibaba/fastjson/issues/2779
+public class Issue2779Test {
+    @Test
+    public void canDeserializeLargeJavaBean() {
+        JSON.parseObject("{}", LargeJavaBean.class);
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issue2779/LargeJavaBean.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issue2779/LargeJavaBean.java
@@ -1,0 +1,615 @@
+package com.alibaba.fastjson.deserializer.issue2779;
+
+import java.util.List;
+
+public class LargeJavaBean {
+    public List<Alphabet> getList100() {
+        return list100;
+    }
+
+    public void setList100(List<Alphabet> list100) {
+        this.list100 = list100;
+    }
+
+    public List<Alphabet> getList101() {
+        return list101;
+    }
+
+    public void setList101(List<Alphabet> list101) {
+        this.list101 = list101;
+    }
+
+    public List<Alphabet> getList102() {
+        return list102;
+    }
+
+    public void setList102(List<Alphabet> list102) {
+        this.list102 = list102;
+    }
+
+    public List<Alphabet> getList103() {
+        return list103;
+    }
+
+    public void setList103(List<Alphabet> list103) {
+        this.list103 = list103;
+    }
+
+    public List<Alphabet> getList104() {
+        return list104;
+    }
+
+    public void setList104(List<Alphabet> list104) {
+        this.list104 = list104;
+    }
+
+    public List<Alphabet> getList105() {
+        return list105;
+    }
+
+    public void setList105(List<Alphabet> list105) {
+        this.list105 = list105;
+    }
+
+    public List<Alphabet> getList106() {
+        return list106;
+    }
+
+    public void setList106(List<Alphabet> list106) {
+        this.list106 = list106;
+    }
+
+    public List<Alphabet> getList107() {
+        return list107;
+    }
+
+    public void setList107(List<Alphabet> list107) {
+        this.list107 = list107;
+    }
+
+    public List<Alphabet> getList108() {
+        return list108;
+    }
+
+    public void setList108(List<Alphabet> list108) {
+        this.list108 = list108;
+    }
+
+    public List<Alphabet> getList109() {
+        return list109;
+    }
+
+    public void setList109(List<Alphabet> list109) {
+        this.list109 = list109;
+    }
+
+    public List<Alphabet> getList110() {
+        return list110;
+    }
+
+    public void setList110(List<Alphabet> list110) {
+        this.list110 = list110;
+    }
+
+    public List<Alphabet> getList111() {
+        return list111;
+    }
+
+    public void setList111(List<Alphabet> list111) {
+        this.list111 = list111;
+    }
+
+    public List<Alphabet> getList112() {
+        return list112;
+    }
+
+    public void setList112(List<Alphabet> list112) {
+        this.list112 = list112;
+    }
+
+    public List<Alphabet> getList113() {
+        return list113;
+    }
+
+    public void setList113(List<Alphabet> list113) {
+        this.list113 = list113;
+    }
+
+    public List<Alphabet> getList114() {
+        return list114;
+    }
+
+    public void setList114(List<Alphabet> list114) {
+        this.list114 = list114;
+    }
+
+    public List<Alphabet> getList115() {
+        return list115;
+    }
+
+    public void setList115(List<Alphabet> list115) {
+        this.list115 = list115;
+    }
+
+    public List<Alphabet> getList116() {
+        return list116;
+    }
+
+    public void setList116(List<Alphabet> list116) {
+        this.list116 = list116;
+    }
+
+    public List<Alphabet> getList117() {
+        return list117;
+    }
+
+    public void setList117(List<Alphabet> list117) {
+        this.list117 = list117;
+    }
+
+    public List<Alphabet> getList118() {
+        return list118;
+    }
+
+    public void setList118(List<Alphabet> list118) {
+        this.list118 = list118;
+    }
+
+    public List<Alphabet> getList119() {
+        return list119;
+    }
+
+    public void setList119(List<Alphabet> list119) {
+        this.list119 = list119;
+    }
+
+    public List<Alphabet> getList120() {
+        return list120;
+    }
+
+    public void setList120(List<Alphabet> list120) {
+        this.list120 = list120;
+    }
+
+    public List<Alphabet> getList121() {
+        return list121;
+    }
+
+    public void setList121(List<Alphabet> list121) {
+        this.list121 = list121;
+    }
+
+    public List<Alphabet> getList122() {
+        return list122;
+    }
+
+    public void setList122(List<Alphabet> list122) {
+        this.list122 = list122;
+    }
+
+    public List<Alphabet> getList123() {
+        return list123;
+    }
+
+    public void setList123(List<Alphabet> list123) {
+        this.list123 = list123;
+    }
+
+    public List<Alphabet> getList124() {
+        return list124;
+    }
+
+    public void setList124(List<Alphabet> list124) {
+        this.list124 = list124;
+    }
+
+    public List<Alphabet> getList125() {
+        return list125;
+    }
+
+    public void setList125(List<Alphabet> list125) {
+        this.list125 = list125;
+    }
+
+    public List<Alphabet> getList126() {
+        return list126;
+    }
+
+    public void setList126(List<Alphabet> list126) {
+        this.list126 = list126;
+    }
+
+    public List<Alphabet> getList127() {
+        return list127;
+    }
+
+    public void setList127(List<Alphabet> list127) {
+        this.list127 = list127;
+    }
+
+    public List<Alphabet> getList128() {
+        return list128;
+    }
+
+    public void setList128(List<Alphabet> list128) {
+        this.list128 = list128;
+    }
+
+    public List<Alphabet> getList129() {
+        return list129;
+    }
+
+    public void setList129(List<Alphabet> list129) {
+        this.list129 = list129;
+    }
+
+    public List<Alphabet> getList130() {
+        return list130;
+    }
+
+    public void setList130(List<Alphabet> list130) {
+        this.list130 = list130;
+    }
+
+    public List<Alphabet> getList131() {
+        return list131;
+    }
+
+    public void setList131(List<Alphabet> list131) {
+        this.list131 = list131;
+    }
+
+    public List<Alphabet> getList132() {
+        return list132;
+    }
+
+    public void setList132(List<Alphabet> list132) {
+        this.list132 = list132;
+    }
+
+    public List<Alphabet> getList133() {
+        return list133;
+    }
+
+    public void setList133(List<Alphabet> list133) {
+        this.list133 = list133;
+    }
+
+    public List<Alphabet> getList134() {
+        return list134;
+    }
+
+    public void setList134(List<Alphabet> list134) {
+        this.list134 = list134;
+    }
+
+    public List<Alphabet> getList135() {
+        return list135;
+    }
+
+    public void setList135(List<Alphabet> list135) {
+        this.list135 = list135;
+    }
+
+    public List<Alphabet> getList136() {
+        return list136;
+    }
+
+    public void setList136(List<Alphabet> list136) {
+        this.list136 = list136;
+    }
+
+    public List<Alphabet> getList137() {
+        return list137;
+    }
+
+    public void setList137(List<Alphabet> list137) {
+        this.list137 = list137;
+    }
+
+    public List<Alphabet> getList138() {
+        return list138;
+    }
+
+    public void setList138(List<Alphabet> list138) {
+        this.list138 = list138;
+    }
+
+    public List<Alphabet> getList139() {
+        return list139;
+    }
+
+    public void setList139(List<Alphabet> list139) {
+        this.list139 = list139;
+    }
+
+    public List<Alphabet> getList140() {
+        return list140;
+    }
+
+    public void setList140(List<Alphabet> list140) {
+        this.list140 = list140;
+    }
+
+    public List<Alphabet> getList141() {
+        return list141;
+    }
+
+    public void setList141(List<Alphabet> list141) {
+        this.list141 = list141;
+    }
+
+    public List<Alphabet> getList142() {
+        return list142;
+    }
+
+    public void setList142(List<Alphabet> list142) {
+        this.list142 = list142;
+    }
+
+    public List<Alphabet> getList143() {
+        return list143;
+    }
+
+    public void setList143(List<Alphabet> list143) {
+        this.list143 = list143;
+    }
+
+    public List<Alphabet> getList144() {
+        return list144;
+    }
+
+    public void setList144(List<Alphabet> list144) {
+        this.list144 = list144;
+    }
+
+    public List<Alphabet> getList145() {
+        return list145;
+    }
+
+    public void setList145(List<Alphabet> list145) {
+        this.list145 = list145;
+    }
+
+    public List<Alphabet> getList146() {
+        return list146;
+    }
+
+    public void setList146(List<Alphabet> list146) {
+        this.list146 = list146;
+    }
+
+    public List<Alphabet> getList147() {
+        return list147;
+    }
+
+    public void setList147(List<Alphabet> list147) {
+        this.list147 = list147;
+    }
+
+    public List<Alphabet> getList148() {
+        return list148;
+    }
+
+    public void setList148(List<Alphabet> list148) {
+        this.list148 = list148;
+    }
+
+    public List<Alphabet> getList149() {
+        return list149;
+    }
+
+    public void setList149(List<Alphabet> list149) {
+        this.list149 = list149;
+    }
+
+    public List<Alphabet> getList150() {
+        return list150;
+    }
+
+    public void setList150(List<Alphabet> list150) {
+        this.list150 = list150;
+    }
+
+    public List<Alphabet> getList151() {
+        return list151;
+    }
+
+    public void setList151(List<Alphabet> list151) {
+        this.list151 = list151;
+    }
+
+    public List<Alphabet> getList152() {
+        return list152;
+    }
+
+    public void setList152(List<Alphabet> list152) {
+        this.list152 = list152;
+    }
+
+    public List<Alphabet> getList153() {
+        return list153;
+    }
+
+    public void setList153(List<Alphabet> list153) {
+        this.list153 = list153;
+    }
+
+    public List<Alphabet> getList154() {
+        return list154;
+    }
+
+    public void setList154(List<Alphabet> list154) {
+        this.list154 = list154;
+    }
+
+    public List<Alphabet> getList155() {
+        return list155;
+    }
+
+    public void setList155(List<Alphabet> list155) {
+        this.list155 = list155;
+    }
+
+    public List<Alphabet> getList156() {
+        return list156;
+    }
+
+    public void setList156(List<Alphabet> list156) {
+        this.list156 = list156;
+    }
+
+    public List<Alphabet> getList157() {
+        return list157;
+    }
+
+    public void setList157(List<Alphabet> list157) {
+        this.list157 = list157;
+    }
+
+    public List<Alphabet> getList158() {
+        return list158;
+    }
+
+    public void setList158(List<Alphabet> list158) {
+        this.list158 = list158;
+    }
+
+    public List<Alphabet> getList159() {
+        return list159;
+    }
+
+    public void setList159(List<Alphabet> list159) {
+        this.list159 = list159;
+    }
+
+    public List<Alphabet> getList160() {
+        return list160;
+    }
+
+    public void setList160(List<Alphabet> list160) {
+        this.list160 = list160;
+    }
+
+    public List<Alphabet> getList161() {
+        return list161;
+    }
+
+    public void setList161(List<Alphabet> list161) {
+        this.list161 = list161;
+    }
+
+    public List<Alphabet> getList162() {
+        return list162;
+    }
+
+    public void setList162(List<Alphabet> list162) {
+        this.list162 = list162;
+    }
+
+    public List<Alphabet> getList163() {
+        return list163;
+    }
+
+    public void setList163(List<Alphabet> list163) {
+        this.list163 = list163;
+    }
+
+    // provide by zhaiyao, for fastjson test
+    private List<Alphabet> list100;
+    private List<Alphabet> list101;
+    private List<Alphabet> list102;
+    private List<Alphabet> list103;
+    private List<Alphabet> list104;
+    private List<Alphabet> list105;
+    private List<Alphabet> list106;
+    private List<Alphabet> list107;
+    private List<Alphabet> list108;
+    private List<Alphabet> list109;
+    private List<Alphabet> list110;
+    private List<Alphabet> list111;
+    private List<Alphabet> list112;
+    private List<Alphabet> list113;
+    private List<Alphabet> list114;
+    private List<Alphabet> list115;
+    private List<Alphabet> list116;
+    private List<Alphabet> list117;
+    private List<Alphabet> list118;
+    private List<Alphabet> list119;
+    private List<Alphabet> list120;
+    private List<Alphabet> list121;
+    private List<Alphabet> list122;
+    private List<Alphabet> list123;
+    private List<Alphabet> list124;
+    private List<Alphabet> list125;
+    private List<Alphabet> list126;
+    private List<Alphabet> list127;
+    private List<Alphabet> list128;
+    private List<Alphabet> list129;
+    private List<Alphabet> list130;
+    private List<Alphabet> list131;
+    private List<Alphabet> list132;
+    private List<Alphabet> list133;
+    private List<Alphabet> list134;
+    private List<Alphabet> list135;
+    private List<Alphabet> list136;
+    private List<Alphabet> list137;
+    private List<Alphabet> list138;
+    private List<Alphabet> list139;
+    private List<Alphabet> list140;
+    private List<Alphabet> list141;
+    private List<Alphabet> list142;
+    private List<Alphabet> list143;
+    private List<Alphabet> list144;
+    private List<Alphabet> list145;
+    private List<Alphabet> list146;
+    private List<Alphabet> list147;
+    private List<Alphabet> list148;
+    private List<Alphabet> list149;
+    private List<Alphabet> list150;
+    private List<Alphabet> list151;
+    private List<Alphabet> list152;
+    private List<Alphabet> list153;
+    private List<Alphabet> list154;
+    private List<Alphabet> list155;
+    private List<Alphabet> list156;
+    private List<Alphabet> list157;
+    private List<Alphabet> list158;
+    private List<Alphabet> list159;
+    private List<Alphabet> list160;
+    private List<Alphabet> list161;
+    private List<Alphabet> list162;
+    private List<Alphabet> list163;
+
+
+    public static class Alphabet {
+        // provide by zhaiyao, for fastjson test
+        private List<Double> a;
+        private List<Double> b;
+        private List<Double> c;
+        private List<Double> d;
+        private List<Double> e;
+        private List<Double> f;
+        private List<Double> g;
+        private List<Double> h;
+        private List<Double> i;
+        private List<Double> j;
+        private List<Double> k;
+        private List<Double> l;
+        private List<Double> m;
+        private List<Double> n;
+        private List<Double> o;
+        private List<Double> p;
+        private List<Double> q;
+        private List<Double> r;
+        private List<Double> s;
+        private List<Double> t;
+        private List<Double> u;
+        private List<Double> v;
+        private List<Double> w;
+        private List<Double> x;
+        private List<Double> y;
+        private List<Double> z;
+    }
+
+}


### PR DESCRIPTION
bug报告参见 https://github.com/alibaba/fastjson/issues/2779

在此之前，如果Java bean类过大，ASMDeserializerFactory生成的字节码中
的跳转地址如果超过了signed short能表示的范围，生成的字节码中的地址
可能是负数，即

```
ifeq -32455
```

这个提交修复了该问题，使用ASM库中相同的处理方式：将ifeq转换为
ifne + goto_w语句。参见所做的变更。相应的，Label.put和Label.resolve
方法也做了改变。

提供了一个测试用例

#1207 和 #1092 可能也与本问题相关。