### PR TITLE
Fix issue 3489 循环依赖导致空指针异常

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -127,7 +127,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         {
             if ("false".equals(properties.getProperty("fastjson.asmEnable"))) {
                 ParserConfig.getGlobalInstance().setAsmEnable(false);
-                SerializeConfig.getGlobalInstance().setAsmEnable(false);
+                SerializeConfig.globalAsmEnable = false;
             }
         }
     }

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
@@ -49,8 +49,12 @@ import java.util.regex.Pattern;
  * @author wenshao[szujobs@hotmail.com]
  */
 public class SerializeConfig {
-
+    public static boolean                                 globalAsmEnable = !ASMUtils.IS_ANDROID;
     public final static SerializeConfig                   globalInstance  = new SerializeConfig();
+
+    static{
+        globalInstance.setAsmEnable(globalAsmEnable);
+    }
 
     private static boolean                                awtError        = false;
     private static boolean                                jdk8Error       = false;

--- a/src/test/java/com/alibaba/fastjson/serializer/issue3489/TestIssues3489.java
+++ b/src/test/java/com/alibaba/fastjson/serializer/issue3489/TestIssues3489.java
@@ -1,0 +1,21 @@
+package com.alibaba.fastjson.serializer.issue3489;
+
+import com.alibaba.fastjson.serializer.SerializeConfig;
+import com.alibaba.fastjson.util.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author wangzn
+ * @since 2020/10/13 15:25
+ */
+public class TestIssues3489 {
+
+    @Test
+    public void testIssues3489(){
+        IOUtils.DEFAULT_PROPERTIES.setProperty("fastjson.asmEnable","false");
+        new SerializeConfig();
+        Assert.assertEquals(false, SerializeConfig.getGlobalInstance().isAsmEnable());
+        IOUtils.DEFAULT_PROPERTIES.remove("fastjson.asmEnable");
+    }
+}


### PR DESCRIPTION
bug报告参见 #3489

修复之前，使用fastjson.properties配置文件设置fastjson.asmEnable=false
直接new SerializeConfig(),会导致空指针异常，因为SerializeConfig中静态变量依赖JSON抽象类，JSON类中static块又调用了globalInstance，此时globalInstance还未被初始化

提交修复了这个问题，为了保证asm为私有成员变量，添加了静态变量globalAsmEnable，在JSON类中中加载配置方法中修改globalAsmEnable，SerializeConfig类中静态加载

提供了一个测试用例