### PR TITLE
Fix 3 flaky tests caused by Map ordering assumption

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -126,8 +126,8 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
 
         {
             if ("false".equals(properties.getProperty("fastjson.asmEnable"))) {
-                ParserConfig.getGlobalInstance().setAsmEnable(false);
-                SerializeConfig.getGlobalInstance().setAsmEnable(false);
+                ParserConfig.global.setAsmEnable(false);
+                SerializeConfig.globalInstance.setAsmEnable(false);
             }
         }
     }

--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -1386,5 +1386,5 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         return null;
     }
 
-    public final static String VERSION = "1.2.75";
+    public final static String VERSION = "1.2.76";
 }

--- a/src/test/java/com/alibaba/json/bvt/issue_3000/Issue3082.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3000/Issue3082.java
@@ -2,6 +2,7 @@ package com.alibaba.json.bvt.issue_3000;
 
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.TypeReference;
+import com.alibaba.fastjson.serializer.SerializerFeature;
 import junit.framework.TestCase;
 
 import java.lang.reflect.Type;
@@ -26,6 +27,6 @@ public class Issue3082 extends TestCase {
         HashSet<Map.Entry<String, Map.Entry<String, String>>> deserializedNestedSet;
         Type type = new TypeReference<HashSet<Map.Entry<String, Map.Entry<String, String>>>>() {}.getType();
         deserializedNestedSet = JSON.parseObject(content, type);
-        assertEquals("b", deserializedNestedSet.iterator().next().getValue().getKey());
+        assertEquals(nestedSet, deserializedNestedSet);
     }
 }


### PR DESCRIPTION
Existing tests are flaky because they rely on the ordering of key value pairs in a Map. To fix them, consider all possible orderings of the Map. 

The flaky tests were found by running NonDex (https://github.com/TestingResearchIllinois/NonDex).

