### PR TITLE
修改 DateCodec 判断 dateFormat 长度的逻辑

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
+++ b/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
@@ -47,6 +47,7 @@ public class DefaultJSONParser implements Closeable {
 
     private String                     dateFormatPattern  = JSON.DEFFAULT_DATE_FORMAT;
     private DateFormat                 dateFormat;
+    private Integer                    dateFormatLength;
 
     public final JSONLexer             lexer;
 
@@ -114,13 +115,23 @@ public class DefaultJSONParser implements Closeable {
         return dateFormat;
     }
 
+    public Integer getDateFormatLength() {
+        if (dateFormatLength == null) {
+            DateFormat dateFormat = getDateFormat();
+            dateFormatLength = dateFormat.format(new Date()).length();
+        }
+        return dateFormatLength;
+    }
+
     public void setDateFormat(String dateFormat) {
         this.dateFormatPattern = dateFormat;
         this.dateFormat = null;
+        this.dateFormatLength = null;
     }
 
     public void setDateFomrat(DateFormat dateFormat) {
         this.dateFormat = dateFormat;
+        this.dateFormatLength = null;
     }
 
     public DefaultJSONParser(String input){

--- a/src/main/java/com/alibaba/fastjson/serializer/DateCodec.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/DateCodec.java
@@ -284,8 +284,7 @@ public class DateCodec extends AbstractDateDeserializer implements ObjectSeriali
                 }
             }
             
-            if (strVal.length() == parser.getDateFomartPattern().length()
-                    || (strVal.length() == 22 && parser.getDateFomartPattern().equals("yyyyMMddHHmmssSSSZ"))) {
+            if (strVal.length() == parser.getDateFormatLength()) {
                 DateFormat dateFormat = parser.getDateFormat();
                 try {
                     return (T) dateFormat.parse(strVal);


### PR DESCRIPTION
#3361 
修改 DateCodec 判断 dateFormat 长度的逻辑，以解决 dateFormatPattern  当中含有 [单引号、Z ] 等导致的长度判断错误