### PR TITLE
Fix issue 3493 添加segment的实例类型判断分支

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONPath.java
+++ b/src/main/java/com/alibaba/fastjson/JSONPath.java
@@ -168,6 +168,8 @@ public class JSONPath implements JSONAware {
                     eval = true;
                 } else if (segment instanceof WildCardSegment) {
                     eval = true;
+                }else if(segment instanceof MultiIndexSegment){
+                    eval = true;
                 } else {
                     eval = false;
                 }

--- a/src/test/java/com/alibaba/fastjson/jsonpath/issue3493/TestIssue3493.java
+++ b/src/test/java/com/alibaba/fastjson/jsonpath/issue3493/TestIssue3493.java
@@ -1,0 +1,40 @@
+package com.alibaba.fastjson.jsonpath.issue3493;
+
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONPath;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * @author wangzn
+ * @since 2020/10/27 10:27
+ */
+public class TestIssue3493 {
+
+    @Test
+    public void testIssue3493(){
+        String json = "{\n" +
+                "\"result\": [\n" +
+                "{\n" +
+                "\"puid\": \"21025318\"\n" +
+                "},\n" +
+                "{\n" +
+                "\"puid\": \"21482682\"\n" +
+                "},\n" +
+                "{\n" +
+                "\"puid\": \"21025345\"\n" +
+                "}\n" +
+                "],\n" +
+                "\"state\": 0\n" +
+                "}";
+        Object list = JSONPath.extract(json, "$.result[0,2].puid");
+        JSONArray jsonArray = JSON.parseArray(list.toString());
+        Assert.assertEquals(jsonArray.size(), 2);
+        Assert.assertEquals(jsonArray.get(0), "21025318");
+        Assert.assertEquals(jsonArray.get(1), "21025345");
+    }
+}
+


### PR DESCRIPTION
bug报告参见 #3493

修复之前，抛出异常UnsupportedOperationException

提交修复了这个问题，添加了MultiIndexSegment的类型判断，标志位eval置为true

提供了一个测试用例