### PR TITLE
fix flaky ArrayListMultimapTest

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/guava/ArrayListMultimapTest.java
+++ b/src/test/java/com/alibaba/json/bvt/guava/ArrayListMultimapTest.java
@@ -1,6 +1,7 @@
 package com.alibaba.json.bvt.guava;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.TreeMultimap;
 import com.google.common.primitives.Ints;
@@ -16,8 +17,7 @@ public class ArrayListMultimapTest extends TestCase {
         multimap.putAll("a", Ints.asList(4, 2, 1));
         multimap.putAll("c", Ints.asList(2, 5, 3));
 
-
-        String json = JSON.toJSONString(multimap);
+        String json = JSON.toJSONString(multimap, SerializerFeature.MapSortField);
         assertEquals("{\"a\":[4,2,1],\"b\":[2,4,6],\"c\":[2,5,3]}", json);
 
         TreeMultimap treeMultimap = TreeMultimap.create(multimap);


### PR DESCRIPTION
Existing tests are flaky because they rely on the ordering of elements in a map. To fix it, use SerializerFeature. MapSortField to force ordering when convert JSON to string, so the converted string will be deterministic.

The flaky tests were found by running NonDex (https://github.com/TestingResearchIllinois/NonDex).