### PR TITLE
Fix flaky test JSONPath_reverse_test

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/path/JSONPath_reverse_test.java
+++ b/src/test/java/com/alibaba/json/bvt/path/JSONPath_reverse_test.java
@@ -3,6 +3,7 @@ package com.alibaba.json.bvt.path;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.JSONPath;
+import com.alibaba.fastjson.serializer.SerializerFeature;
 import junit.framework.TestCase;
 
 public class JSONPath_reverse_test extends TestCase
@@ -12,7 +13,13 @@ public class JSONPath_reverse_test extends TestCase
 
         assertEquals("[1001,\"ljw\"]", JSONPath.reserveToArray(object, "id", "name").toString());
         assertEquals("[\"ljw\",1001]", JSONPath.reserveToArray(object, "name", "id").toString());
-        assertEquals("[\"ljw\",[\"ljw\",1001,50]]", JSONPath.reserveToArray(object, "name", "*").toString());
+        String text = JSON.toJSONString(JSONPath.reserveToArray(object, "name", "*"), SerializerFeature.MapSortField);
+        assertTrue(text.equals("[\"ljw\",[\"ljw\",1001,50]]")
+                || text.equals("[\"ljw\",[\"ljw\",50,1001]]")
+                || text.equals("[\"ljw\",[50,1001,\"ljw\"]]")
+                || text.equals("[\"ljw\",[1001,50,\"ljw\"]]")
+                || text.equals("[\"ljw\",[1001,\"ljw\",50]]")
+                || text.equals("[\"ljw\",[50,\"ljw\",1001]]"));
     }
 
     public void test_reserve2() throws Exception {
@@ -26,8 +33,10 @@ public class JSONPath_reverse_test extends TestCase
     public void test_reserve3() throws Exception {
         JSONObject object = JSON.parseObject("{\"player\":{\"id\":1001,\"name\":\"ljw\",\"age\":50}}");
 
-        assertEquals("{\"player\":{\"name\":\"ljw\",\"id\":1001}}", JSONPath.reserveToObject(object, "player.id", "player.name").toString());
-        assertEquals("{\"player\":{\"name\":\"ljw\",\"id\":1001}}", JSONPath.reserveToObject(object, "player.name", "player.id", "ab.c").toString());
+        String text = JSON.toJSONString(JSONPath.reserveToObject(object, "player.id", "player.name"), SerializerFeature.MapSortField);
+        assertEquals("{\"player\":{\"id\":1001,\"name\":\"ljw\"}}", text);
+        text = JSON.toJSONString(JSONPath.reserveToObject(object, "player.name", "player.id", "ab.c"), SerializerFeature.MapSortField);
+        assertEquals("{\"player\":{\"id\":1001,\"name\":\"ljw\"}}", text);
     }
 
 


### PR DESCRIPTION
Existing test is flaky because it relies on the ordering of elements in a map. To fix it, use SerializerFeature.MapSortField to force ordering when convert JSON to string, but the MapSortField config does not apply to list elements, so I manually compare all permutations of list elements. 

The flaky test was found by running NonDex (https://github.com/TestingResearchIllinois/NonDex).