### PR TITLE
config ci.yaml to run NonDex on Github Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,5 +22,20 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Test with Maven
         run: mvn test -B --file pom.xml
+  
+  nondex:
+    runs-on: macOS-latest
+    strategy:
+      matrix:
+        java: [8]
+      fail-fast: false
+    name: NonDex Test JDK ${{ matrix.java }}, macOS-latest
 
-...
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Run NonDex
+        run: sh ./nondex.sh

--- a/nondex.sh
+++ b/nondex.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+COMMIT_RANGE=$(git rev-parse origin/master)...$(git rev-parse HEAD)
+nondextests=$(git diff --name-status --diff-filter=AM $COMMIT_RANGE | grep /test/ | sed -e 's;.*test/java/;;' -e 's/.java//' -e 's;/;.;g')
+
+if [[ ! -z $nondextests ]]
+then
+    printf "Running NonDex on tests:\n$nondextests\n"
+    nondextests=$(echo $nondextests | tr -s '[:blank:]' ',')
+    mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn edu.illinois:nondex-maven-plugin:1.1.2:nondex -DnondexSeed=$RANDOM -DnondexRuns=10 -DfailIfNoTests=false -Dtest=$nondextests
+fi  
+if [[ -d ".nondex" ]]
+then
+    flakyTests=$(awk ' !x[$0]++' .nondex/*/failures)
+fi
+if [[ ! -z "$flakyTests" ]]
+then 
+    printf "Found flaky tests:\n$flakyTests\n"
+    exit 1 ;
+else 
+    printf "No flaky tests found.\n"
+fi


### PR DESCRIPTION
There are many open or merged PR regarding flaky tests found by NonDex(https://github.com/TestingResearchIllinois/NonDex). By configuring the CI settings, we can run NonDex automatically on new pushes instead of running the tool offline manually. With this configuration, NonDex will only be ran on modified or newly added tests, so flaky tests can be detected when they are created.