### PR TITLE
Fix Issues 3277：Method Overriding generics #3277

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
@@ -484,6 +484,11 @@ public class FieldInfo implements Comparable<FieldInfo> {
     }
 
     public int compareTo(FieldInfo o) {
+        // Deal extend bridge
+        if (o.method != null && this.method != null && o.method.isBridge() && !this.method.isBridge()) {
+            return 1;
+        }
+
         if (this.ordinal < o.ordinal) {
             return -1;
         }
@@ -510,7 +515,6 @@ public class FieldInfo implements Comparable<FieldInfo> {
                 return 1;
             }
         }
-        
         boolean isSampeType = this.field != null && this.field.getType() == this.fieldClass;
         boolean oSameType = o.field != null && o.field.getType() == o.fieldClass;
         

--- a/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
@@ -485,7 +485,9 @@ public class FieldInfo implements Comparable<FieldInfo> {
 
     public int compareTo(FieldInfo o) {
         // Deal extend bridge
-        if (o.method != null && this.method != null && o.method.isBridge() && !this.method.isBridge()) {
+        if (o.method != null && this.method != null
+                && o.method.isBridge() && !this.method.isBridge()
+                && o.method.getName().equals(this.method.getName())) {
             return 1;
         }
 

--- a/src/test/java/com/alibaba/json/bvt/issue_3200/Issue3227.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3200/Issue3227.java
@@ -1,0 +1,54 @@
+package com.alibaba.json.bvt.issue_3200;
+
+import com.alibaba.fastjson.JSON;
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+/**
+ * @Author ：Nanqi
+ * @Date ：Created in 20:38 2020/6/27
+ */
+public class Issue3227 extends TestCase {
+    public void test_for_issue() {
+        String json = "{\"code\":\"123\"}";
+        if (!Child.class.getMethods()[0].getReturnType().getName().contains("Object")) {
+            System.out.println(Child.class.getMethods()[0].getReturnType().getName());
+        }
+        Child child = JSON.parseObject(json, Child.class);
+        Assert.assertNotNull(child);
+    }
+
+    static class Parent<T> {
+        protected String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        protected T code;
+
+        public T getCode() {
+            return code;
+        }
+
+        public void setCode(T code) {
+            this.code = code;
+        }
+    }
+
+    static class Child extends Parent<Integer>{
+        @Override
+        public Integer getCode() {
+            return code;
+        }
+
+        @Override
+        public void setCode(Integer code) {
+            this.code = code;
+        }
+    }
+}


### PR DESCRIPTION
1. 子类实现泛型，重写 get 和 set 方法，生成新的 method，这个没问题，确实会存在顺序上不同的情况
2. 在调用 method.invoke(object, value)，尝试多次确实会存在内转换异常
原因为com.alibaba.fastjson.util.JavaBeanInfo#add 在 method 同名比较的时候，如果先数组中历史存在的为子类，现在添加父类，在compare 会返回 -1，会将目前的值替换