### PR TITLE
fix bug: format error for long byte[] serialization when SerializerFe…

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
@@ -626,30 +626,6 @@ public final class SerializeWriter extends Writer {
     public void writeHex(byte[] bytes) {
         int newcount = count + bytes.length * 2 + 3;
         if (newcount > buf.length) {
-            if (writer != null) {
-                char[] chars = new char[bytes.length * 2 + 3];
-                int pos = 0;
-                chars[pos++] = 'x';
-                chars[pos++] = '\'';
-
-                for (int i = 0; i < bytes.length; ++i) {
-                    byte b = bytes[i];
-
-                    int a = b & 0xFF;
-                    int b0 = a >> 4;
-                    int b1 = a & 0xf;
-
-                    chars[pos++] = (char) (b0 + (b0 < 10 ? 48 : 55));
-                    chars[pos++] = (char) (b1 + (b1 < 10 ? 48 : 55));
-                }
-                chars[pos++] = '\'';
-                try {
-                    writer.write(chars);
-                } catch (IOException ex) {
-                    throw new JSONException("writeBytes error.", ex);
-                }
-                return;
-            }
             expandCapacity(newcount);
         }
 

--- a/src/test/java/com/alibaba/json/ByteArrayTest.java
+++ b/src/test/java/com/alibaba/json/ByteArrayTest.java
@@ -1,38 +1,54 @@
 package com.alibaba.json;
 
+import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONWriter;
+import com.alibaba.fastjson.parser.Feature;
+import com.alibaba.fastjson.parser.ParserConfig;
 import com.alibaba.fastjson.serializer.SerializerFeature;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
 
-class CertFile {
-    public String name;
-    public byte[] data;
-}
 
-public class ByteArrayTest {
+public class ByteArrayTest  {
 
-    public static void main(String[] args) {
-        try {
-            CertFile file = new CertFile();
-            file.name = "testname";
+    public static class CertFile {
+        public String name;
+        public byte[] data;
+    }
 
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < 2048; i++) {
-                sb.append("1");
-            }
-            file.data = sb.toString().getBytes();
+    @Test
+    public void test_0() throws Exception {
+        ParserConfig.getGlobalInstance().setAutoTypeSupport(true);
 
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            JSONWriter writer = new JSONWriter(new OutputStreamWriter(bos));
-            writer.config(SerializerFeature.WriteClassName, true);
-            writer.writeObject(file);
-            writer.flush();
+        CertFile file = new CertFile();
+        file.name = "testname";
 
-            System.out.println(bos);
-        } catch (Exception ex) {
-            ex.printStackTrace();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 2048; i++) {
+            sb.append("1");
         }
+        file.data = sb.toString().getBytes();
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        JSONWriter writer = new JSONWriter(new OutputStreamWriter(bos));
+        writer.config(SerializerFeature.WriteClassName, true);
+        writer.writeObject(file);
+        writer.flush();
+
+        System.out.println(bos);
+
+        byte[] data = bos.toByteArray();
+        Charset charset = Charset.forName("UTF-8");
+        CertFile convertFile =  (CertFile)JSON.parse(data, 0, data.length, charset.newDecoder(), Feature.AllowArbitraryCommas,
+                Feature.IgnoreNotMatch, Feature.SortFeidFastMatch, Feature.DisableCircularReferenceDetect,
+                Feature.AutoCloseSource);
+
+        Assert.assertEquals(file.name, convertFile.name);
+        Assert.assertArrayEquals(file.data, convertFile.data);
     }
 }

--- a/src/test/java/com/alibaba/json/ByteArrayTest.java
+++ b/src/test/java/com/alibaba/json/ByteArrayTest.java
@@ -1,0 +1,38 @@
+package com.alibaba.json;
+
+import com.alibaba.fastjson.JSONWriter;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+
+class CertFile {
+    public String name;
+    public byte[] data;
+}
+
+public class ByteArrayTest {
+
+    public static void main(String[] args) {
+        try {
+            CertFile file = new CertFile();
+            file.name = "testname";
+
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 2048; i++) {
+                sb.append("1");
+            }
+            file.data = sb.toString().getBytes();
+
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            JSONWriter writer = new JSONWriter(new OutputStreamWriter(bos));
+            writer.config(SerializerFeature.WriteClassName, true);
+            writer.writeObject(file);
+            writer.flush();
+
+            System.out.println(bos);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
当开启WriteClassName特性时，如果byte数组比较长，会序列化成下面这种错误的格式
x'313131...31313131'{"@type":"com.alibaba.json.CertFile","data":,"name":"testname"}

