### PR TITLE
Use LinkedHashMap for deterministic order in Issue1177_2.java

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/issue_1100/Issue1177_2.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1100/Issue1177_2.java
@@ -6,6 +6,7 @@ import com.alibaba.fastjson.JSONPath;
 import com.alibaba.fastjson.TypeReference;
 import junit.framework.TestCase;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -14,7 +15,7 @@ import java.util.Map;
 public class Issue1177_2 extends TestCase {
     public void test_for_issue() throws Exception {
         String text = "{\"a\":{\"x\":\"y\"},\"b\":{\"x\":\"y\"}}";
-        Map<String, Model> jsonObject = JSONObject.parseObject(text, new TypeReference<Map<String, Model>>(){});
+        Map<String, Model> jsonObject = JSONObject.parseObject(text, new TypeReference<LinkedHashMap<String, Model>>(){});
         System.out.println(JSON.toJSONString(jsonObject));
         String jsonpath = "$..x";
         String value="y2";


### PR DESCRIPTION
The test in `com.alibaba.json.bvt.issue_1100.Issue1177_2#test_for_issue` can fail due to a different order. The assertion compares a hard-coded string against the string representation of a JSON object implemented by `HashMap`. The failure is presented as follows:
`junit.framework.ComparisonFailure`: 
expected:`<{"a":{"x":"y2"},"b":{"x":"y2"}}>`
but was:   `<{"b":{"x":"y2"},"a":{"x":"y2"}}>`

The reason is that HashMap makes no guarantee about the iteration order. The specification about HashMap says that "this class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time". The documentation is here for your reference: https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html

The fix is to change HashMap into LinkedHashMap. In this way, we can get rid of the non-deterministic behaviour and make the test more stable.