### PR TITLE
Fix issue 3132 包名为中文的时候toJSONString会有异常

### DIFF
--- a/src/main/java/com/alibaba/fastjson/asm/ByteVector.java
+++ b/src/main/java/com/alibaba/fastjson/asm/ByteVector.java
@@ -185,7 +185,7 @@ public class ByteVector {
 		data[len++] = (byte) charLength;
 		for (int i = 0; i < charLength; ++i) {
 			final char c = s.charAt(i);
-			if (c >= '\001' && c <= '\177') {
+			if ((c >= '\001' && c <= '\177') || (c >= '\u4E00' && c <= '\u9FFF')) {
 				data[len++] = (byte) c;
 			} else {
 				throw new UnsupportedOperationException();

--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
@@ -510,18 +510,18 @@ public class JavaBeanDeserializer implements ObjectDeserializer {
             String typeKey = beanInfo.typeKey;
             for (int fieldIndex = 0, notMatchCount = 0;; fieldIndex++) {
                 String key = null;
-                FieldDeserializer fieldDeser = null;
+                FieldDeserializer fieldDeserializer = null;
                 FieldInfo fieldInfo = null;
                 Class<?> fieldClass = null;
-                JSONField feildAnnotation = null;
-                boolean customDeserilizer = false;
+                JSONField fieldAnnotation = null;
+                boolean customDeserializer = false;
                 if (fieldIndex < sortedFieldDeserializers.length && notMatchCount < 16) {
-                    fieldDeser = sortedFieldDeserializers[fieldIndex];
-                    fieldInfo = fieldDeser.fieldInfo;
+                    fieldDeserializer = sortedFieldDeserializers[fieldIndex];
+                    fieldInfo = fieldDeserializer.fieldInfo;
                     fieldClass = fieldInfo.fieldClass;
-                    feildAnnotation = fieldInfo.getAnnotation();
-                    if (feildAnnotation != null && fieldDeser instanceof DefaultFieldDeserializer) {
-                        customDeserilizer = ((DefaultFieldDeserializer) fieldDeser).customDeserilizer;
+                    fieldAnnotation = fieldInfo.getAnnotation();
+                    if (fieldAnnotation != null && fieldDeserializer instanceof DefaultFieldDeserializer) {
+                        customDeserializer = ((DefaultFieldDeserializer) fieldDeserializer).customDeserilizer;
                     }
                 }
 
@@ -529,9 +529,9 @@ public class JavaBeanDeserializer implements ObjectDeserializer {
                 boolean valueParsed = false;
                 
                 Object fieldValue = null;
-                if (fieldDeser != null) {
+                if (fieldDeserializer != null) {
                     char[] name_chars = fieldInfo.name_chars;
-                    if (customDeserilizer && lexer.matchField(name_chars)) {
+                    if (customDeserializer && lexer.matchField(name_chars)) {
                         matchField = true;
                     } else if (fieldClass == int.class || fieldClass == Integer.class) {
                         int intVal = lexer.scanFieldInt(name_chars);
@@ -651,10 +651,10 @@ public class JavaBeanDeserializer implements ObjectDeserializer {
                         }
                     } else if (fieldClass.isEnum() // 
                             && parser.getConfig().getDeserializer(fieldClass) instanceof EnumDeserializer
-                            && (feildAnnotation == null || feildAnnotation.deserializeUsing() == Void.class)
+                            && (fieldAnnotation == null || fieldAnnotation.deserializeUsing() == Void.class)
                             ) {
-                        if (fieldDeser instanceof DefaultFieldDeserializer) {
-                            ObjectDeserializer fieldValueDeserilizer = ((DefaultFieldDeserializer) fieldDeser).fieldValueDeserilizer;
+                        if (fieldDeserializer instanceof DefaultFieldDeserializer) {
+                            ObjectDeserializer fieldValueDeserilizer = ((DefaultFieldDeserializer) fieldDeserializer).fieldValueDeserilizer;
                             fieldValue = this.scanEnum(lexer, name_chars, fieldValueDeserilizer);
 
                             if (lexer.matchStat > 0) {
@@ -835,7 +835,7 @@ public class JavaBeanDeserializer implements ObjectDeserializer {
 
                 if (matchField) {
                     if (!valueParsed) {
-                        fieldDeser.parseField(parser, object, type, fieldValues);
+                        fieldDeserializer.parseField(parser, object, type, fieldValues);
                     } else {
                         if (object == null) {
                             fieldValues.put(fieldInfo.name, fieldValue);
@@ -846,10 +846,10 @@ public class JavaBeanDeserializer implements ObjectDeserializer {
                                     && fieldClass != double.class //
                                     && fieldClass != boolean.class //
                                     ) {
-                                fieldDeser.setValue(object, fieldValue);
+                                fieldDeserializer.setValue(object, fieldValue);
                             }
                         } else {
-                            fieldDeser.setValue(object, fieldValue);
+                            fieldDeserializer.setValue(object, fieldValue);
                         }
 
                         if (setFlags != null) {

--- a/src/test/java/com/alibaba/json/bvt/issue_3000/Issue3132.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3000/Issue3132.java
@@ -1,0 +1,16 @@
+package com.alibaba.json.bvt.issue_3000;
+
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.json.bvtVO.一个中文名字的包.User;
+import junit.framework.TestCase;
+
+public class Issue3132 extends TestCase {
+
+    public void test_for_issue() throws Exception {
+        User user = new User();
+        user.setId(9);
+        user.setName("asdffsf");
+        System.out.println(JSONObject.toJSONString(user));
+    }
+
+}

--- a/src/test/java/com/alibaba/json/bvtVO/一个中文名字的包/User.java
+++ b/src/test/java/com/alibaba/json/bvtVO/一个中文名字的包/User.java
@@ -1,0 +1,18 @@
+package com.alibaba.json.bvtVO.一个中文名字的包;
+
+public class User {
+    Integer id ;
+    String name;
+    public Integer getId() {
+        return id;
+    }
+    public void setId(Integer id) {
+        this.id = id;
+    }
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
fix #3132 

由于`com.alibaba.fastjson.asm.ByteVector#putUTF8`在判断char的值的时候, 只判断了c >= '\001' && c <= '\177'的情况, 导致中文路径传入后解析发现不在这个范围内, 中文包名虽然不符合代码规范, 但是编译不会报错, 因此在这里对所有中文字符做了补充支持, 使得包名为中文的情况下依旧可以正常调用相应API