### PR TITLE
issue 3083 bug fix and fix typo

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
@@ -756,7 +756,7 @@ public class JavaBeanInfo {
             List<String> getMethodNameList = null;
 
             if (kotlin) {
-                getMethodNameList = new ArrayList<>();
+                getMethodNameList = new ArrayList();
                 for (int i = 0; i < methods.length; i++) {
                     if (methods[i].getName().startsWith("get")) {
                         getMethodNameList.add(methods[i].getName());

--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -1866,7 +1866,7 @@ public class TypeUtils{
             if(annotation == null && kotlin){
                 if(constructors == null){
                     constructors = clazz.getDeclaredConstructors();
-                    Constructor creatorConstructor = TypeUtils.getKoltinConstructor(constructors);
+                    Constructor creatorConstructor = TypeUtils.getKotlinConstructor(constructors);
                     if(creatorConstructor != null){
                         paramAnnotationArrays = TypeUtils.getParameterAnnotations(creatorConstructor);
                         paramNames = TypeUtils.getKoltinConstructorParameters(clazz);
@@ -2915,11 +2915,11 @@ public class TypeUtils{
         return kotlin_metadata != null && clazz.isAnnotationPresent(kotlin_metadata);
     }
 
-    public static Constructor getKoltinConstructor(Constructor[] constructors){
-        return getKoltinConstructor(constructors, null);
+    public static Constructor getKotlinConstructor(Constructor[] constructors){
+        return getKotlinConstructor(constructors, null);
     }
 
-    public static Constructor getKoltinConstructor(Constructor[] constructors, String[] paramNames){
+    public static Constructor getKotlinConstructor(Constructor[] constructors, String[] paramNames){
         Constructor creatorConstructor = null;
         for(Constructor<?> constructor : constructors){
             Class<?>[] parameterTypes = constructor.getParameterTypes();

--- a/src/test/java/com/alibaba/json/bvt/issue_3000/Issue3083.kt
+++ b/src/test/java/com/alibaba/json/bvt/issue_3000/Issue3083.kt
@@ -1,0 +1,18 @@
+package com.alibaba.json.bvt.issue_3000
+
+import com.alibaba.fastjson.JSON
+
+class TestBean {
+    var is_subscribe = 0
+    var subscribe = 0
+    var isHave = 0
+    var _have = 0
+    var normal = 0
+    var Abnormal = 0
+}
+
+fun main(args: Array<String>) {
+    val s = "{'is_subscribe':1,'subscribe':2,'isHave':3, '_have':4, 'normal':5, 'Abnormal':6}"
+    val b = JSON.parseObject(s, TestBean::class.java)
+    println("${b.is_subscribe}--${b.subscribe}--${b.isHave}--${b._have}--${b.normal}--${b.Abnormal}")
+}


### PR DESCRIPTION
fix #3083 

由于kotlin是弱类型语言, 如果在对kotlin bean的fieldName进行解析判断的时候如果用Java的一套解析方法去做的话就会出现issue中的问题, 因此这里针对kotlin进行了kotlin的bean的field解析的增强, 思路主要是通过分析kotlin bean经过java反射之后, 不同格式的名称会有不同类型的get/set方法, 通过这些方法来进行fieldName的推断, 以此来推测出正确的fieldName

字段名称 | set方法名 | get方法名
-- | -- | --
abc | setAbc | getAbc
_abc | set_abc | get_abc
is_abc | set_abc | is_abc
isAbc | setAbc | isAbc


