### PR TITLE
Fix flaky testcases for issue #1780

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/issue_1700/Issue1780_JSONObject.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1700/Issue1780_JSONObject.java
@@ -1,5 +1,6 @@
 package com.alibaba.json.bvt.issue_1700;
 
+import com.alibaba.fastjson.serializer.SerializerFeature;
 import org.junit.Assert;
 import com.alibaba.fastjson.JSON;
 import junit.framework.TestCase;
@@ -10,6 +11,7 @@ public class Issue1780_JSONObject extends TestCase {
 		org.json.JSONObject req = new org.json.JSONObject();
 		req.put("id", 1111);
 		req.put("name", "name11");
-		Assert.assertEquals("{\"name\":\"name11\",\"id\":1111}", JSON.toJSONString(req));
+		String text = JSON.toJSONString(req, SerializerFeature.SortField);
+		Assert.assertEquals("{\"id\":1111,\"name\":\"name11\"}", text);
 	}
 }

--- a/src/test/java/com/alibaba/json/bvt/issue_1700/Issue1780_Module.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1700/Issue1780_Module.java
@@ -3,6 +3,7 @@ package com.alibaba.json.bvt.issue_1700;
 import java.io.IOException;
 import java.lang.reflect.Type;
 
+import com.alibaba.fastjson.serializer.SerializerFeature;
 import org.junit.Assert;
 
 import com.alibaba.fastjson.JSON;
@@ -24,7 +25,8 @@ public class Issue1780_Module extends TestCase {
 		config.register(new myModule());
 		req.put("id", 1111);
 		req.put("name", "name11");
-		Assert.assertEquals("{\"name\":\"name11\",\"id\":1111}", JSON.toJSONString(req, config));
+		String text = JSON.toJSONString(req, SerializerFeature.SortField);
+		Assert.assertEquals("{\"id\":1111,\"name\":\"name11\"}", text);
 	}
 
 	public class myModule implements Module {


### PR DESCRIPTION
The test(s) shouldn't rely on the ordering of elements in a JSON object. To fix it, use SerializerFeature.SortField to force ordering when convert JSON to string, so the converted string will be deterministic. 

The flaky tests were found by running NonDex (https://github.com/TestingResearchIllinois/NonDex). 

