### PR TITLE
修正枚举转换不支持自定义Deserializer的问题

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -1267,17 +1267,13 @@ public class TypeUtils{
                         return (T) values[ordinal];
                     }
                 }
-            }
-
-            if(obj instanceof BigDecimal){
+            } else if(obj instanceof BigDecimal){
                 int ordinal = intValue((BigDecimal) obj);
                 Object[] values = clazz.getEnumConstants();
                 if(ordinal < values.length){
                     return (T) values[ordinal];
                 }
-            }
-
-            if(obj instanceof Number){
+            } else if(obj instanceof Number){
                 int ordinal = ((Number) obj).intValue();
                 Object[] values = clazz.getEnumConstants();
                 if(ordinal < values.length){
@@ -1296,6 +1292,7 @@ public class TypeUtils{
         if (obj instanceof String) {
             return (String) obj;
         } else if (obj instanceof BigDecimal) {
+            // 避免出现科学计数符号
             return ((BigDecimal)obj).toPlainString();
         } else if (obj instanceof Number) {
             return String.valueOf(((Number) obj).intValue());

--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -1234,8 +1234,8 @@ public class TypeUtils{
         if (obj == null || (obj instanceof String && ((String) obj).length() == 0)) {
             return null;
         }
-        try{
 
+        try {
             if (mapping == null) {
                 mapping = ParserConfig.getGlobalInstance();
             }
@@ -1254,7 +1254,13 @@ public class TypeUtils{
                 DefaultJSONParser parser = new DefaultJSONParser(string, mapping);
                 return (T) deserializer.deserialze(parser, clazz, null);
             }
+        } catch(JSONException ex){
+            throw ex;
+        } catch(Exception ex){
+            throw new JSONException("can not cast " + obj + " to : " + clazz.getName(), ex);
+        }
 
+        try {
             if(obj instanceof String){
                 String name = (String) obj;
                 if (!isDigitString(name)) {
@@ -1280,12 +1286,10 @@ public class TypeUtils{
                     return (T) values[ordinal];
                 }
             }
-        } catch(JSONException e){
-            throw e;
         } catch(Exception ex){
-            throw new JSONException("can not cast to : " + clazz.getName(), ex);
+            throw new JSONException("can not cast " + obj + " to : " + clazz.getName(), ex);
         }
-        throw new JSONException("can not cast to : " + clazz.getName());
+        throw new JSONException("can not cast " + obj + " to : " + clazz.getName());
     }
     
     private static String castToEnumString(Object obj, Class<?> clazz) {
@@ -1299,7 +1303,7 @@ public class TypeUtils{
         } else if (obj instanceof Boolean) {
             return String.valueOf(obj);
         } else {
-            throw new JSONException("can not cast to : " + clazz.getName());
+            throw new JSONException("can not cast " + obj + " to : " + clazz.getName());
         }
     }
     

--- a/src/test/java/com/alibaba/fastjson/deserializer/EnumCustomizedDeserializerTest.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/EnumCustomizedDeserializerTest.java
@@ -1,0 +1,179 @@
+package com.alibaba.fastjson.deserializer;
+
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.parser.DefaultJSONParser;
+import com.alibaba.fastjson.parser.JSONLexer;
+import com.alibaba.fastjson.parser.JSONToken;
+import com.alibaba.fastjson.parser.ParserConfig;
+import com.alibaba.fastjson.parser.deserializer.ObjectDeserializer;
+import com.alibaba.fastjson.util.TypeUtils;
+import junit.framework.TestCase;
+
+/**
+ * 针对特殊枚举定制的反序列化处理类测试
+ *
+ * @author zhaohuihua
+ * @version 20200728
+ */
+public class EnumCustomizedDeserializerTest extends TestCase {
+
+    public static void main(String[] args) {
+        EnumCustomizedDeserializerTest test = new EnumCustomizedDeserializerTest();
+        test.setUp();
+        test.testConvert();
+        test.testException();
+    }
+
+    protected void setUp() {
+        // 给UserState注册定制的反序列化处理类
+        ParserConfig.getGlobalInstance().putDeserializer(UserState.class, new UserStateDeserializer());
+    }
+
+    public void testConvert() {
+        assertEquals(UserState.NORMAL, TypeUtils.castToEnum("NORMAL", UserState.class, null));
+        assertEquals(UserState.NORMAL, TypeUtils.castToEnum("1", UserState.class, null));
+        assertEquals(UserState.NORMAL, TypeUtils.castToEnum(1, UserState.class, null));
+        assertEquals(UserState.LOCKED, TypeUtils.castToEnum("LOCKED", UserState.class, null));
+        assertEquals(UserState.LOCKED, TypeUtils.castToEnum("2", UserState.class, null));
+        assertEquals(UserState.LOCKED, TypeUtils.castToEnum(2, UserState.class, null));
+        assertEquals(UserState.UNACTIVATED, TypeUtils.castToEnum("UNACTIVATED", UserState.class, null));
+        assertEquals(UserState.UNACTIVATED, TypeUtils.castToEnum("3", UserState.class, null));
+        assertEquals(UserState.UNACTIVATED, TypeUtils.castToEnum(3, UserState.class, null));
+        assertEquals(UserState.LOGOFF, TypeUtils.castToEnum("LOGOFF", UserState.class, null));
+        assertEquals(UserState.LOGOFF, TypeUtils.castToEnum("9", UserState.class, null));
+        assertEquals(UserState.LOGOFF, TypeUtils.castToEnum(9, UserState.class, null));
+    }
+
+    public void testException() {
+        try {
+            TypeUtils.castToEnum(0, UserState.class, null);
+        } catch (Exception e) {
+            assertEquals(JSONException.class, e.getClass());
+        }
+        try {
+            TypeUtils.castToEnum("AAA", UserState.class, null);
+        } catch (Exception e) {
+            assertEquals(JSONException.class, e.getClass());
+        }
+    }
+
+    /** 用户状态 **/
+    protected static enum UserState {
+
+        /** 1.正常 **/
+        NORMAL(1),
+        /** 2.锁定 **/
+        LOCKED(2),
+        /** 3.待激活 **/
+        UNACTIVATED(3),
+        /** 9.已注销 **/
+        LOGOFF(9);
+
+        private int code;
+
+        UserState(int code) {
+            this.code = code;
+        }
+
+        public int code() {
+            return this.code;
+        }
+    }
+
+    /** 用户状态专用反序列化处理类(数字根据code转换) **/
+    protected static class UserStateDeserializer implements ObjectDeserializer {
+
+        public <T> T deserialze(DefaultJSONParser parser, Type type, Object fieldName) {
+            JSONLexer lexer = parser.lexer;
+            if (lexer.token() == JSONToken.NULL) {
+                lexer.nextToken(JSONToken.COMMA);
+                return null;
+            }
+
+            Class<T> targetClass = (Class<T>) TypeUtils.getRawClass(type);
+            if (targetClass != UserState.class) {
+                throw new JSONException("UserStateDeserializer do not support " + targetClass.getName());
+            }
+            if (lexer.token() == JSONToken.LITERAL_INT) {
+                BigDecimal number = lexer.decimalValue();
+                lexer.nextToken(JSONToken.COMMA);
+                return (T) convertFromNumber(number);
+            } else if (lexer.token() == JSONToken.LITERAL_FLOAT) {
+                BigDecimal number = lexer.decimalValue();
+                lexer.nextToken(JSONToken.COMMA);
+                return (T) convertFromNumber(number);
+            } else if (lexer.token() == JSONToken.LITERAL_STRING) {
+                String string = lexer.stringVal();
+                if (isDigitString(string)) {
+                    BigDecimal number = new BigDecimal(string);
+                    return (T) convertFromNumber(number);
+                } else {
+                    return (T) convertFromString(string);
+                }
+            }
+
+            Object value = parser.parse();
+            String msg = value + " can not cast to : " + targetClass.getName();
+            throw new JSONException(msg);
+        }
+
+        private UserState convertFromNumber(BigDecimal number) {
+            // 整数部分
+            BigInteger integer = number.toBigInteger();
+            // 是不是整数
+            boolean isIntegral = number.compareTo(new BigDecimal(integer)) == 0;
+            if (!isIntegral) { // 不是整数
+                String msg = number.toPlainString() + " can not cast to : " + UserState.class.getName();
+                throw new JSONException(msg);
+            }
+            BigInteger minInteger = BigInteger.valueOf(Integer.MIN_VALUE);
+            BigInteger maxInteger = BigInteger.valueOf(Integer.MAX_VALUE);
+            if (integer.compareTo(minInteger) < 0 || integer.compareTo(maxInteger) > 0) {
+                // 不在Integer范围内
+                throw new JSONException(integer + " can not cast to : " + UserState.class.getName());
+            }
+            // 根据code转换
+            int targetValue = number.intValue();
+            for (UserState item : UserState.values()) {
+                if (item.code() == targetValue) {
+                    return item;
+                }
+            }
+            throw new JSONException(integer + " can not cast to : " + UserState.class.getName());
+        }
+
+        private UserState convertFromString(String string) {
+            if (string.length() == 0) {
+                return null;
+            }
+            // 根据name转换
+            for (UserState item : UserState.values()) {
+                if (item.name().equals(string)) {
+                    return item;
+                }
+            }
+            throw new JSONException(string + " can not cast to : " + UserState.class.getName());
+        }
+
+        private boolean isDigitString(String string) {
+            if (string == null || string.length() == 0) {
+                return false;
+            }
+            for (int i = 0, z = string.length(); i < z; i++) {
+                char c = string.charAt(i);
+                if (c < '0' || c > '9') {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public int getFastMatchToken() {
+            return JSONToken.UNDEFINED; // name or ordinal
+        }
+
+    }
+}


### PR DESCRIPTION
注册了自定义的枚举Deserializer之后，TypeUtils.castToEnum并不会调用它。

原因是原先的逻辑有些问题：
1. 只有转换string才会调用mapping.getDeserializer(clazz)，有时数字也需要自定义转换逻辑；
2. 自定义的Deserializer必须是EnumDeserializer才会调用，这不应该是必要条件吧；
3. 不支持数字型字符串按ordinal查找，这个不算问题但也可以优化一下，TypeUtils.castToEnum("1", XxxEnum.class, null)。

问题描述详见 Issues: https://github.com/alibaba/fastjson/issues/3372