### PR TITLE
Add test case, #3329

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3329.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3329.java
@@ -1,0 +1,38 @@
+package com.alibaba.json.bvt.issue_3300;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.util.ParameterizedTypeImpl;
+import junit.framework.TestCase;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * @Author ：Nanqi
+ * @Date ：Created in 19:40 2020/7/6
+ */
+public class Issue3329 extends TestCase {
+    public void test_for_issue() throws Exception {
+        Integer count = 0;
+        while (count < 100 * 10000) {
+            parse("{\"id\":1001,\"values\":[{}]}", User.class);
+            count++;
+        }
+        System.out.println("No OOM");
+    }
+
+    public <T> Response<T> parse(String text, Class<T> clazz) {
+        ParameterizedTypeImpl type = new ParameterizedTypeImpl(new Type[] { User.class }, null, Response.class);
+        return JSON.parseObject(text, type);
+    }
+
+    public static class Response<T> {
+
+        public long    id;
+        public List<T> values;
+    }
+
+    public static class User {
+
+    }
+}


### PR DESCRIPTION
1. IdentityHashMap.buckets 数组大小为 8192 恒定值，不管怎么样都不会一直增大
2. 在 get 的时候会二次判断 key 对象的值，所以也不存在一个反序列化器替换的问题