### PR TITLE
修复bug #3452

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/FieldInfo.java
@@ -48,7 +48,7 @@ public class FieldInfo implements Comparable<FieldInfo> {
     public final String[]  alternateNames;
 
     public final long nameHashCode;
-    
+    public final long propertyNameHashCode;
     public FieldInfo(String name, // 
                      Class<?> declaringClass, // 
                      Class<?> fieldClass, // 
@@ -98,6 +98,7 @@ public class FieldInfo implements Comparable<FieldInfo> {
         this.alternateNames = new String[0];
 
         nameHashCode = nameHashCode64(name, fieldAnnotation);
+        propertyNameHashCode = nameHashCode64(name, null);
     }
 
     public FieldInfo(String name, //
@@ -167,6 +168,7 @@ public class FieldInfo implements Comparable<FieldInfo> {
         JSONField annotation = getAnnotation();
 
         nameHashCode = nameHashCode64(name, annotation);
+        propertyNameHashCode = nameHashCode64(name, null);
 
         boolean jsonDirect = false;
         if (annotation != null) {

--- a/src/test/java/com/alibaba/json/bvt/issue_3400/Issue3452.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3400/Issue3452.java
@@ -1,0 +1,37 @@
+package com.alibaba.json.bvt.issue_3400;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import junit.framework.TestCase;
+import lombok.Data;
+import org.junit.Assert;
+
+/**
+ * Description:  <br>
+ *
+ * @author byw
+ * @create 2020/9/19
+ */
+public class Issue3452 extends TestCase {
+
+    public void test_for_issue() throws Exception {
+        String s = "{ \"componentKey\" : \"CMDB_UPDATE_SERVER\"}";
+        Step step = JSON.parseObject(s, Step.class);
+        Assert.assertEquals("CMDB_UPDATE_SERVER",step.getComponentKey());
+        System.out.println(step.getComponentKey());
+    }
+
+
+    private static class Step {
+        @JSONField(name = "component_key")
+        private String componentKey;
+
+        public String getComponentKey() {
+            return componentKey;
+        }
+
+        public void setComponentKey(String componentKey) {
+            this.componentKey = componentKey;
+        }
+    }
+}


### PR DESCRIPTION
#3452

反序列化时如果JSONField注解没有可以匹配的值就用属性的名字匹配