### PR TITLE
fixed: JSONLexer#scanNumberValue() fails for double value, such as 0.5D

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/JSONLexer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONLexer.java
@@ -1561,6 +1561,10 @@ public final class JSONLexer {
             if (!negative) {
                 longValue = -longValue;
             }
+            if (ch == 'F' || ch == 'D') {
+                np++;
+                next();
+            }
         } else {
             if (!negative) {
                 longValue = -longValue;

--- a/src/test/java/com/alibaba/json/demo/Demo1.java
+++ b/src/test/java/com/alibaba/json/demo/Demo1.java
@@ -2,6 +2,7 @@ package com.alibaba.json.demo;
 
 import java.math.BigDecimal;
 
+import com.alibaba.fastjson.JSON;
 import junit.framework.TestCase;
 
 import com.alibaba.fastjson.JSONObject;
@@ -16,5 +17,16 @@ public class Demo1 extends TestCase {
 
         String text = jsonObject.toJSONString();
         System.out.println(text);
+    }
+
+    public void test_1() throws Exception {
+        String dataString = "{\"value\":0.5D}";
+        System.out.println(JSON.parse(dataString));
+        dataString = "{\"value\":5D}";
+        System.out.println(JSON.parse(dataString));
+        dataString = "{\"value\":3e5D}";
+        System.out.println(JSON.parse(dataString));
+        dataString = "{\"value\":4.5F}";
+        System.out.println(JSON.parse(dataString));
     }
 }


### PR DESCRIPTION
double value with ending flag, such as 0.5F, will cause JSONLexer#scanNumberValue() to fail.