### PR TITLE
Fix issue2866(@JSONField name 不支持 private 字段)

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
@@ -1123,6 +1123,13 @@ public class JavaBeanDeserializer implements ObjectDeserializer {
                         if ((fieldModifiers & Modifier.FINAL) != 0 || (fieldModifiers & Modifier.STATIC) != 0) {
                             continue;
                         }
+                        JSONField jsonField = TypeUtils.getAnnotation(field, JSONField.class);
+                        if (jsonField != null) {
+                            String alteredFieldName = field.getAnnotation(JSONField.class).name();
+                            if (!"".equals(alteredFieldName)) {
+                                fieldName = alteredFieldName;
+                            }
+                        }
                         extraFieldDeserializers.put(fieldName, field);
                     }
                 }

--- a/src/test/java/com/alibaba/json/bvt/issue_2800/Issue2866.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2800/Issue2866.java
@@ -1,0 +1,28 @@
+package com.alibaba.json.bvt.issue_2800;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.parser.Feature;
+import junit.framework.TestCase;
+
+public class Issue2866 extends TestCase {
+    public void test_for_issue() throws Exception {
+        String json = "{\"A1\":1,\"A2\":2,\"A3\":3}";
+
+        A a = JSON.parseObject(json, A.class, Feature.SupportNonPublicField);
+
+        assertEquals(1, a.a1);
+        assertEquals(2, a.A2);
+        assertEquals(3, a.a3);
+
+    }
+
+    static class A{
+        @JSONField(name="A1")
+        int a1;
+        int A2;
+        @JSONField(name="A3")
+        public int a3;
+    }
+}


### PR DESCRIPTION
#2866 
原因是开启SupportNonPublicField特性后，会创建extraFieldDeserializers这个map，用于存储非public的属性，但往里写入属性键值对时使用的是初始的属性名，而不是JSONField上配置的名字，导致后面从map里取值的时候取不到