### PR TITLE
bugfix for JSONValidator, fix #3293

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONValidator.java
+++ b/src/main/java/com/alibaba/fastjson/JSONValidator.java
@@ -58,8 +58,11 @@ public abstract class JSONValidator implements Cloneable {
             }
 
             count++;
+            if (eof) {
+                return true;
+            }
 
-            if (supportMultiValue && !eof) {
+            if (supportMultiValue) {
                 skipWhiteSpace();
                 if (eof) {
                     break;

--- a/src/test/java/com/alibaba/json/bvt/issue_3200/Issue3293.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3200/Issue3293.java
@@ -1,0 +1,27 @@
+package com.alibaba.json.bvt.issue_3200;
+
+import com.alibaba.fastjson.JSONValidator;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+/**
+ * @Author ：Nanqi
+ * @Date ：Created in 09:59 2020/6/24
+ */
+public class Issue3293 extends TestCase {
+    public void test_for_issue() throws Exception {
+        JSONValidator jv = JSONValidator.from("{\"a\"}");
+        Assert.assertFalse(jv.validate());
+
+        jv = JSONValidator.from("113{}[]");
+        jv.setSupportMultiValue(false);
+        Assert.assertFalse(jv.validate());
+        Assert.assertEquals(JSONValidator.Type.Value, jv.getType());
+
+        jv = JSONValidator.from("{\"a\":\"12333\"}");
+        Assert.assertTrue(jv.validate());
+
+        jv = JSONValidator.from("{}");
+        Assert.assertTrue(jv.validate());
+    }
+}


### PR DESCRIPTION
处理当 supportMultiValue 为 true 的时候并且 json 只为 single，则永远会为 false，所以将 eof 判断移动到判断 supportMultiValue 之前，解决该问题