### PR TITLE
FIX issue#3582

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -2514,6 +2514,17 @@ public class TypeUtils{
     }
 
     public static Type getCollectionItemType(Type fieldType) {
+        // issue#3582 在kotlin中, val map = Map<Int, List<SomeClass>>,
+        // 获取到的value的Type是 ? extends java.util.List，
+        // 如果想要List中的SomeClass在解析的时候自动转成对象，必须进行处理，否则全部会解析为JSONObject
+        if (fieldType instanceof WildcardType) {
+            Type[] upperTypes = ((WildcardType) fieldType).getUpperBounds();
+            for (Type upperType : upperTypes) {
+                if (getRawClass(upperType) == List.class) {
+                    return getCollectionItemType(upperType);
+                }
+            }
+        }
         if (fieldType instanceof ParameterizedType) {
             return getCollectionItemType((ParameterizedType) fieldType);
         }

--- a/src/test/java/com/alibaba/fastjson/deserializer/issue3582/TestIssue3582.kt
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issue3582/TestIssue3582.kt
@@ -1,0 +1,38 @@
+package com.alibaba.fastjson.deserializer.issue3582
+
+import com.alibaba.fastjson.JSON
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TestIssue3582 {
+
+    @Test
+    fun test() {
+        val obj = Data1(
+            f1 = listOf(Data(1)),
+            f2 = mapOf(
+                1 to listOf(
+                    Data(2),
+                    Data(22)
+                ),
+                2 to listOf(
+                    Data(3),
+                    Data(33)
+                )
+            )
+        )
+
+        val str = JSON.toJSONString(obj)
+        val parsed = JSON.parseObject(str, Data1::class.java)
+        assertEquals(obj, parsed)
+    }
+}
+
+data class Data(
+    val id: Int
+)
+
+data class Data1(
+    val f1: List<Data> = listOf(),
+    val f2: Map<Int, List<Data>> = mapOf()
+)


### PR DESCRIPTION
在kotlin中, `val map = Map<Int, List<SomeClass>>`,
获取到的value的Type是`? extends java.util.List`，
如果想要List中的SomeClass在解析的时候自动转成对象，必须进行处理，否则全部会解析为JSONObject
