### PR TITLE
Use LinkedHashSet for deterministic order in Bug_for_smoothrat6.java

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/CollectionCodec.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/CollectionCodec.java
@@ -55,7 +55,7 @@ public class CollectionCodec implements ObjectSerializer, ObjectDeserializer {
         serializer.setContext(context, object, fieldName, 0);
 
         if (out.isEnabled(SerializerFeature.WriteClassName)) {
-            if (HashSet.class == collection.getClass()) {
+            if (HashSet.class.isAssignableFrom(collection.getClass())) {
                 out.append("Set");
             } else if (TreeSet.class == collection.getClass()) {
                 out.append("TreeSet");

--- a/src/test/java/com/alibaba/json/bvt/bug/Bug_for_smoothrat6.java
+++ b/src/test/java/com/alibaba/json/bvt/bug/Bug_for_smoothrat6.java
@@ -1,6 +1,6 @@
 package com.alibaba.json.bvt.bug;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.junit.Assert;
@@ -12,7 +12,7 @@ import com.alibaba.fastjson.serializer.SerializerFeature;
 public class Bug_for_smoothrat6 extends TestCase {
 
     public void test_set() throws Exception {
-        Set<Object> set = new HashSet<Object>();
+        Set<Object> set = new LinkedHashSet<Object>();
         set.add(3L);
         set.add(4L);
 


### PR DESCRIPTION
The test in `com.alibaba.json.bvt.bug.Bug_for_smoothrat6#test_set`  can fail due to a different order. The assertion compares a hard-coded string with a string representation returned by `JSON.toJSONString(entity, SerializerFeature.WriteClassName);`.  
The test can cause failure as follows:
`{"@ type":"com.alibaba.json.bvt.bug.Bug_for_smoothrat6$Entity","value":Set[4L,3L]}
org.junit.ComparisonFailure: ` 
`expected:<...Entity","value":Set[3L,4L]}> `
`but was:  <...Entity","value":Set[4L,3L]}>`

The reason is that it uses a `HashSet` internally. The stack trace of how of the `HashSet`'s iteration is invoked is presented here:
`com.alibaba.fastjson.serializer.CollectionCodec.write(CollectionCodec.java:68)
com.alibaba.fastjson.serializer.JSONSerializer.writeWithFieldName(JSONSerializer.java:333)
com.alibaba.fastjson.serializer.ASMSerializer_1_Entity.writeNormal(Unknown Source)
com.alibaba.fastjson.serializer.ASMSerializer_1_Entity.write(Unknown Source)
com.alibaba.fastjson.serializer.JSONSerializer.write(JSONSerializer.java:285)
com.alibaba.fastjson.JSON.toJSONString(JSON.java:663)
com.alibaba.fastjson.JSON.toJSONString(JSON.java:652)
com.alibaba.json.bvt.bug.Bug_for_smoothrat6.test_set(Bug_for_smoothrat6.java:23)`
Where the iteration is `for (Object item : collection) {` in `CollectionCodec.java`.

The specification about HashSet says that "it makes no guarantees as to the iteration order of the set; in particular, it does not guarantee that the order will remain constant over time". The documentation is here for your reference: https://docs.oracle.com/javase/8/docs/api/java/util/HashSet.html

The fix is to use `LinkedHashSet` instead of `HashSet`. Apart from that, since `HashSet.class == collection.getClass()` is `false` for 'LinkedHashSet', so the fix also changes the `==` to `isAssignableFrom`. In this way, the test will not suffer from failure any more and the code will be more stable, free of this non-deterministic behaviour.