### PR TITLE
Fix issue3079（JSONValidator直接返回False）

### DIFF
--- a/src/test/java/com/wheelchair/validate/JSONValidatorTest.java
+++ b/src/test/java/com/wheelchair/validate/JSONValidatorTest.java
@@ -14,112 +14,62 @@ public class JSONValidatorTest {
 
     @Test
     public void validate_test_accurate() throws Throwable {
-        boolean thrown = false;
-        try {
-            JSONValidator.from("{\"string\":\"a\",\"nums\":[0,-1,10,0.123,1e5,-1e+6,0.1e-7],\"object\":{\"empty\":{},\"list\":[]},\"list\":[\"object\",{\"true\":true,\"false\":false,\"null\":null}]}").validate();
-        } catch (JSONException e) {
-            thrown = true;
-        }
-        assertFalse(thrown);
+        boolean isValidate = JSONValidator.from("{\"string\":\"a\",\"nums\":[0,-1,10,0.123,1e5,-1e+6,0.1e-7],\"object\":{\"empty\":{},\"list\":[]},\"list\":[\"object\",{\"true\":true,\"false\":false,\"null\":null}]}").validate();
+        assertTrue(isValidate);
     }
 
     @Test
     public void validate_test_quotation() throws Throwable {
-        boolean thrown = false;
-        try {
-            JSONValidator.from("{noQuotationMarksError}").validate();
-        } catch (JSONException e) {
-            thrown = true;
-        }
-        assertTrue(thrown);
+        boolean isValidate = JSONValidator.from("{noQuotationMarksError}").validate();
+        assertFalse(isValidate);
     }
 
     @Test
     public void validate_test_colon() throws Throwable {
-        boolean thrown = false;
-        try {
-            JSONValidator.from("{\"colonError\"}").validate();
-        } catch (JSONException e) {
-            thrown = true;
-        }
-        assertTrue(thrown);
+        boolean isValidate = JSONValidator.from("{\"colonError\"}").validate();
+        assertFalse(isValidate);
 
     }
 
     @Test
     public void validate_test_bracket() throws Throwable {
-        boolean thrown = false;
-        try {
-            JSONValidator.from("[1}").validate();
-        } catch (JSONException e) {
-            thrown = true;
-        }
-        assertTrue(thrown);
+        boolean isValidate = JSONValidator.from("[1}").validate();
+        assertFalse(isValidate);
     }
 
     @Test
     public void validate_test_num1() throws Throwable {
-        boolean thrown = false;
-        try {
-            JSONValidator.from("-a").validate();
-        } catch (JSONException e) {
-            thrown = true;
-        }
-        assertTrue(thrown);
+        boolean isValidate = JSONValidator.from("-a").validate();
+        assertFalse(isValidate);
     }
 
     @Test
     public void validate_test_num2() throws Throwable {
-        boolean thrown = false;
-        try {
-            JSONValidator.from("1.a1").validate();
-        } catch (JSONException e) {
-            thrown = true;
-        }
-        assertTrue(thrown);
+        boolean isValidate = JSONValidator.from("1.a1").validate();
+        assertFalse(isValidate);
     }
 
     @Test
     public void validate_test_num3() throws Throwable {
-        boolean thrown = false;
-        try {
-            JSONValidator.from("1.e1").validate();
-        } catch (JSONException e) {
-            thrown = true;
-        }
-        assertTrue(thrown);
+        boolean isValidate = JSONValidator.from("1.e1").validate();
+        assertFalse(isValidate);
     }
 
     @Test
     public void validate_test_num4() throws Throwable {
-        boolean thrown = false;
-        try {
-            JSONValidator.from("+1").validate();
-        } catch (JSONException e) {
-            thrown = true;
-        }
-        assertTrue(thrown);
+        boolean isValidate = JSONValidator.from("+1").validate();
+        assertFalse(isValidate);
     }
 
     @Test
     public void validate_test_num5() throws Throwable {
-        boolean thrown = false;
-        try {
-            JSONValidator.from("1ea").validate();
-        } catch (JSONException e) {
-            thrown = true;
-        }
-        assertTrue(thrown);
+        boolean isValidate = JSONValidator.from("1ea").validate();
+        assertFalse(isValidate);
     }
 
     @Test
     public void validate_test_tfn() throws Throwable {
-        boolean thrown = false;
-        try {
-            JSONValidator.from("trua").validate();
-        } catch (JSONException e) {
-            thrown = true;
-        }
-        assertTrue(thrown);
+        boolean isValidate = JSONValidator.from("trua").validate();
+        assertFalse(isValidate);
     }
 }


### PR DESCRIPTION
closes #3079 
修改了JSONValidatorAPI的行为，当json字符串不符合要求时`validator()`方法不再抛出异常，而是返回false，更符合正常人的思维逻辑