### PR TITLE
fixed issue3521

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONValidator.java
+++ b/src/main/java/com/alibaba/fastjson/JSONValidator.java
@@ -125,15 +125,17 @@ public abstract class JSONValidator implements Cloneable, Closeable {
                         return false;
                     }
 
+                    // kv 结束时，只能是 "," 或 "}"
                     skipWhiteSpace();
                     if (ch == ',') {
                         next();
                         skipWhiteSpace();
-                        continue;
                     } else if (ch == '}') {
                         next();
                         type = Type.Object;
                         return true;
+                    } else {
+                        return false;
                     }
                 }
             case '[':


### PR DESCRIPTION
bug见 #3521 

### 原因分析
validate验证时，kv解析完毕时的判断有遗漏

### 解决方法
完善判断逻辑

> 另: `continue` 关键字放置此处无效，剔除