### PR TITLE
fixed issue2721 JSONPath 不能根据中文key取值过滤

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/IOUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/IOUtils.java
@@ -369,7 +369,7 @@ public class IOUtils {
     }
 
     public static boolean firstIdentifier(char ch) {
-        return ch < IOUtils.firstIdentifierFlags.length && IOUtils.firstIdentifierFlags[ch];
+        return (ch < IOUtils.firstIdentifierFlags.length && IOUtils.firstIdentifierFlags[ch]) || Character.isJavaIdentifierStart(ch);
     }
     
     public static boolean isIdent(char ch) {

--- a/src/test/java/com/alibaba/fastjson/parser/issue2721/Issue2721Test.java
+++ b/src/test/java/com/alibaba/fastjson/parser/issue2721/Issue2721Test.java
@@ -1,0 +1,22 @@
+package com.alibaba.fastjson.parser.issue2721;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONPath;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Issue2721Test {
+    @Test
+    public void test2721() {
+        String chineseKeyString = "[{\"名称\": \"脆皮青豆\", \"配料\": [\"豌豆\", \"棕榈油\", \"白砂糖\", \"食用盐\", \"玉米淀粉\"]}]";
+        String normalKeyString = "[{ \"name\": \"脆皮青豆\", \"配料\": [\"豌豆\", \"棕榈油\", \"白砂糖\", \"食用盐\", \"玉米淀粉\"] }]";
+
+        System.out.println(JSONPath.read(chineseKeyString, "$[名称 = '脆皮青豆']"));
+        // [{"名称":"脆皮青豆","配料":["豌豆","棕榈油","白砂糖","食用盐","玉米淀粉"]}]
+        System.out.println(JSONPath.read(normalKeyString, "$[name = '脆皮青豆']"));
+        // [{"name":"脆皮青豆","配料":["豌豆","棕榈油","白砂糖","食用盐","玉米淀粉"]}]
+
+        Assert.assertFalse("Chinese Key is NOT OK, Array length is 0!", ((JSONArray) JSONPath.read(chineseKeyString, "$[名称 = '脆皮青豆']")).isEmpty());
+        Assert.assertFalse("Chinese Key is NOT OK, Array length is 0!", ((JSONArray) JSONPath.read(normalKeyString, "$[name = '脆皮青豆']")).isEmpty());
+    }
+}


### PR DESCRIPTION
bug 见 #2721 

1. `$[名称 = '脆皮青豆']` 不能解析
2. 而`$[name = '脆皮青豆']` 能够解析

### 原因分析
通过`JSONPath#parseArrayAccessFilter(boolean acceptBracket)` 解析数组内字符串。解析path时，紧挨 **左括号`[`** 的第一个关键字，默认限制了是`A-Z`、`a-z`、`_`、`$` 这四种情况。但 `1`中的第一个是`'名'`

因此，`parseArrayAccessFilter`中，下面逻辑就进不去，`$[名称 = '脆皮青豆']` 拿不到其对应的 `StringOpSegement`，所以解析不了
```java
// omitted
if (predicateFlag || IOUtils.firstIdentifier(ch) || ch == '\\' || ch == '@') {
// omitted
```
### 解决方案：
将 `IOUtils.firstIdentifier(ch) `功能扩充，使之能够支持中文。通过find usage，该 `firstIdentifier` method就只在`parseArrayAccessFilter`一处使用过，暂未发现其他异常