### PR TITLE
反序列化时如果JSONField注解没有可以匹配的key就用属性的名字匹配 #3452

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/issue_3400/Issue3452.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3400/Issue3452.java
@@ -1,0 +1,37 @@
+package com.alibaba.json.bvt.issue_3400;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import junit.framework.TestCase;
+import lombok.Data;
+import org.junit.Assert;
+
+/**
+ * Description:  <br>
+ *
+ * @author byw
+ * @create 2020/9/19
+ */
+public class Issue3452 extends TestCase {
+
+    public void test_for_issue() throws Exception {
+        String s = "{ \"componentKey\" : \"CMDB_UPDATE_SERVER\"}";
+        Step step = JSON.parseObject(s, Step.class);
+        Assert.assertEquals("CMDB_UPDATE_SERVER",step.getComponentKey());
+        System.out.println(step.getComponentKey());
+    }
+
+
+    private static class Step {
+        @JSONField(name = "component_key")
+        private String componentKey;
+
+        public String getComponentKey() {
+            return componentKey;
+        }
+
+        public void setComponentKey(String componentKey) {
+            this.componentKey = componentKey;
+        }
+    }
+}


### PR DESCRIPTION
#3452

反序列化时如果JSONField注解没有可以匹配的值就用属性的名字匹配

很抱歉 变更的代码中有一部分是因为IDE格式化工具导致的 虽然不多 但是也很抱歉增加了审核代码同学的工作量