### PR TITLE
fix #3160 save encode bytes buf to thread local

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
@@ -452,6 +452,7 @@ public final class SerializeWriter extends Writer {
             bytes = new byte[1024 * 8];
             bytesBufLocal.set(bytes);
         }
+        byte[] bytesLocal = bytes;
 
         if (bytes.length < bytesLength) {
             bytes = new byte[bytesLength];
@@ -459,6 +460,11 @@ public final class SerializeWriter extends Writer {
 
         int position = IOUtils.encodeUTF8(buf, 0, count, bytes);
         out.write(bytes, 0, position);
+
+        if (bytes!=bytesLocal && bytes.length <= BUFFER_THRESHOLD) {
+            bytesBufLocal.set(bytes);
+        }
+
         return position;
     }
     
@@ -470,6 +476,7 @@ public final class SerializeWriter extends Writer {
             bytes = new byte[1024 * 8];
             bytesBufLocal.set(bytes);
         }
+        byte[] bytesLocal = bytes;
 
         if (bytes.length < bytesLength) {
             bytes = new byte[bytesLength];
@@ -478,6 +485,11 @@ public final class SerializeWriter extends Writer {
         int position = IOUtils.encodeUTF8(buf, 0, count, bytes);
         byte[] copy = new byte[position];
         System.arraycopy(bytes, 0, copy, 0, position);
+
+        if (bytes!=bytesLocal && bytes.length <= BUFFER_THRESHOLD) {
+            bytesBufLocal.set(bytes);
+        }
+
         return copy;
     }
     

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
@@ -461,7 +461,7 @@ public final class SerializeWriter extends Writer {
         int position = IOUtils.encodeUTF8(buf, 0, count, bytes);
         out.write(bytes, 0, position);
 
-        if (bytes!=bytesLocal && bytes.length <= BUFFER_THRESHOLD) {
+        if (bytes != bytesLocal && bytes.length <= BUFFER_THRESHOLD) {
             bytesBufLocal.set(bytes);
         }
 
@@ -486,7 +486,7 @@ public final class SerializeWriter extends Writer {
         byte[] copy = new byte[position];
         System.arraycopy(bytes, 0, copy, 0, position);
 
-        if (bytes!=bytesLocal && bytes.length <= BUFFER_THRESHOLD) {
+        if (bytes != bytesLocal && bytes.length <= BUFFER_THRESHOLD) {
             bytesBufLocal.set(bytes);
         }
 

--- a/src/test/java/com/alibaba/fastjson/serializer/SerializeWriterToBytesTest.java
+++ b/src/test/java/com/alibaba/fastjson/serializer/SerializeWriterToBytesTest.java
@@ -1,0 +1,66 @@
+package com.alibaba.fastjson.serializer;
+
+import com.alibaba.fastjson.util.IOUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+/**
+ * @author gongdewei 2020/5/15
+ */
+public class SerializeWriterToBytesTest {
+
+    /**
+     * Execute toBytes periodically, use tools to analyze JVM memory allocation.
+     * For example, Memory Allocation Record of YourKit java profiler
+     */
+    public static void testLargeStrToBytes() {
+        String str = createTestStr();
+        for (int i = 0; i < 600; i++) {
+            SerializeWriter writer = new SerializeWriter();
+            try {
+                writer.writeString(str);
+                writer.toBytes("UTF-8");
+            } finally {
+                writer.close();
+            }
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+            }
+        }
+    }
+
+    public static void testLargeStrWriteToEx() throws IOException {
+        String str = createTestStr();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(str.length()+2);
+        for (int i = 0; i < 600; i++) {
+            SerializeWriter writer = new SerializeWriter();
+            try {
+                writer.writeString(str);
+                writer.writeToEx(baos, IOUtils.UTF8);
+            } finally {
+                writer.close();
+                baos.reset();
+            }
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+            }
+        }
+    }
+
+    private static String createTestStr() {
+        String tmp = new String(IOUtils.DIGITS);
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < 400; i++) {
+            builder.append(tmp);
+        }
+        return builder.toString();
+    }
+
+    public static void main(String[] args) throws IOException {
+        testLargeStrToBytes();
+//        testLargeStrWriteToEx();
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/issue_3100/Issue3160.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3100/Issue3160.java
@@ -1,0 +1,39 @@
+package com.alibaba.json.bvt.issue_3100;
+
+import com.alibaba.fastjson.serializer.SerializeWriter;
+import com.alibaba.fastjson.util.IOUtils;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import java.lang.reflect.Field;
+
+public class Issue3160 extends TestCase {
+
+    public void test_for_issue() throws Exception {
+        String str = createLargeBasicStr();
+        SerializeWriter writer = new SerializeWriter();
+        //写入大于12K的字符串
+        writer.writeString(str);
+        writer.writeString(str);
+        byte[] bytes = writer.toBytes("UTF-8");
+        writer.close();
+
+        //检查bytesLocal大小，如果缓存成功应该大于等于输出的bytes长度
+        Field bytesBufLocalField = SerializeWriter.class.getDeclaredField("bytesBufLocal");
+        bytesBufLocalField.setAccessible(true);
+        ThreadLocal<byte[]> bytesBufLocal = (ThreadLocal<byte[]>) bytesBufLocalField.get(null);
+        byte[] bytesLocal = bytesBufLocal.get();
+        Assert.assertNotNull("bytesLocal is null", bytesLocal);
+        Assert.assertTrue("bytesLocal is smaller than expected", bytesLocal.length >= bytes.length);
+
+    }
+
+    private String createLargeBasicStr() {
+        String tmp = new String(IOUtils.DIGITS);
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < 400; i++) {
+            builder.append(tmp);
+        }
+        return builder.toString();
+    }
+}


### PR DESCRIPTION
fix https://github.com/alibaba/fastjson/issues/3160
已经用YourKit Java Profiler验证，重复处理6k字符串，encodeToUTF8Bytes 只有copy bytes的内存消耗，encodeToUTF8 无内存分配。
注意：补丁影响到Java应用内存占用，每个worker线程增加占用一个BUFFER_THRESHOLD大小的byte array。
encodeToUTF8 超过8/3 K字符串没有使用到cache的问题还是比较严重，这个修复方案不一定符合要求，请评估是否有更加好的处理方法，是否要增加新的参数用于控制是否启用encodeToUTF8的byte buf及大小？