### PR TITLE
Fix flaky test WriteDuplicateType#test_dupType

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/writeClassName/WriteDuplicateType.java
+++ b/src/test/java/com/alibaba/json/bvt/writeClassName/WriteDuplicateType.java
@@ -24,8 +24,8 @@ public class WriteDuplicateType extends TestCase {
         obj.put(JSON.DEFAULT_TYPE_KEY, "com.alibaba.json.bvt.writeClassName.WriteDuplicateType$DianDianCart");
         cartMap.put("1001", obj);
         
-        String text1 = JSON.toJSONString(cartMap, SerializerFeature.WriteClassName);
-        Assert.assertEquals("{\"@type\":\"java.util.LinkedHashMap\",\"1001\":{\"@type\":\"com.alibaba.json.bvt.writeClassName.WriteDuplicateType$DianDianCart\",\"id\":1001}}", text1);
+        String text1 = JSON.toJSONString(cartMap, SerializerFeature.WriteClassName, SerializerFeature.MapSortField);
+        Assert.assertEquals("{\"@type\":\"java.util.LinkedHashMap\",\"1001\":{\"id\":1001,\"@type\":\"com.alibaba.json.bvt.writeClassName.WriteDuplicateType$DianDianCart\"}}", text1);
         
     }
     


### PR DESCRIPTION
Existing test is flaky because it relies on the ordering of elements in a map. To fix it, use SerializerFeature.MapSortField to force ordering when convert JSON to string, so the converted string will be deterministic.

The flaky tests was found by running NonDex (https://github.com/TestingResearchIllinois/NonDex).