### PR TITLE
支持了全局转换枚举类

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/ParserConfig.java
+++ b/src/main/java/com/alibaba/fastjson/parser/ParserConfig.java
@@ -812,7 +812,7 @@ public class ParserConfig {
                 }
             }
 
-            deserializer = new EnumDeserializer(clazz);
+            deserializer = getEnumDeserializer(clazz);
         } else if (clazz.isArray()) {
             deserializer = ObjectArrayCodec.instance;
         } else if (clazz == Set.class || clazz == HashSet.class || clazz == Collection.class || clazz == List.class
@@ -835,6 +835,17 @@ public class ParserConfig {
         putDeserializer(type, deserializer);
 
         return deserializer;
+    }
+
+    /**
+     * 可以通过重写这个方法，定义自己的枚举反序列化实现
+     * @param clazz 转换的类型
+     * @return 返回一个枚举的反序列化实现
+     * @author zhu.xiaojie
+     * @time 2020-4-5
+     */
+    protected ObjectDeserializer getEnumDeserializer(Class<?> clazz){
+        return new EnumDeserializer(clazz);
     }
 
     /**

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
@@ -513,14 +513,14 @@ public class SerializeConfig {
                 if (jsonType != null && jsonType.serializeEnumAsJavaBean()) {
                     put(clazz, writer = createJavaBeanSerializer(clazz));
                 } else {
-                    put(clazz, writer = EnumSerializer.instance);
+                    put(clazz, writer = getEnumSerializer());
                 }
             } else if ((superClass = clazz.getSuperclass()) != null && superClass.isEnum()) {
                 JSONType jsonType = TypeUtils.getAnnotation(superClass, JSONType.class);
                 if (jsonType != null && jsonType.serializeEnumAsJavaBean()) {
                     put(clazz, writer = createJavaBeanSerializer(clazz));
                 } else {
-                    put(clazz, writer = EnumSerializer.instance);
+                    put(clazz, writer = getEnumSerializer());
                 }
             } else if (clazz.isArray()) {
                 Class<?> componentType = clazz.getComponentType();
@@ -799,6 +799,16 @@ public class SerializeConfig {
             }
         }
         return writer;
+    }
+
+    /**
+     * 可以通过重写这个方法，定义自己的枚举序列化实现
+     * @return 返回一个枚举的反序列化实现
+     * @author zhu.xiaojie
+     * @time 2020-4-5
+     */
+    protected ObjectSerializer getEnumSerializer(){
+        return EnumSerializer.instance;
     }
 	
     public final ObjectSerializer get(Type type) {


### PR DESCRIPTION
现在转换枚举类，有两种方式，一种是使用注解，第二种是使用 ObjectSerializer

但是使用第二种时会有一个问题，就是必须精确到枚举的类名，不能使用它所实现的接口类，这样就会导致我整个工程中所有的枚举类，都需要在这里添加转换器，如下：

```java
serializeConfig.put("精确的类名.class" , new XXX());
serializeConfig.put("AEnum.class" , new XXX());
serializeConfig.put("BEnum.class" , new XXX());
serializeConfig.put("CEnum.class" , new XXX());
```


现在我想了一种新的方式，比如定义一个基本接口，如下

```java
interface BaseEnum{
   String getCode();
}
```
然后需要转换的枚举实现这个接口，然后就可以 `serializeConfig.put(BaseEnum.class , new XXX())` ， 这样就不需要把所有的枚举类型全部写一遍了，一条配置，就可以定义所有的转换类型。

**但是原有代码里面的是写死的，而且有一些变量是private，该方法无法重写，所以提取了这个部分代码**


详情查看代码，就改了几行代码，不到十行

