### PR TITLE
use LinkedHashMap for a deterministic order

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/issue_1400/Issue1480.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1400/Issue1480.java
@@ -7,12 +7,13 @@ import junit.framework.TestCase;
 import org.junit.Assert;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class Issue1480 extends TestCase {
     public void test_for_issue() throws Exception {
 
-        Map<Integer,Integer> map = new HashMap<Integer,Integer>();
+        Map<Integer,Integer> map = new LinkedHashMap<Integer,Integer>();
         map.put(1,10);
         map.put(2,4);
         map.put(3,5);


### PR DESCRIPTION
The test in com.alibaba.json.bvt.issue_1400.Issue1480#test_for_issue fails due to a different order in `Assert.assertEquals("{1:10,2:4,3:5,4:5,37306:98,36796:9}",json);`. `json` is a String initialized by `String json = JSON.toJSONString(map);`, but  `map` here is a HashMap, which makes no guarantee about the iterating order when generating a string representation of `map`. In order to get rid of this non-deterministic behavior so that the string representation becomes stable across different JVM versions, the fix is to use `LinkedHashMap` instead.
The specification about HashMap says "this class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time" and the link here is for your reference: https://docs.oracle.com/javase/8/docs/api/?java/util/HashMap.html