### PR TITLE
fix issue #2065

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/EnumDeserializer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/EnumDeserializer.java
@@ -121,7 +121,7 @@ public class EnumDeserializer implements ObjectDeserializer {
                 int intValue = lexer.intValue();
                 lexer.nextToken(JSONToken.COMMA);
 
-                if (intValue < 0 || intValue > ordinalEnums.length) {
+                if (intValue < 0 || intValue >= ordinalEnums.length) {
                     throw new JSONException("parse enum " + enumClass.getName() + " error, value : " + intValue);
                 }
 

--- a/src/test/java/com/alibaba/json/bvt/issue_2000/Issue2065.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_2000/Issue2065.java
@@ -1,12 +1,43 @@
 package com.alibaba.json.bvt.issue_2000;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.annotation.JSONField;
 import junit.framework.TestCase;
+import org.junit.Test;
 
 public class Issue2065 extends TestCase {
+
     public void test_for_issue() throws Exception {
-        // JSON.parseObject("{\"code\":1}", Model.class);
+        Exception error = null;
+        try {
+            JSON.parseObject("{\"code\":1}", Model.class);
+        } catch (JSONException e) {
+            error = e;
+        }
+        assertNotNull(error);
+        error.printStackTrace();
+    }
+
+    public void test_for_issue_01() {
+        Exception error = null;
+        try {
+            JSON.parseObject("1", EnumClass.class);
+        } catch (JSONException e) {
+            error = e;
+        }
+        assertNotNull(error);
+        error.printStackTrace();
+    }
+
+    @Test
+    public void test_for_issue_02() {
+        JSON.parseObject("0", EnumClass.class);
+    }
+
+    @Test
+    public void test_for_issue_03() {
+        JSON.parseObject("{\"code\":0}", Model.class);
     }
 
     public static class Model {


### PR DESCRIPTION
反序列化枚举字段时, 当枚举值(enum value)为边界值(枚举值==枚举个数),  
枚举反序列化器(EnumDeserializer)中会出现数组 ordinalEnums越界 (128行)