### PR TITLE
bug fixed for smartMatchField, #3312

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
@@ -1307,16 +1307,16 @@ public class JavaBeanDeserializer implements ObjectDeserializer {
             }
 
             // smartMatchHashArrayMapping
-            long smartKeyHash = TypeUtils.fnv1a_64_extract(key);
+            long smartKeyHash = TypeUtils.fnv1a_64_lower(key);
             int pos = Arrays.binarySearch(smartMatchHashArray, smartKeyHash);
             if (pos < 0) {
-                long smartKeyHash1 = TypeUtils.fnv1a_64_lower(key);
+                long smartKeyHash1 = TypeUtils.fnv1a_64_extract(key);
                 pos = Arrays.binarySearch(smartMatchHashArray, smartKeyHash1);
             }
 
             boolean is = false;
             if (pos < 0 && (is = key.startsWith("is"))) {
-                smartKeyHash = TypeUtils.fnv1a_64_lower(key.substring(2));
+                smartKeyHash = TypeUtils.fnv1a_64_extract(key.substring(2));
                 pos = Arrays.binarySearch(smartMatchHashArray, smartKeyHash);
             }
 

--- a/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
@@ -255,9 +255,9 @@ public class FieldInfo implements Comparable<FieldInfo> {
     private long nameHashCode64(String name, JSONField annotation)
     {
         if (annotation != null && annotation.name().length() != 0) {
-            return TypeUtils.fnv1a_64_extract(name);
+            return TypeUtils.fnv1a_64_lower(name);
         }
-        return TypeUtils.fnv1a_64_lower(name);
+        return TypeUtils.fnv1a_64_extract(name);
     }
 
     protected char[] genFieldNameChars() {

--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -2901,7 +2901,7 @@ public class TypeUtils{
         return Float.parseFloat(str);
     }
 
-    public static long fnv1a_64_lower(String key){
+    public static long fnv1a_64_extract(String key){
         long hashCode = 0xcbf29ce484222325L;
         for(int i = 0; i < key.length(); ++i){
             char ch = key.charAt(i);
@@ -2917,10 +2917,13 @@ public class TypeUtils{
         return hashCode;
     }
 
-    public static long fnv1a_64_extract(String key){
+    public static long fnv1a_64_lower(String key){
         long hashCode = 0xcbf29ce484222325L;
         for(int i = 0; i < key.length(); ++i){
             char ch = key.charAt(i);
+            if(ch >= 'A' && ch <= 'Z'){
+                ch = (char) (ch + 32);
+            }
             hashCode ^= ch;
             hashCode *= 0x100000001b3L;
         }

--- a/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3313.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3313.java
@@ -1,0 +1,29 @@
+package com.alibaba.json.bvt.issue_3300;
+
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.annotation.JSONField;
+import junit.framework.TestCase;
+import lombok.Data;
+import org.springframework.util.Assert;
+
+/**
+ * @Author ：Nanqi
+ * @Date ：Created in 21:54 2020/6/30
+ */
+public class Issue3313 extends TestCase {
+    public void test_for_issue() throws Exception {
+        String jsonStr = "{\"NAME\":\"nanqi\",\"age\":18}";
+        Model model = JSONObject.parseObject(jsonStr, Model.class);
+        Assert.notNull(model.getAGe());
+        Assert.notNull(model.getName());
+    }
+
+    @Data
+    static class Model {
+        @JSONField(name = "NaMe")
+        private String name;
+
+        @JSONField(name = "age")
+        private Integer aGe;
+    }
+}


### PR DESCRIPTION
原先在抽取下划线的时候把大小写转化也处理掉了，应该是大小写转化是必须的，抽取下划线才是非必须的