### PR TITLE
Fix flaky test FeatureCollectionTest#test_geo

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/geo/FeatureCollectionTest.java
+++ b/src/test/java/com/alibaba/json/bvt/geo/FeatureCollectionTest.java
@@ -1,6 +1,7 @@
 package com.alibaba.json.bvt.geo;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
 import com.alibaba.fastjson.support.geo.FeatureCollection;
 import com.alibaba.fastjson.support.geo.Geometry;
 import com.alibaba.fastjson.support.geo.Point;
@@ -61,7 +62,7 @@ public class FeatureCollectionTest
         Geometry geometry = JSON.parseObject(str, Geometry.class);
         assertEquals(FeatureCollection.class, geometry.getClass());
 
-        assertEquals("{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.0,0.5]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"0.0\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0],[103.0,1.0],[104.0,0.0],[105.0,1.0]]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"{\\\"this\\\":\\\"that\\\"}\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}}]}", JSON.toJSONString(geometry));
+        assertEquals("{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.0,0.5]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"0.0\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0],[103.0,1.0],[104.0,0.0],[105.0,1.0]]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"{\\\"this\\\":\\\"that\\\"}\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}}]}", JSON.toJSONString(geometry, SerializerFeature.MapSortField));
 
         String str2 = JSON.toJSONString(geometry);
         assertEquals(str2, JSON.toJSONString(JSON.parseObject(str2, Geometry.class)));

--- a/src/test/java/com/alibaba/json/bvt/geo/FeatureCollectionTest.java
+++ b/src/test/java/com/alibaba/json/bvt/geo/FeatureCollectionTest.java
@@ -62,9 +62,9 @@ public class FeatureCollectionTest
         Geometry geometry = JSON.parseObject(str, Geometry.class);
         assertEquals(FeatureCollection.class, geometry.getClass());
 
-        assertEquals("{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.0,0.5]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"0.0\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0],[103.0,1.0],[104.0,0.0],[105.0,1.0]]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"{\\\"this\\\":\\\"that\\\"}\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}}]}", JSON.toJSONString(geometry, SerializerFeature.MapSortField));
+        assertEquals("{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.0,0.5]}},{\"type\":\"Feature\",\"properties\":{\"prop0\":\"value0\",\"prop1\":\"0.0\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0],[103.0,1.0],[104.0,0.0],[105.0,1.0]]}},{\"type\":\"Feature\",\"properties\":{\"prop0\":\"value0\",\"prop1\":\"{\\\"this\\\":\\\"that\\\"}\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}}]}", JSON.toJSONString(geometry, SerializerFeature.MapSortField));
 
-        String str2 = JSON.toJSONString(geometry);
-        assertEquals(str2, JSON.toJSONString(JSON.parseObject(str2, Geometry.class)));
+        String str2 = JSON.toJSONString(geometry, SerializerFeature.MapSortField);
+        assertEquals(str2, JSON.toJSONString(JSON.parseObject(str2, Geometry.class), SerializerFeature.MapSortField));
     }
 }


### PR DESCRIPTION
Existing test is flaky because it relies on the ordering of elements in a map. To fix it, use SerializerFeature.MapSortField to force ordering when convert JSON to string, so the converted string will be deterministic.

The flaky test was found by running NonDex (https://github.com/TestingResearchIllinois/NonDex).