### PR TITLE
Use JSONAssert.assertEquals for more robust comparison

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -612,6 +612,13 @@
             <version>2.1.9</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/src/test/java/com/alibaba/json/bvt/issue_2100/Issue2182.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2100/Issue2182.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson.JSON;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import junit.framework.TestCase;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 public class Issue2182 extends TestCase {
     public void test_for_issue() throws Exception {
@@ -15,11 +16,11 @@ public class Issue2182 extends TestCase {
         multimap.put("user", "user.delete");
 
         String json = JSON.toJSONString(multimap);
-        assertEquals("{\"admin\":[\"admin.create\",\"admin.update\",\"admin.delete\"],\"user\":[\"user.create\",\"user.delete\"]}", json);
+        JSONAssert.assertEquals("{\"admin\":[\"admin.create\",\"admin.update\",\"admin.delete\"],\"user\":[\"user.create\",\"user.delete\"]}", json, false);
 
         ArrayListMultimap multimap1 = JSON.parseObject(json, ArrayListMultimap.class);
 
         assertEquals(multimap.size(), multimap1.size());
-        assertEquals(json, JSON.toJSONString(multimap1));
+        JSONAssert.assertEquals(json, JSON.toJSONString(multimap1), false);
     }
 }


### PR DESCRIPTION
Test `com.alibaba.json.bvt.issue_2100.Issue2182#test_for_issue` can fail due to non-deterministic iteration of `Multimap` when translating into a JSON string, specifically the order of fields `admin` and `user` can differ. One can ignore the order of these fields using [JSONAssert.assertEquals](https://github.com/skyscreamer/JSONassert) (with parameter `false`).

Do you want to add to your project something like `JSONAssert.assertEquals` to compare JSON strings by ignoring order of fields? If you want this, we can send more fixes for similar tests. If you don't like this, please let us know how you want us to change it.