### PR TITLE
加入getStringValue方法，业务中界面显示经常用到getString方法，不用每次都写过滤null值

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONObject.java
+++ b/src/main/java/com/alibaba/fastjson/JSONObject.java
@@ -321,6 +321,16 @@ public class JSONObject extends JSON implements Map<String, Object>, Cloneable, 
         return value.toString();
     }
 
+	public String getStringValue(String key) {
+        String value = getString(key);
+
+        if (value == null) {
+            return "";
+        }
+
+        return value;
+    }
+
     public Date getDate(String key) {
         Object value = get(key);
 


### PR DESCRIPTION
渲染界面用到JSONObject的getString方法，当JSONObject调用getString方法取值为空时在界面上显示null非常不美观，每次都得在外面再包一层判断null，非常不方便