### PR TITLE
Fix: 501 HTTPS Required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ https://github.com/eishay/jvm-serializers/wiki
 - [maven][1]
 - [the latest JAR][2]
 
-[1]: http://repo1.maven.org/maven2/com/alibaba/fastjson/
+[1]: https://repo1.maven.org/maven2/com/alibaba/fastjson/
 [2]: https://search.maven.org/remote_content?g=com.alibaba&a=fastjson&v=LATEST
 
 ## Maven


### PR DESCRIPTION
501 HTTPS Required. 
Use https://repo1.maven.org/maven2/
More information at https://links.sonatype.com/central/501-https-required