### PR TITLE
Fix 3 flaky tests using SerializerFeature.MapSortField to make order deterministic

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/issue_1100/Issue1177_1.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1100/Issue1177_1.java
@@ -2,6 +2,7 @@ package com.alibaba.json.bvt.issue_1100;
 
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.JSONPath;
+import com.alibaba.fastjson.serializer.SerializerFeature;
 import junit.framework.TestCase;
 
 /**
@@ -15,7 +16,7 @@ public class Issue1177_1 extends TestCase {
         String jsonpath = "$..x";
         String value="y2";
         JSONPath.set(jsonObject, jsonpath, value);
-        assertEquals("{\"a\":{\"x\":\"y2\"},\"b\":{\"x\":\"y2\"}}", jsonObject.toString());
+        assertEquals("{\"a\":{\"x\":\"y2\"},\"b\":{\"x\":\"y2\"}}", jsonObject.toString(SerializerFeature.MapSortField));
 
     }
 }

--- a/src/test/java/com/alibaba/json/bvt/issue_1300/Issue1363.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1300/Issue1363.java
@@ -1,6 +1,7 @@
 package com.alibaba.json.bvt.issue_1300;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
 import junit.framework.TestCase;
 
 import java.util.HashMap;
@@ -21,7 +22,7 @@ public class Issue1363 extends TestCase {
         String jsonStr = JSON.toJSONString(b);
         System.out.println(jsonStr);
         DataSimpleVO obj = JSON.parseObject(jsonStr, DataSimpleVO.class);
-        assertEquals(jsonStr, JSON.toJSONString(obj));
+        assertEquals(jsonStr, JSON.toJSONString(obj, SerializerFeature.MapSortField));
 
     }
 
@@ -38,7 +39,7 @@ public class Issue1363 extends TestCase {
         DataSimpleVO obj = JSON.parseObject(jsonStr, DataSimpleVO.class);
         System.out.println(obj.toString());
         assertNotNull(obj.value1);
-        assertEquals(jsonStr, JSON.toJSONString(obj));
+        assertEquals(jsonStr, JSON.toJSONString(obj, SerializerFeature.MapSortField));
     }
 
     public static class DataSimpleVO {


### PR DESCRIPTION
The following tests are flaky: `com.alibaba.json.bvt.issue_1100.Issue1177_1#test_for_issue`, `com.alibaba.json.bvt.issue_1300.Issue1363#test_for_issue`, `com.alibaba.json.bvt.issue_1300.Issue1363#test_for_issue_1` due to the order of elements.
Similar to https://github.com/alibaba/fastjson/pull/3503 you have merged, this PR aims to completely remove flakiness by adding `SerializerFeature.MapSortField`.

Let me know if you have questions, thanks!