### PR TITLE
Fix flaky test JSONObjectTest_readObject#test_6

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/JSONObjectTest_readObject.java
+++ b/src/test/java/com/alibaba/json/bvt/JSONObjectTest_readObject.java
@@ -3,6 +3,7 @@ package com.alibaba.json.bvt;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.parser.ParserConfig;
+import com.alibaba.fastjson.serializer.SerializerFeature;
 import junit.framework.TestCase;
 
 import java.io.ByteArrayInputStream;
@@ -129,7 +130,7 @@ public class JSONObjectTest_readObject extends TestCase {
         Object obj = objIn.readObject();
 
         assertEquals(JSONObject.class, obj.getClass());
-        assertEquals(jsonObject.toJSONString(), JSON.toJSONString(obj));
+        assertEquals(JSON.toJSONString(jsonObject, SerializerFeature.MapSortField), JSON.toJSONString(obj, SerializerFeature.MapSortField));
     }
 
     public void test_7() throws Exception {


### PR DESCRIPTION
Existing test is flaky because it relies on the ordering of elements in a map. To fix it, use SerializerFeature.MapSortField to force ordering when convert JSON to string, so the both converted strings will be deterministic.

The flaky test was found by running NonDex (https://github.com/TestingResearchIllinois/NonDex).