### PR TITLE
Fix flaky test SortFieldTest#test_1

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/asm/SortFieldTest.java
+++ b/src/test/java/com/alibaba/json/bvt/asm/SortFieldTest.java
@@ -28,14 +28,13 @@ public void test_1() throws Exception {
     V1 entity = new V1();
 
     String text = JSON.toJSONString(entity, SerializerFeature.SortField);
-    System.out.println(text);
 
     // 按字段顺序输出
     // {"f1":0,"f2":0,"f3":0,"f4":0,"f5":0} 
     Assert.assertEquals("{\"f1\":0,\"f2\":0,\"f3\":0,\"f4\":0,\"f5\":0}", text);
 
     JSONObject object = JSON.parseObject(text);
-    text = JSON.toJSONString(object, SerializerFeature.SortField);
+    text = JSON.toJSONString(object, SerializerFeature.MapSortField);
     Assert.assertEquals("{\"f1\":0,\"f2\":0,\"f3\":0,\"f4\":0,\"f5\":0}", text);
 
 }


### PR DESCRIPTION
test_1 is flaky. "object" was parsed from a map object without specifying the type. Using SerializerFeature.SortField cannot properly sort the resulted string; instead, SerializerFeature.MapSortField should be used. **However, this test was designed for SerializerFeature.SortField, so I'm not sure if we want to keep this test or not.** 

The flaky test was found by running NonDex (https://github.com/TestingResearchIllinois/NonDex).
