### PR TITLE
修复问题：当时间为1970-01-01 08:00:00 时，TypeUtils.castToTimestamp 转换异常。

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -707,7 +707,8 @@ public class TypeUtils{
                 }
             }
         }
-        if(longValue <= 0){
+
+        if(longValue < 0){
             throw new JSONException("can not cast to Timestamp, value : " + value);
         }
         return new java.sql.Timestamp(longValue);

--- a/src/test/java/com/alibaba/json/bvt/parser/TypeUtilsTest.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/TypeUtilsTest.java
@@ -244,7 +244,6 @@ public class TypeUtilsTest extends TestCase {
         Assert.assertEquals(null, TypeUtils.castToTimestamp(null));
     }
 
-
     public void test_cast_to_Timestamp_1970_01_01_00_00_00() throws Exception {
         Assert.assertEquals(new Timestamp(0), TypeUtils.castToTimestamp("1970-01-01 08:00:00"));
     }

--- a/src/test/java/com/alibaba/json/bvt/parser/TypeUtilsTest.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/TypeUtilsTest.java
@@ -3,6 +3,7 @@ package com.alibaba.json.bvt.parser;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -241,6 +242,11 @@ public class TypeUtilsTest extends TestCase {
 
     public void test_cast_to_Timestamp_null2() throws Exception {
         Assert.assertEquals(null, TypeUtils.castToTimestamp(null));
+    }
+
+
+    public void test_cast_to_Timestamp_1970_01_01_00_00_00() throws Exception {
+        Assert.assertEquals(new Timestamp(0), TypeUtils.castToTimestamp("1970-01-01 08:00:00"));
     }
 
     public void test_cast_to_BigDecimal_same() throws Exception {


### PR DESCRIPTION
修复问题：当时间为1970-01-01 08:00:00 时，TypeUtils.castToTimestamp 转换异常。

测试用例通过。