### PR TITLE
Fix test write duplicate type

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/writeClassName/WriteDuplicateType.java
+++ b/src/test/java/com/alibaba/json/bvt/writeClassName/WriteDuplicateType.java
@@ -24,8 +24,8 @@ public class WriteDuplicateType extends TestCase {
         obj.put(JSON.DEFAULT_TYPE_KEY, "com.alibaba.json.bvt.writeClassName.WriteDuplicateType$DianDianCart");
         cartMap.put("1001", obj);
         
-        String text1 = JSON.toJSONString(cartMap, SerializerFeature.WriteClassName);
-        Assert.assertEquals("{\"@type\":\"java.util.LinkedHashMap\",\"1001\":{\"@type\":\"com.alibaba.json.bvt.writeClassName.WriteDuplicateType$DianDianCart\",\"id\":1001}}", text1);
+        String text1 = JSON.toJSONString(cartMap, SerializerFeature.WriteClassName, SerializerFeature.MapSortField);
+        Assert.assertEquals("{\"@type\":\"java.util.LinkedHashMap\",\"1001\":{\"id\":1001,\"@type\":\"com.alibaba.json.bvt.writeClassName.WriteDuplicateType$DianDianCart\"}}", text1);
         
     }
     

--- a/src/test/java/com/alibaba/json/bvt/writeClassName/WriteDuplicateType.java
+++ b/src/test/java/com/alibaba/json/bvt/writeClassName/WriteDuplicateType.java
@@ -24,8 +24,9 @@ public class WriteDuplicateType extends TestCase {
         obj.put(JSON.DEFAULT_TYPE_KEY, "com.alibaba.json.bvt.writeClassName.WriteDuplicateType$DianDianCart");
         cartMap.put("1001", obj);
         
-        String text1 = JSON.toJSONString(cartMap, SerializerFeature.WriteClassName, SerializerFeature.MapSortField);
-        Assert.assertEquals("{\"@type\":\"java.util.LinkedHashMap\",\"1001\":{\"id\":1001,\"@type\":\"com.alibaba.json.bvt.writeClassName.WriteDuplicateType$DianDianCart\"}}", text1);
+        String text1 = JSON.toJSONString(cartMap, SerializerFeature.WriteClassName);
+        assertTrue(text1.equals("{\"@type\":\"java.util.LinkedHashMap\",\"1001\":{\"@type\":\"com.alibaba.json.bvt.writeClassName.WriteDuplicateType$DianDianCart\",\"id\":1001}}")
+                || text1.equals("{\"@type\":\"java.util.LinkedHashMap\",\"1001\":{\"id\":1001,\"@type\":\"com.alibaba.json.bvt.writeClassName.WriteDuplicateType$DianDianCart\"}}"));
         
     }
     


### PR DESCRIPTION
Existing test is flaky because it relies on the ordering of elements within a JSON object To fix it, compare the parsed string against all possible orderings.

The flaky tests was found by running NonDex (https://github.com/TestingResearchIllinois/NonDex).