### PR TITLE
修复在JodaCodec中 write 指定 SerializerFeature WriteDateUseDateFormat 无效的问题 #3287

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/JodaCodec.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JodaCodec.java
@@ -441,6 +441,8 @@ public class JodaCodec implements ObjectSerializer, ContextObjectSerializer, Obj
                 if (format == null) {
                     if ((features & mask) != 0 || serializer.isEnabled(SerializerFeature.UseISO8601DateFormat)) {
                         format = formatter_iso8601_pattern;
+                    } else if (serializer.isEnabled(SerializerFeature.WriteDateUseDateFormat)) {
+                        format = JSON.DEFFAULT_DATE_FORMAT;
                     } else {
                         int millis = dateTime.getMillisOfSecond();
                         if (millis == 0) {
@@ -453,9 +455,6 @@ public class JodaCodec implements ObjectSerializer, ContextObjectSerializer, Obj
 
                 if (format != null) {
                     write(out, dateTime, format);
-                } else if (out.isEnabled(SerializerFeature.WriteDateUseDateFormat)) {
-                    //使用固定格式转化时间
-                    write(out, dateTime, JSON.DEFFAULT_DATE_FORMAT);
                 } else {
                     out.writeLong(dateTime.toDateTime(DateTimeZone.forTimeZone(JSON.defaultTimeZone)).toInstant().getMillis());
                 }


### PR DESCRIPTION
原先的代码在 JavaCodec 中在serializer.isEnabled(SerializerFeature.WriteDateUseDateFormat) 的时候 format 永远为非空，所以永远走不进 当前判断，所以JSON.DEFFAULT_DATE_FORMAT; 无法实现