### PR TITLE
修复FastJson在Android系统上处理BigDecimal解析错误

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/JSONLexerBase.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONLexerBase.java
@@ -3046,7 +3046,7 @@ public abstract class JSONLexerBase implements JSONLexer, Closeable {
                 throw new JSONException("decimal overflow");
             }
             char[] chars = this.sub_chars(start, count);
-            value = new BigDecimal(chars, 0, chars.length, MathContext.UNLIMITED);
+            value = new BigDecimal(chars, 0, count, MathContext.UNLIMITED);
         } else if (chLocal == 'n' && charAt(bp + offset) == 'u' && charAt(bp + offset + 1) == 'l' && charAt(bp + offset + 2) == 'l') {
             matchStat = VALUE_NULL;
             value = null;
@@ -3724,7 +3724,7 @@ public abstract class JSONLexerBase implements JSONLexer, Closeable {
             }
 
             char[] chars = this.sub_chars(start, count);
-            value = new BigDecimal(chars, 0, chars.length, MathContext.UNLIMITED);
+            value = new BigDecimal(chars, 0, count, MathContext.UNLIMITED);
         } else if (chLocal == 'n' &&
                    charAt(bp + offset) == 'u' &&
                    charAt(bp + offset + 1) == 'l' &&


### PR DESCRIPTION
#3398 
#2977 
#2873 
### 问题
当实体类里参数有BigDecimal的时候，在Android系统中，无法从Json字符串中转换为该实体类
问题产生原因：
https://github.com/alibaba/fastjson/blob/master/src/main/java/com/alibaba/fastjson/parser/JSONLexerBase.java
代码：`char[] chars = this.sub_chars(start, count);
            value = new BigDecimal(chars, 0, chars.length, MathContext.UNLIMITED);`
 chars.length应为count
修复：
`char[] chars = this.sub_chars(start, count);
            value = new BigDecimal(chars, 0,count, MathContext.UNLIMITED);`