### PR TITLE
Fix flaky test MultiMapTes#test_multimap

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/guava/MultiMapTes.java
+++ b/src/test/java/com/alibaba/json/bvt/guava/MultiMapTes.java
@@ -1,6 +1,7 @@
 package com.alibaba.json.bvt.guava;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
 import com.google.common.collect.*;
 import junit.framework.TestCase;
 
@@ -15,7 +16,7 @@ public class MultiMapTes extends TestCase {
         Map<String, Integer> map = ImmutableMap.of("a", 1, "b", 1, "c", 2);
         SetMultimap<String, Integer> multimap = Multimaps.forMap(map);
         Multimap<Integer, String> inverse = Multimaps.invertFrom(multimap, HashMultimap.<Integer, String>create());
-        String json = JSON.toJSONString(inverse);
-        assertEquals("{1:[\"a\",\"b\"],2:[\"c\"]}",json);
+        String json = JSON.toJSONString(inverse, SerializerFeature.MapSortField);
+        assertTrue(json.equals("{1:[\"a\",\"b\"],2:[\"c\"]}") || json.equals("{1:[\"b\",\"a\"],2:[\"c\"]}"));
     }
 }


### PR DESCRIPTION
Existing test is flaky because it relies on the ordering of elements in a map. To fix it, use SerializerFeature.MapSortField to force ordering when convert JSON to string, but the MapSortField config does not apply to list elements, so I manually compare all permutations of list elements.

The flaky test was found by running NonDex (https://github.com/TestingResearchIllinois/NonDex).