### PR TITLE
Use LinkedHashMap for deterministic iterations

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/writeClassName/WriteDuplicateType.java
+++ b/src/test/java/com/alibaba/json/bvt/writeClassName/WriteDuplicateType.java
@@ -35,13 +35,13 @@ public class WriteDuplicateType extends TestCase {
         
         LinkedHashMap<String, HashMap<String, Object>> cartMap = new LinkedHashMap<String, HashMap<String, Object>>();
         
-        HashMap<String, Object> obj = new HashMap<String, Object>();
+        HashMap<String, Object> obj = new LinkedHashMap<String, Object>();
         obj.put("id", 1001);
         obj.put(JSON.DEFAULT_TYPE_KEY, "com.alibaba.json.bvt.writeClassName.WriteDuplicateType$DianDianCart");
         cartMap.put("1001", obj);
         
         String text1 = JSON.toJSONString(cartMap, SerializerFeature.WriteClassName);
-        Assert.assertEquals("{\"@type\":\"java.util.LinkedHashMap\",\"1001\":{\"@type\":\"com.alibaba.json.bvt.writeClassName.WriteDuplicateType$DianDianCart\",\"id\":1001}}", text1);
+        Assert.assertEquals("{\"@type\":\"java.util.LinkedHashMap\",\"1001\":{\"id\":1001,\"@type\":\"com.alibaba.json.bvt.writeClassName.WriteDuplicateType$DianDianCart\"}}", text1);
         
     }
     


### PR DESCRIPTION
Tests in [WriteDuplicateType](https://github.com/alibaba/fastjson/blob/master/src/test/java/com/alibaba/json/bvt/writeClassName/WriteDuplicateType.java) tries to convert a HashMap into a JSON string and compares it with a hard-coded JSON string. The `toJSONString` operations relies on the iteration order of the HashMap. However, HashMap does not guarantee any specific order of entries. Therefore, the assertions in this test will fail if the iteration order is different. 

This PR proposes to change the HashMap to LinkedHashMap for a deterministic iteration order (same as insertion order) and also modifies the corresponding test assertions.