### PR TITLE
Enable SerializeFeature.MapSortField for deterministic order

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/jsonp/JSONPParseTest3.java
+++ b/src/test/java/com/alibaba/json/bvt/jsonp/JSONPParseTest3.java
@@ -21,7 +21,7 @@ public class JSONPParseTest3 extends TestCase {
         assertEquals(1, param.get("id"));
         assertEquals("ido)nans", param.get("name"));
 
-        String json = JSON.toJSONString(jsonpObject, SerializerFeature.BrowserSecure);
-        assertEquals("/**/parent.callback({\"name\":\"ido\\u0029nans\",\"id\":1},1,2)", json);
+        String json = JSON.toJSONString(jsonpObject, SerializerFeature.BrowserSecure, SerializerFeature.MapSortField);
+        assertEquals("/**/parent.callback({\"id\":1,\"name\":\"ido\\u0029nans\"},1,2)", json);
     }
 }


### PR DESCRIPTION
Similar to the change you already merged for `JSONPParseTest2.java`:
`test_f` in `JSONPParseTest3` parses a text to a `JSONPObject` and compares its `toJSONString` representation to a hard-coded string. However, `JSONPObject` uses a `HashMap` that does not guarantee any specific order of entries. Therefore, the assertion in the test can fail if the order differs.

This PR uses `SerializerFeature.MapSortField` to make the order deterministic and appropriately modifies the corresponding test assertion.