### PR TITLE
泛型对象反序列化获取对象类型时，直接返回了里层的泛型，应该去掉return改为在外层统一返回外层的泛型

### DIFF
--- a/src/main/java/com/alibaba/fastjson/TypeReference.java
+++ b/src/main/java/com/alibaba/fastjson/TypeReference.java
@@ -122,7 +122,7 @@ public class TypeReference<T> {
 
             // 如果有多层泛型且该泛型已经注明实现的情况下，判断该泛型下一层是否还有泛型
             if(argTypes[i] instanceof ParameterizedType) {
-                return handlerParameterizedType((ParameterizedType) argTypes[i], actualTypeArguments, actualIndex);
+                handlerParameterizedType((ParameterizedType) argTypes[i], actualTypeArguments, actualIndex);
             }
         }
 

--- a/src/test/java/com/alibaba/fastjson/parser/issue3448/TestIssue3448.java
+++ b/src/test/java/com/alibaba/fastjson/parser/issue3448/TestIssue3448.java
@@ -1,0 +1,72 @@
+package com.alibaba.fastjson.parser.issue3448;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.TypeReference;
+import org.junit.Test;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author wuzihao
+ * @date 2020/9/17
+ * https://github.com/alibaba/fastjson/issues/3448
+ */
+public class TestIssue3448 {
+
+    public static class SelfTypeReference<T> {
+
+    }
+
+    @Test
+    public void test() {
+        List<Map<String, List<String>>> list = new ArrayList<>(4);
+        list.add(Collections.singletonMap("key1", Collections.singletonList("item")));
+        String text = JSON.toJSONString(list);
+        System.out.println("text = " + text);
+
+        List<Map<String, List<String>>> result = parseObject(text,
+                new TestIssue3448.SelfTypeReference<Map<String, List<String>>>() {
+                });
+        System.out.println("result = " + result);
+    }
+
+    @Test
+    public void test2() {
+        List<List<String>> list = new ArrayList<>(4);
+        list.add(Collections.singletonList("item"));
+        String text = JSON.toJSONString(list);
+        System.out.println("text = " + text);
+
+        List<List<String>> result = parseObject(text,
+                new TestIssue3448.SelfTypeReference<List<String>>() {
+                });
+        System.out.println("result = " + result);
+    }
+
+    @Test
+    public void test3() {
+        List<String> list = new ArrayList<>(4);
+        list.add("item");
+        String text = JSON.toJSONString(list);
+        System.out.println("text = " + text);
+
+        List<String> result = parseObject(text,
+                new TestIssue3448.SelfTypeReference<String>() {
+                });
+        System.out.println("result = " + result);
+    }
+
+    public <T> List<T> parseObject(String text, TestIssue3448.SelfTypeReference<T> selfTypeReference) {
+        Type genericSuperclass = selfTypeReference.getClass().getGenericSuperclass();
+        Type[] actualTypeArguments = ((ParameterizedType) genericSuperclass).getActualTypeArguments();
+        return JSON.parseObject(text, new TypeReference<List<T>>(actualTypeArguments) {
+        });
+    }
+
+
+}


### PR DESCRIPTION
问题：https://github.com/alibaba/fastjson/issues/3448
现象：嵌套泛型反序列化失败
原因：泛型对象反序列化获取对象类型时，直接返回了里层的泛型，导致在反序列化时字符串和泛型类型不一致，应该去掉return改为在外层统一返回外层的泛型