### PR TITLE
Fix 3 tests using SerializerFeature.MapSortField

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -126,8 +126,8 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
 
         {
             if ("false".equals(properties.getProperty("fastjson.asmEnable"))) {
-                ParserConfig.getGlobalInstance().setAsmEnable(false);
-                SerializeConfig.getGlobalInstance().setAsmEnable(false);
+                ParserConfig.global.setAsmEnable(false);
+                SerializeConfig.globalInstance.setAsmEnable(false);
             }
         }
     }

--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -1386,5 +1386,5 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         return null;
     }
 
-    public final static String VERSION = "1.2.75";
+    public final static String VERSION = "1.2.76";
 }

--- a/src/test/java/com/alibaba/json/bvt/writeClassName/WriteClassNameTest_Map.java
+++ b/src/test/java/com/alibaba/json/bvt/writeClassName/WriteClassNameTest_Map.java
@@ -25,7 +25,7 @@ public class WriteClassNameTest_Map extends TestCase {
         assertEquals("{\"tables\":{\"1001\":{\"@type\":\"com.alibaba.json.bvt.writeClassName.WriteClassNameTest_Map$ExtTable\",\"id\":1001},\"1002\":{}}}", json);
 
         JSONObject jsonObject = JSON.parseObject(json, Feature.IgnoreAutoType);
-        assertEquals("{\"tables\":{\"1002\":{},\"1001\":{\"id\":1001}}}", jsonObject.toJSONString());
+        assertEquals("{\"tables\":{\"1001\":{\"id\":1001},\"1002\":{}}}", JSON.toJSONString(jsonObject, SerializerFeature.MapSortField));
 
         Model model2 = JSON.parseObject(json, Model.class);
         assertEquals(ExtTable.class, model2.getTables().get("1001").getClass());


### PR DESCRIPTION
Existing tests are flaky because they rely on the ordering of elements in a map. To fix it, use SerializerFeature. MapSortField to force ordering when convert JSON to string, so the converted string will be deterministic.

The flaky tests were found by running NonDex (https://github.com/TestingResearchIllinois/NonDex).

