### PR TITLE
Fix: 使用方法 remove() 替代 set(null)

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONValidator.java
+++ b/src/main/java/com/alibaba/fastjson/JSONValidator.java
@@ -433,7 +433,7 @@ public abstract class JSONValidator implements Cloneable, Closeable {
             this.is = is;
             buf = bufLocal.get();
             if (buf != null) {
-                bufLocal.set(null);
+                bufLocal.remove();
             } else {
                 buf = new byte[1024 * 8];
             }
@@ -559,7 +559,7 @@ public abstract class JSONValidator implements Cloneable, Closeable {
             this.r = r;
             buf = bufLocal.get();
             if (buf != null) {
-                bufLocal.set(null);
+                bufLocal.remove();
             } else {
                 buf = new char[1024 * 8];
             }

--- a/src/main/java/com/alibaba/fastjson/parser/JSONReaderScanner.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONReaderScanner.java
@@ -61,7 +61,7 @@ public final class JSONReaderScanner extends JSONLexerBase {
 
         buf = BUF_LOCAL.get();
         if (buf != null) {
-            BUF_LOCAL.set(null);
+            BUF_LOCAL.remove();
         }
 
         if (buf == null) {
@@ -260,7 +260,7 @@ public final class JSONReaderScanner extends JSONLexerBase {
         if (count < 0) {
             throw new StringIndexOutOfBoundsException(count);
         }
-        
+
         if (offset == 0) {
             return buf;
         }

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeWriter.java
@@ -111,7 +111,7 @@ public final class SerializeWriter extends Writer {
         buf = bufLocal.get();
 
         if (buf != null) {
-            bufLocal.set(null);
+            bufLocal.remove();
         } else {
             buf = new char[2048];
         }
@@ -234,7 +234,7 @@ public final class SerializeWriter extends Writer {
     public boolean isEnabled(SerializerFeature feature) {
         return (this.features & feature.mask) != 0;
     }
-    
+
     public boolean isEnabled(int feature) {
         return (this.features & feature) != 0;
     }
@@ -258,7 +258,7 @@ public final class SerializeWriter extends Writer {
 
     /**
      * Writes characters to the buffer.
-     * 
+     *
      * @param c the data to be written
      * @param off the start offset in the data
      * @param len the number of chars that are written
@@ -317,7 +317,7 @@ public final class SerializeWriter extends Writer {
 
         buf = newValue;
     }
-    
+
     public SerializeWriter append(CharSequence csq) {
         String s = (csq == null ? "null" : csq.toString());
         write(s, 0, s.length());
@@ -337,7 +337,7 @@ public final class SerializeWriter extends Writer {
 
     /**
      * Write a portion of a string to the buffer.
-     * 
+     *
      * @param str String to be written from
      * @param off Offset from which to start reading characters
      * @param len Number of characters to be written
@@ -365,7 +365,7 @@ public final class SerializeWriter extends Writer {
 
     /**
      * Writes the contents of the buffer to another character stream.
-     * 
+     *
      * @param out the output stream to write to
      * @throws IOException If an I/O error occurs.
      */
@@ -379,7 +379,7 @@ public final class SerializeWriter extends Writer {
     public void writeTo(OutputStream out, String charsetName) throws IOException {
         writeTo(out, Charset.forName(charsetName));
     }
-    
+
     public void writeTo(OutputStream out, Charset charset) throws IOException {
         writeToEx(out, charset);
     }
@@ -388,7 +388,7 @@ public final class SerializeWriter extends Writer {
         if (this.writer != null) {
             throw new UnsupportedOperationException("writer not null");
         }
-        
+
         if (charset == IOUtils.UTF8) {
             return encodeToUTF8(out);
         } else {
@@ -400,7 +400,7 @@ public final class SerializeWriter extends Writer {
 
     /**
      * Returns a copy of the input data.
-     * 
+     *
      * @return an array of chars copied from the input data.
      */
     public char[] toCharArray() {
@@ -412,7 +412,7 @@ public final class SerializeWriter extends Writer {
         System.arraycopy(buf, 0, newValue, 0, count);
         return newValue;
     }
-    
+
     /**
      * only for springwebsocket
      * @return
@@ -437,7 +437,7 @@ public final class SerializeWriter extends Writer {
         if (this.writer != null) {
             throw new UnsupportedOperationException("writer not null");
         }
-        
+
         if (charset == IOUtils.UTF8) {
             return encodeToUTF8Bytes();
         } else {
@@ -469,7 +469,7 @@ public final class SerializeWriter extends Writer {
 
         return position;
     }
-    
+
     private byte[] encodeToUTF8Bytes() {
         int bytesLength = (int) (count * (double) 3);
         byte[] bytes = bytesBufLocal.get();
@@ -494,7 +494,7 @@ public final class SerializeWriter extends Writer {
 
         return copy;
     }
-    
+
     public int size() {
         return count;
     }
@@ -722,7 +722,7 @@ public final class SerializeWriter extends Writer {
             writeNull();
             return;
         }
-        
+
         String strVal = null;
         if (writeEnumUsingName && !writeEnumUsingToString) {
             strVal = value.name();
@@ -797,11 +797,11 @@ public final class SerializeWriter extends Writer {
     public void writeNull() {
         write("null");
     }
-    
+
     public void writeNull(SerializerFeature feature) {
         writeNull(0, feature.mask);
     }
-    
+
     public void writeNull(int beanFeatures , int feature) {
         if ((beanFeatures & feature) == 0 //
             && (this.features & feature) == 0) {
@@ -814,7 +814,7 @@ public final class SerializeWriter extends Writer {
             writeNull();
             return;
         }
-        
+
         if (feature == SerializerFeature.WriteNullListAsEmpty.mask) {
             write("[]");
         } else if (feature == SerializerFeature.WriteNullStringAsEmpty.mask) {
@@ -827,7 +827,7 @@ public final class SerializeWriter extends Writer {
             writeNull();
         }
     }
-    
+
     public void writeStringWithDoubleQuote(String text, final char seperator) {
         if (text == null) {
             writeNull();
@@ -1594,7 +1594,7 @@ public final class SerializeWriter extends Writer {
             buf[count - 1] = '\"';
         }
     }
-    
+
     public void writeFieldNameDirect(String text) {
         int len = text.length();
         int newcount = count + len + 3;
@@ -1681,7 +1681,7 @@ public final class SerializeWriter extends Writer {
         count = offset;
     }
 
-    
+
     public void writeFieldValue(char seperator, String name, char value) {
         write(seperator);
         writeFieldName(name);
@@ -2083,7 +2083,7 @@ public final class SerializeWriter extends Writer {
                 }
             }
         }
-        
+
 
         buf[count - 1] = '\"';
     }
@@ -2129,7 +2129,7 @@ public final class SerializeWriter extends Writer {
     }
 
 
-    
+
     public void writeFieldValue(char seperator, String name, Enum<?> value) {
         if (value == null) {
             write(seperator);

--- a/src/main/java/com/alibaba/fastjson/util/ThreadLocalCache.java
+++ b/src/main/java/com/alibaba/fastjson/util/ThreadLocalCache.java
@@ -26,7 +26,7 @@ public class ThreadLocalCache {
     }
 
     public static void clearChars() {
-        charsBufLocal.set(null);
+        charsBufLocal.remove();
     }
 
     public static char[] getChars(int length) {
@@ -81,7 +81,7 @@ public class ThreadLocalCache {
     private final static ThreadLocal<SoftReference<byte[]>> bytesBufLocal        = new ThreadLocal<SoftReference<byte[]>>();
 
     public static void clearBytes() {
-        bytesBufLocal.set(null);
+        bytesBufLocal.remove();
     }
 
     public static byte[] getBytes(int length) {

--- a/src/test/java/com/alibaba/json/bvt/util/ThreadLocalCacheTest.java
+++ b/src/test/java/com/alibaba/json/bvt/util/ThreadLocalCacheTest.java
@@ -33,19 +33,19 @@ public class ThreadLocalCacheTest extends TestCase {
         clearChars();
 
     }
-    
+
     static char[] allocateChars(int length) throws Exception {
         Method method = JSON.class.getDeclaredMethod("allocateChars", int.class);
         method.setAccessible(true);
         return (char[]) method.invoke(null, length);
     }
-    
+
     public static void clearChars() throws Exception {
         Field field = JSON.class.getDeclaredField("charsLocal");
         field.setAccessible(true);
-        
+
         ThreadLocal<char[]> charsLocal = (ThreadLocal<char[]>) field.get(null);
-        charsLocal.set(null);
+        charsLocal.remove();
     }
 
     public void testBytes() throws Exception {
@@ -67,29 +67,29 @@ public class ThreadLocalCacheTest extends TestCase {
         clearBytes();
 
     }
-    
+
     public static byte[] getBytes(int length) throws Exception {
         Field field = SerializeWriter.class.getDeclaredField("bytesBufLocal");
         field.setAccessible(true);
         ThreadLocal<byte[]> bytesBufLocal = (ThreadLocal<byte[]>) field.get(null);
-        
+
         byte[] bytes = bytesBufLocal.get();
 
         if (bytes == null) {
             bytes = new byte[1024 * 8];
             bytesBufLocal.set(bytes);
         }
-        
+
         return bytes.length < length //
             ? new byte[length] //
             : bytes;
     }
-    
+
     public static void clearBytes() throws Exception {
         Field field = SerializeWriter.class.getDeclaredField("bytesBufLocal");
         field.setAccessible(true);
         ThreadLocal<byte[]> bytesBufLocal = (ThreadLocal<byte[]>) field.get(null);
-        bytesBufLocal.set(null);
+        bytesBufLocal.remove();
     }
 
     public void test_chars() throws Exception {


### PR DESCRIPTION
- 使用`set(null)`方法，可能会使 map 持有对象引用导致的内存泄露问题，推荐始终使用 ` remove()`方法来清除 `ThreadLocal` 的值。
```
ThreadLocal variables are supposed to be garbage collected once the holding thread is no longer alive. Memory leaks can occur when holding threads are re-used which is the case on application servers using pool of threads.

To avoid such problems, it is recommended to always clean up ThreadLocal variables using the remove() method to remove the current thread’s value for the ThreadLocal variable.

In addition, calling set(null) to remove the value might keep the reference to this pointer in the map, which can cause memory leak in some scenarios. Using remove is safer to avoid this issue.
```

- 下面摘自JDK `ThreadLocal` 的部分源码：

```java
public void remove() {
         ThreadLocalMap m = getMap(Thread.currentThread());
         if (m != null) {
             m.remove(this);
         }
     }
```
```java
 public void set(T value) {
        Thread t = Thread.currentThread();
        ThreadLocalMap map = getMap(t);
        if (map != null) {
            map.set(this, value);
        } else {
            createMap(t, value);
        }
    }
```



