### PR TITLE
Support serializer return null, #3323

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -673,22 +673,14 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     }
 
     public static String toJSONString(Object object, SerializerFeature... features) {
-        return toJSONString(object, DEFAULT_GENERATE_FEATURE, features);
+        return toJSONString(object, SerializeConfig.globalInstance, null, null, DEFAULT_GENERATE_FEATURE, features);
     }
     
     /**
      * @since 1.2.11
      */
     public static String toJSONString(Object object, int defaultFeatures, SerializerFeature... features) {
-        SerializeWriter out = new SerializeWriter((Writer) null, defaultFeatures, features);
-
-        try {
-            JSONSerializer serializer = new JSONSerializer(out);
-            serializer.write(object);
-            return out.toString();
-        } finally {
-            out.close();
-        }
+        return toJSONString(object, SerializeConfig.globalInstance, null, null, defaultFeatures, features);
     }
 
     /**
@@ -753,6 +745,10 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         SerializeWriter out = new SerializeWriter(null, defaultFeatures, features);
 
         try {
+            if (out.isWriteNullOfNullObject() && object == null) {
+                return null;
+            }
+
             JSONSerializer serializer = new JSONSerializer(out, config);
             
             if (dateFormat != null && dateFormat.length() != 0) {
@@ -833,6 +829,10 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         SerializeWriter out = new SerializeWriter(null, defaultFeatures, features);
 
         try {
+            if (out.isWriteNullOfNullObject() && object == null) {
+                return null;
+            }
+
             JSONSerializer serializer = new JSONSerializer(out, config);
 
             if (dateFormat != null && dateFormat.length() != 0) {
@@ -869,6 +869,10 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         SerializeWriter out = new SerializeWriter(null, defaultFeatures, features);
 
         try {
+            if (out.isWriteNullOfNullObject() && object == null) {
+                return null;
+            }
+
             JSONSerializer serializer = new JSONSerializer(out, config);
 
             if (dateFormat != null && dateFormat.length() != 0) {

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
@@ -75,6 +75,7 @@ public final class SerializeWriter extends Writer {
     protected boolean                        writeEnumUsingName;
     protected boolean                        writeEnumUsingToString;
     protected boolean                        writeDirect;
+    protected boolean                        WriteNullOfNullObject;
 
     protected char                           keySeperator;
 
@@ -193,6 +194,7 @@ public final class SerializeWriter extends Writer {
         notWriteDefaultValue = (this.features & SerializerFeature.NotWriteDefaultValue.mask) != 0;
         writeEnumUsingName = (this.features & SerializerFeature.WriteEnumUsingName.mask) != 0;
         writeEnumUsingToString = (this.features & SerializerFeature.WriteEnumUsingToString.mask) != 0;
+        WriteNullOfNullObject = (this.features & SerializerFeature.WriteNullOfNullObject.mask) != 0;
 
         writeDirect = quoteFieldNames //
                       && (this.features & nonDirectFeatures) == 0 //
@@ -231,6 +233,10 @@ public final class SerializeWriter extends Writer {
         return notWriteDefaultValue;
     }
 
+    public boolean isWriteNullOfNullObject() {
+        return WriteNullOfNullObject;
+    }
+
     public boolean isEnabled(SerializerFeature feature) {
         return (this.features & feature.mask) != 0;
     }
@@ -242,6 +248,7 @@ public final class SerializeWriter extends Writer {
     /**
      * Writes a character to the buffer.
      */
+    @Override
     public void write(int c) {
         int newcount = count + 1;
         if (newcount > buf.length) {
@@ -318,18 +325,21 @@ public final class SerializeWriter extends Writer {
         buf = newValue;
     }
     
+    @Override
     public SerializeWriter append(CharSequence csq) {
         String s = (csq == null ? "null" : csq.toString());
         write(s, 0, s.length());
         return this;
     }
 
+    @Override
     public SerializeWriter append(CharSequence csq, int start, int end) {
         String s = (csq == null ? "null" : csq).subSequence(start, end).toString();
         write(s, 0, s.length());
         return this;
     }
 
+    @Override
     public SerializeWriter append(char c) {
         write(c);
         return this;
@@ -499,6 +509,8 @@ public final class SerializeWriter extends Writer {
         return count;
     }
 
+
+    @Override
     public String toString() {
         return new String(buf, 0, count);
     }
@@ -507,6 +519,7 @@ public final class SerializeWriter extends Writer {
      * Close the stream. This method does not release the buffer, since its contents might still be required. Note:
      * Invoking this method in this class will have no effect.
      */
+    @Override
     public void close() {
         if (writer != null && count > 0) {
             flush();
@@ -518,6 +531,7 @@ public final class SerializeWriter extends Writer {
         this.buf = null;
     }
 
+    @Override
     public void write(String text) {
         if (text == null) {
             writeNull();
@@ -795,6 +809,10 @@ public final class SerializeWriter extends Writer {
     }
 
     public void writeNull() {
+        if (isWriteNullOfNullObject()) {
+            return;
+        }
+
         write("null");
     }
     
@@ -2503,6 +2521,7 @@ public final class SerializeWriter extends Writer {
         buf[newcount - 1] = ':';
     }
 
+    @Override
     public void flush() {
         if (writer == null) {
             return;

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializerFeature.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializerFeature.java
@@ -152,7 +152,12 @@ public enum SerializerFeature {
     /**
      * @since 1.2.27
      */
-    MapSortField;
+    MapSortField,
+
+    /**
+     * @since 1.2.73
+     */
+    WriteNullOfNullObject;
 
     SerializerFeature(){
         mask = (1 << ordinal());

--- a/src/main/java/com/alibaba/fastjson/support/config/FastJsonConfig.java
+++ b/src/main/java/com/alibaba/fastjson/support/config/FastJsonConfig.java
@@ -1,6 +1,7 @@
 
 package com.alibaba.fastjson.support.config;
 
+import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.parser.Feature;
 import com.alibaba.fastjson.parser.ParserConfig;
 import com.alibaba.fastjson.parser.deserializer.ParseProcess;
@@ -52,6 +53,7 @@ public class FastJsonConfig {
      * serializerFeatures
      */
     private SerializerFeature[] serializerFeatures;
+    private int serializerFeaturesValues;
 
     /**
      * serializeFilters
@@ -92,10 +94,22 @@ public class FastJsonConfig {
                 SerializerFeature.BrowserSecure
         };
 
+        dealSerializerFeaturesValues();
         this.serializeFilters = new SerializeFilter[0];
         this.features = new Feature[0];
 
         this.writeContentLength = true;
+    }
+
+    /**
+     * Init serializerFeaturesValues
+     */
+    private void dealSerializerFeaturesValues() {
+        int featuresValue = JSON.DEFAULT_GENERATE_FEATURE;
+        for (SerializerFeature feature : serializerFeatures) {
+            featuresValue |= feature.getMask();
+        }
+        this.serializerFeaturesValues = featuresValue;
     }
 
     /**
@@ -138,6 +152,7 @@ public class FastJsonConfig {
      */
     public void setSerializerFeatures(SerializerFeature... serializerFeatures) {
         this.serializerFeatures = serializerFeatures;
+        dealSerializerFeaturesValues();
     }
 
     /**
@@ -253,5 +268,13 @@ public class FastJsonConfig {
      */
     public void setParseProcess(ParseProcess parseProcess) {
         this.parseProcess = parseProcess;
+    }
+
+    /**
+     *
+     * @return
+     */
+    public boolean isWriteNullOfNullObject() {
+        return (this.serializerFeaturesValues & SerializerFeature.WriteNullOfNullObject.mask) != 0;
     }
 }

--- a/src/main/java/com/alibaba/fastjson/support/spring/FastJsonRedisSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/FastJsonRedisSerializer.java
@@ -28,9 +28,12 @@ public class FastJsonRedisSerializer<T> implements RedisSerializer<T> {
         this.fastJsonConfig = fastJsonConfig;
     }
 
-    @Override
     public byte[] serialize(T t) throws SerializationException {
         if (t == null) {
+            if (fastJsonConfig.isWriteNullOfNullObject()) {
+                return null;
+            }
+
             return new byte[0];
         }
         try {
@@ -48,7 +51,6 @@ public class FastJsonRedisSerializer<T> implements RedisSerializer<T> {
         }
     }
 
-    @Override
     public T deserialize(byte[] bytes) throws SerializationException {
         if (bytes == null || bytes.length == 0) {
             return null;

--- a/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3323.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3323.java
@@ -1,0 +1,92 @@
+package com.alibaba.json.bvt.issue_3300;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import com.alibaba.fastjson.support.config.FastJsonConfig;
+import com.alibaba.fastjson.support.spring.FastJsonRedisSerializer;
+import junit.framework.TestCase;
+import org.junit.Before;
+
+import java.io.StringWriter;
+
+/**
+ * @Author ：Nanqi
+ * @Date ：Created in 14:21 2020/7/5
+ */
+public class Issue3323 extends TestCase {
+    private FastJsonRedisSerializer<Simple> serializer;
+
+    @Before
+    public void setUp() {
+        this.serializer = new FastJsonRedisSerializer<Simple>(Simple.class);
+        FastJsonConfig config = new FastJsonConfig();
+        config.setSerializerFeatures(SerializerFeature.WriteNullOfNullObject);
+        this.serializer.setFastJsonConfig(config);
+    }
+
+    public void test_for_issue() throws Exception {
+        // String
+        String nullString = JSON.toJSONString(null, SerializerFeature.WriteNullOfNullObject);
+        assertNull(nullString);
+
+        nullString = JSON.toJSONString(null);
+        assertEquals("null", nullString);
+
+        // bytes
+        byte[] bytes = JSON.toJSONBytes(null, SerializerFeature.WriteNullOfNullObject);
+        assertNull(bytes);
+
+        String bytesString = new String(JSON.toJSONBytes(null));
+        assertEquals("null", bytesString);
+
+        // writer
+        StringWriter writer = null;
+        try {
+            writer = new StringWriter();
+            JSON.writeJSONString(writer, null, SerializerFeature.WriteNullOfNullObject);
+            String text = writer.toString();
+            assertEquals("", text);
+        } finally {
+            writer.close();
+        }
+
+        try {
+            writer = new StringWriter();
+            JSON.writeJSONString(writer, null);
+            String text = writer.toString();
+            assertEquals("null", text);
+        } finally {
+            writer.close();
+        }
+
+        // FastJson
+        byte[] serializeSimple = serializer.serialize(null);
+        assertNull(serializeSimple);
+
+        serializer.getFastJsonConfig().setSerializerFeatures();
+        serializeSimple = serializer.serialize(null);
+        assertTrue(serializeSimple.length == 0);
+    }
+
+    static class Simple {
+        private int age;
+
+        private Integer money;
+
+        public int getAge() {
+            return age;
+        }
+
+        public void setAge(int age) {
+            this.age = age;
+        }
+
+        public Integer getMoney() {
+            return money;
+        }
+
+        public void setMoney(Integer money) {
+            this.money = money;
+        }
+    }
+}


### PR DESCRIPTION
1. SerializerFeature 增量反序列化 WriteNullOfNullObject，如果对象为 null 则返回 null
2. 去除 serializeWriter 当中部分不需要 override 的注解
2.优化 JSON 中 toJSONString 具体实现改为只剩下一个