### PR TITLE
Support pars Constructor & Setters

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
@@ -550,8 +550,7 @@ public class JavaBeanInfo {
                         add(fieldList, fieldInfo);
                     }
 
-                    if ((!kotlin)
-                            && !clazz.getName().equals("javax.servlet.http.Cookie")) {
+                    if (clazz.getName().equals("javax.servlet.http.Cookie")) {
                         return new JavaBeanInfo(clazz, builderClass, null, creatorConstructor, null, null, jsonType, fieldList);
                     }
                 } else {

--- a/src/test/java/com/alibaba/json/bvt/parser/ClassConstructorTest1.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/ClassConstructorTest1.java
@@ -1,0 +1,39 @@
+package com.alibaba.json.bvt.parser;
+
+import com.alibaba.fastjson.JSON;
+import junit.framework.TestCase;
+import org.springframework.util.Assert;
+
+public class ClassConstructorTest1 extends TestCase {
+    public void test_error() throws Exception {
+        String modelJSON = "{\"age\":12, \"name\":\"nanqi\"}";
+        Model model = JSON.parseObject(modelJSON, Model.class);
+        Assert.notNull(model.getName());
+    }
+
+    public static class Model {
+        public Model(int age) {
+            this.age = age;
+        }
+
+        private String name;
+
+        private int age;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        public void setAge(int age) {
+            this.age = age;
+        }
+    }
+}


### PR DESCRIPTION
反序列化时, 如果没有加 @JsonCreator 注解, 只会反序列化构造方法字段, 其他字段为空
解决方案：
在非 isInterfaceOrAbstract 的时候，最后面校验只校验javax.servlet.http.Cookie类，其他的都继续走 setter，不直接返回JavaBeanInfo