### PR TITLE
fix AfterFilter NullPointer exception in #3443

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/AfterFilter.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/AfterFilter.java
@@ -23,9 +23,9 @@ public abstract class AfterFilter implements SerializeFilter {
         JSONSerializer serializer = serializerLocal.get();
         char seperator = seperatorLocal.get();
 
-        boolean ref = serializer.references.containsKey(value);
+        boolean ref = serializer.containsReference(value);
         serializer.writeKeyValue(seperator, key, value);
-        if (!ref) {
+        if (!ref && serializer.references != null) {
             serializer.references.remove(value);
         }
         if (seperator != ',') {

--- a/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3443.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3443.java
@@ -1,0 +1,58 @@
+package com.alibaba.json.bvt.issue_3300;
+
+import com.alibaba.fastjson.serializer.*;
+import junit.framework.TestCase;
+
+public class Issue3443 extends TestCase {
+    public void testCustomJsonSerializerAndAfterFilter() throws Exception {
+        SerializeWriter serializeWriter = new SerializeWriter();
+        try {
+            JSONSerializer jsonSerializer = new JSONSerializer(serializeWriter, new SerializeConfig());
+
+            Parameter parameter = new Parameter();
+            parameter.setParameterDesc(new ParameterDesc("vipExpireDate", "VIP expire date."));
+
+            jsonSerializer.config(SerializerFeature.DisableCircularReferenceDetect, true);
+            jsonSerializer.getAfterFilters().add(new CustomFilter());
+            jsonSerializer.write(parameter);
+            assertEquals("{\"parameterDesc\":{\"ParameterDesc\":\"VIP expire date.\"}}", serializeWriter.toString());
+        } finally {
+            serializeWriter.close();
+        }
+    }
+
+    static class Parameter {
+        private ParameterDesc parameterDesc;
+
+        public ParameterDesc getParameterDesc() {
+            return parameterDesc;
+        }
+
+        public void setParameterDesc(ParameterDesc parameterType) {
+            this.parameterDesc = parameterType;
+        }
+    }
+
+    static class ParameterDesc {
+        private String parameterName;
+        private String parameterUsage;
+        // do some work...
+
+        public ParameterDesc(String parameterName, String parameterUsage) {
+            this.parameterName = parameterName;
+            this.parameterUsage = parameterUsage;
+        }
+
+
+    }
+
+    static class CustomFilter extends AfterFilter {
+
+        @Override
+        public void writeAfter(Object object) {
+            if (object instanceof ParameterDesc) {
+                writeKeyValue("ParameterDesc", "VIP expire date.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
I have a problem similar to #3443 and try to fix this.

**fastjson version**: 1.2.73(by the way, 1.7.20 works fine.)
**reason**:
When I create a  `JSONSerializer` like `JSONSerializer jsonSerializer = new JSONSerializer(serializeWriter, new SerializeConfig());` in my service, the class member:`references` will be `null`. Then if we custom a new AfterFilter class  and try to create the json string. The `AfterFilter`  class  will throw a Nullpointer Exception like below.
**exception stacktrace**:
```shell
Exception in thread "main" com.alibaba.fastjson.JSONException: write javaBean error, fastjson version 1.2.73, class CustomAfterFilter$Parameter, write javaBean error, fastjson version 1.2.73, class CustomAfterFilter$ParameterDesc, fieldName : parameterDesc
	at com.alibaba.fastjson.serializer.JavaBeanSerializer.write(JavaBeanSerializer.java:539)
	at com.alibaba.fastjson.serializer.JavaBeanSerializer.write(JavaBeanSerializer.java:149)
	at com.alibaba.fastjson.serializer.JSONSerializer.write(JSONSerializer.java:312)
	at CustomAfterFilter.main(CustomAfterFilter.java:15)
Caused by: com.alibaba.fastjson.JSONException: write javaBean error, fastjson version 1.2.73, class CustomAfterFilter$ParameterDesc, fieldName : parameterDesc
	at com.alibaba.fastjson.serializer.JavaBeanSerializer.write(JavaBeanSerializer.java:539)
	at com.alibaba.fastjson.serializer.JavaBeanSerializer.write(JavaBeanSerializer.java:149)
	at com.alibaba.fastjson.serializer.FieldSerializer.writeValue(FieldSerializer.java:320)
	at com.alibaba.fastjson.serializer.JavaBeanSerializer.write(JavaBeanSerializer.java:470)
	... 3 more
Caused by: java.lang.NullPointerException
	at com.alibaba.fastjson.serializer.AfterFilter.writeKeyValue(AfterFilter.java:26)
	at CustomAfterFilter$CustomFilter.writeAfter(CustomAfterFilter.java:53)
	at com.alibaba.fastjson.serializer.AfterFilter.writeAfter(AfterFilter.java:17)
	at com.alibaba.fastjson.serializer.JavaBeanSerializer.writeAfter(JavaBeanSerializer.java:834)
	at com.alibaba.fastjson.serializer.JavaBeanSerializer.write(JavaBeanSerializer.java:502)
	... 6 more
```

**Simplified  reproduce code**:
```java
import com.alibaba.fastjson.serializer.*;

public class CustomAfterFilter {
    public static void main(String args[]) {
        SerializeWriter serializeWriter = new SerializeWriter();
        try {
            JSONSerializer jsonSerializer = new JSONSerializer(serializeWriter, new SerializeConfig());

            Parameter parameter = new Parameter();
            parameter.setParameterDesc(new ParameterDesc("vipExpireDate", "VIP expire date."));

            jsonSerializer.config(SerializerFeature.DisableCircularReferenceDetect, true);
            jsonSerializer.getAfterFilters().add(new CustomFilter());
            jsonSerializer.write(parameter);

            System.out.println(jsonSerializer.toString());
        } finally {
            serializeWriter.close();
        }
    }

    static class Parameter {
        private ParameterDesc parameterDesc;

        public ParameterDesc getParameterDesc() {
            return parameterDesc;
        }
        public void setParameterDesc(ParameterDesc parameterType) {
            this.parameterDesc = parameterType;
        }
    }

    static class ParameterDesc {
        private String parameterName;
        private String parameterUsage;
        // do some work...

        public ParameterDesc(String parameterName, String parameterUsage) {
            this.parameterName = parameterName;
            this.parameterUsage = parameterUsage;
        }
    }

    static class CustomFilter extends AfterFilter {
        @Override
        public void writeAfter(Object object) {
            if (object instanceof ParameterDesc) {
                writeKeyValue("ParameterDesc", "VIP expire date.");
            }
        }
    }
}
```