### PR TITLE
Make tests more stable by using JSONAssert equals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -612,6 +612,12 @@
             <version>2.1.9</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/src/test/java/com/alibaba/json/bvt/asm/SortFieldTest.java
+++ b/src/test/java/com/alibaba/json/bvt/asm/SortFieldTest.java
@@ -1,5 +1,7 @@
 package com.alibaba.json.bvt.asm;
 
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.json.JSONException;
 import org.junit.Assert;
 import junit.framework.TestCase;
 
@@ -23,7 +25,10 @@ public class SortFieldTest extends TestCase {
         Assert.assertEquals("{'f0':0,'f1':0,'f10':0,'f11':0,'f12':0,'f13':0,'f14':0,'f2':0,'f3':0,'f4':0,'f5':0,'f6':0,'f7':0,'f8':0,'f9':0}", text);
 
     }
-    
+
+    public static void assertJSONEqual(String s1, String s2) throws JSONException{
+        JSONAssert.assertEquals(s1, s2, false);
+    }
 public void test_1() throws Exception {
     V1 entity = new V1();
 
@@ -32,11 +37,11 @@ public void test_1() throws Exception {
 
     // 按字段顺序输出
     // {"f1":0,"f2":0,"f3":0,"f4":0,"f5":0} 
-    Assert.assertEquals("{\"f1\":0,\"f2\":0,\"f3\":0,\"f4\":0,\"f5\":0}", text);
+    assertJSONEqual("{\"f1\":0,\"f2\":0,\"f3\":0,\"f4\":0,\"f5\":0}", text);
 
     JSONObject object = JSON.parseObject(text);
     text = JSON.toJSONString(object, SerializerFeature.SortField);
-    Assert.assertEquals("{\"f1\":0,\"f2\":0,\"f3\":0,\"f4\":0,\"f5\":0}", text);
+    assertJSONEqual("{\"f1\":0,\"f2\":0,\"f3\":0,\"f4\":0,\"f5\":0}", text);
 
 }
 

--- a/src/test/java/com/alibaba/json/bvt/issue_1900/Issue1972.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1900/Issue1972.java
@@ -3,6 +3,7 @@ package com.alibaba.json.bvt.issue_1900;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.JSONPath;
+import com.alibaba.json.bvt.asm.SortFieldTest;
 import junit.framework.TestCase;
 
 public class Issue1972 extends TestCase {
@@ -20,6 +21,6 @@ public class Issue1972 extends TestCase {
         jsonObject.put("a", a);
         JSONPath.arrayAdd(jsonObject,"$.a.b[c = '2018-04'].d", obj);
 
-        assertEquals("{\"a\":{\"b\":{\"c\":\"2018-04\",\"d\":[123]}}}", jsonObject.toString());
+        SortFieldTest.assertJSONEqual("{\"a\":{\"b\":{\"c\":\"2018-04\",\"d\":[123]}}}", jsonObject.toString());
     }
 }


### PR DESCRIPTION
`test_1` in `SortFieldTest` parses a text to a `JSONObject` and compares its `toJSONString `representation to a hard-coded string. However, the JSON results can contain entries in any order. `test_for_issue` in `Issue1972` compares stringily results with hard-coded string. The underlying `toString` method actually depends on `java.lang.Class.getDeclaredFields`. However, the order of this API is not guaranteed so the JSON result also can contain entries in any order. Thus, tests may fail or pass without any changes made to the source code.


This PR proposes to use JSONAssert and modify the corresponding JSON test assertions so that the test is more stable.