### PR TITLE
Update an inconsistent name

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONArray.java
+++ b/src/main/java/com/alibaba/fastjson/JSONArray.java
@@ -444,7 +444,7 @@ public class JSONArray extends JSON implements List<Object>, Cloneable, RandomAc
     /**
      * @since  1.2.23
      */
-    public <T> List<T> toJavaList(Class<T> clazz) {
+    public <T> List<T> getJavaList(Class<T> clazz) {
         List<T> list = new ArrayList<T>(this.size());
 
         ParserConfig config = ParserConfig.getGlobalInstance();

--- a/src/main/java/com/alibaba/fastjson/JSONWriter.java
+++ b/src/main/java/com/alibaba/fastjson/JSONWriter.java
@@ -145,7 +145,7 @@ public class JSONWriter implements Closeable, Flushable {
         }
     }
 
-    private void afterWriter() {
+    private void afterWrite() {
         if (context == null) {
             return;
         }


### PR DESCRIPTION
During the work, I just found that one method name may not good. The original name is toJavaList, but all other names in the same class follow the structure like get<>. So in order to make it consistent for the whole class, I suggest changing the original name to getJavaList. And also, the new name can also catch the meaning of changing a class into a java list.