### PR TITLE
Fix issue #2962

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
@@ -618,9 +618,11 @@ public final class JSONScanner extends JSONLexerBase {
                 if(t3 == '4' && t4 == '5') {
                     // handle some special timezones like xx:45
 
-                    if (t0 == '1' && t1 == '2') {
+                    if (t0 == '1' && (t1 == '2' || t1 == '3')) {
                         // NZ-CHAT          => +12:45
                         // Pacific/Chatham  => +12:45
+                        // NZ-CHAT          => +13:45 (DST)
+                        // Pacific/Chatham  => +13:45 (DST)
                     } else if (t0 == '0' && (t1 == '5' || t1 == '8')) {
                         // Asia/Kathmandu   => +05:45
                         // Asia/Katmandu    => +05:45
@@ -704,11 +706,7 @@ public final class JSONScanner extends JSONLexerBase {
         }
 
         if (calendar.getTimeZone().getRawOffset() != timeZoneOffset) {
-            String[] timeZoneIDs = TimeZone.getAvailableIDs(timeZoneOffset);
-            if (timeZoneIDs.length > 0) {
-                TimeZone timeZone = TimeZone.getTimeZone(timeZoneIDs[0]);
-                calendar.setTimeZone(timeZone);
-            }
+            calendar.setTimeZone(new SimpleTimeZone(timeZoneOffset, "" + timeZoneOffset));
         }
     }
 

--- a/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
@@ -706,7 +706,7 @@ public final class JSONScanner extends JSONLexerBase {
         }
 
         if (calendar.getTimeZone().getRawOffset() != timeZoneOffset) {
-            calendar.setTimeZone(new SimpleTimeZone(timeZoneOffset, "" + timeZoneOffset));
+            calendar.setTimeZone(new SimpleTimeZone(timeZoneOffset, Integer.toString(timeZoneOffset)));
         }
     }
 

--- a/src/main/java/com/alibaba/fastjson/serializer/DateCodec.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/DateCodec.java
@@ -190,7 +190,7 @@ public class DateCodec extends AbstractDateDeserializer implements ObjectSeriali
                     out.writeInt(timeZone);
                 } else if (timeZone < -9) {
                     out.write('-');
-                    out.writeInt(timeZone);
+                    out.writeInt(-timeZone);
                 } else if (timeZone < 0) {
                     out.write('-');
                     out.write('0');
@@ -199,7 +199,7 @@ public class DateCodec extends AbstractDateDeserializer implements ObjectSeriali
                 out.write(':');
                 // handles uneven timeZones 30 mins, 45 mins
                 // this would always be less than 60
-                int offSet = (int)((timeZoneF - timeZone) * 60);
+                int offSet = (int)(Math.abs(timeZoneF - timeZone) * 60);
                 out.append(String.format("%02d", offSet));
             }
 

--- a/src/test/java/com/alibaba/json/bvt/issue_2900/Issue2962.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2900/Issue2962.java
@@ -1,0 +1,48 @@
+package com.alibaba.json.bvt.issue_2900;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+
+import junit.framework.TestCase;
+
+public class Issue2962 extends TestCase {
+    private TimeZone original = TimeZone.getDefault();
+
+    @Override
+    public void tearDown () {
+        TimeZone.setDefault(original);
+        JSON.defaultTimeZone = original;
+    }
+
+    public void test_dates_different_timeZones() {
+    	for (String id : TimeZone.getAvailableIDs()) {
+    		TimeZone timeZone = TimeZone.getTimeZone(id);
+            TimeZone.setDefault(timeZone);
+            JSON.defaultTimeZone = timeZone;
+
+            Calendar cal = Calendar.getInstance();
+            Date now = cal.getTime();
+
+            VO vo = new VO();
+            vo.date = now;
+
+            String json = JSON.toJSONString(vo);
+            VO result = JSON.parseObject(json, VO.class);
+            assertEquals(vo.date, result.date);
+
+            // with iso-format
+            json = JSON.toJSONString(vo, SerializerFeature.UseISO8601DateFormat);
+    		System.out.println(id + " " + json);
+            result = JSON.parseObject(json, VO.class);
+            assertEquals(JSON.toJSONString(vo.date), JSON.toJSONString(result.date));
+    	}
+    }
+
+    public static class VO {
+        public Date date;
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/issue_2900/Issue2962.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2900/Issue2962.java
@@ -19,8 +19,8 @@ public class Issue2962 extends TestCase {
     }
 
     public void test_dates_different_timeZones() {
-    	for (String id : TimeZone.getAvailableIDs()) {
-    		TimeZone timeZone = TimeZone.getTimeZone(id);
+        for (String id : TimeZone.getAvailableIDs()) {
+            TimeZone timeZone = TimeZone.getTimeZone(id);
             TimeZone.setDefault(timeZone);
             JSON.defaultTimeZone = timeZone;
 
@@ -36,10 +36,10 @@ public class Issue2962 extends TestCase {
 
             // with iso-format
             json = JSON.toJSONString(vo, SerializerFeature.UseISO8601DateFormat);
-    		System.out.println(id + " " + json);
+            System.out.println(id + " " + json);
             result = JSON.parseObject(json, VO.class);
             assertEquals(JSON.toJSONString(vo.date), JSON.toJSONString(result.date));
-    	}
+        }
     }
 
     public static class VO {

--- a/src/test/java/com/alibaba/json/bvt/serializer/date/DateTest4_indian.java
+++ b/src/test/java/com/alibaba/json/bvt/serializer/date/DateTest4_indian.java
@@ -32,7 +32,7 @@ public class DateTest4_indian extends TestCase {
         assertEquals(-25200000, delta_4_3);
 
         long delta_5_4 = date5.getTime() - date4.getTime();
-        assertEquals(17100000, delta_5_4);
+        assertEquals(-3600000, delta_5_4);
 
     }
 


### PR DESCRIPTION
Fix issue #2962:

- Pacific/Chatham DST: add support UTC offset +13:45
- Pacific/Honolulu: fix UTC offset output
- America/St_Johns: fix UTC offset output
- Australia/Adelaide: use SimpleTimeZone instead of TimeZone.getAvailableIDs()[0]

Test case Issue2962 tested all time zones in jdk8. DSTs in northern hemisphere are also tested.