### PR TITLE
Fix flaky test for TypeUtilsTest

### DIFF
--- a/src/test/java/com/alibaba/json/bvt/parser/TypeUtilsTest.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/TypeUtilsTest.java
@@ -10,6 +10,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import junit.framework.TestCase;
 
@@ -245,6 +246,7 @@ public class TypeUtilsTest extends TestCase {
     }
 
     public void test_cast_to_Timestamp_1970_01_01_00_00_00() throws Exception {
+        JSON.defaultTimeZone = TimeZone.getTimeZone("Asia/Shanghai");
         Assert.assertEquals(new Timestamp(0), TypeUtils.castToTimestamp("1970-01-01 08:00:00"));
     }
 


### PR DESCRIPTION
The test is flaky because the casted time may vary depending on different timezones. To fix it, set timezone before checking. 

The flaky test was found by running NonDex (https://github.com/TestingResearchIllinois/NonDex).

 