### PR TITLE
bugfix for JSONValidator, fix #3293

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONValidator.java
+++ b/src/main/java/com/alibaba/fastjson/JSONValidator.java
@@ -66,7 +66,7 @@ public abstract class JSONValidator implements Cloneable {
                 }
                 continue;
             } else {
-                return false;
+                break;
             }
         }
 

--- a/src/test/java/com/alibaba/json/bvt/issue_3200/Issue3293.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3200/Issue3293.java
@@ -1,0 +1,22 @@
+package com.alibaba.json.bvt.issue_3200;
+
+import com.alibaba.fastjson.JSONValidator;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+/**
+ * @Author ：Nanqi
+ * @Date ：Created in 09:59 2020/6/24
+ */
+public class Issue3293 extends TestCase {
+    public void test_for_issue() throws Exception {
+        JSONValidator jv = JSONValidator.from("{\"a\"}");
+        Assert.assertFalse(jv.validate());
+
+        jv = JSONValidator.from("{\"a\":\"12333\"}");
+        Assert.assertTrue(jv.validate());
+
+        jv = JSONValidator.from("{}");
+        Assert.assertTrue(jv.validate());
+    }
+}


### PR DESCRIPTION
JSONValidator validate 中在正常的 解析中，在字符串结束之后，永远返回的是 false