### PR TITLE
Fix Bug of issue #3652.

### DIFF
--- a/src/main/java/com/alibaba/fastjson/PropertyNamingStrategy.java
+++ b/src/main/java/com/alibaba/fastjson/PropertyNamingStrategy.java
@@ -4,11 +4,12 @@ package com.alibaba.fastjson;
  * @since 1.2.15
  */
 public enum PropertyNamingStrategy {
-                                    CamelCase, //
-                                    PascalCase, //
-                                    SnakeCase, //
-                                    KebabCase, //
-                                    NoChange;
+                                    CamelCase, // camelCase
+                                    PascalCase, // PascalCase
+                                    SnakeCase, // snake_case
+                                    KebabCase, // kebab-case
+                                    NoChange,  //
+                                    NeverUseThisValueExceptDefaultValue;
 
     public String translate(String propertyName) {
         switch (this) {
@@ -65,6 +66,7 @@ public enum PropertyNamingStrategy {
                 return propertyName;
             }
             case NoChange:
+            case NeverUseThisValueExceptDefaultValue:
             default:
                 return propertyName;
         }

--- a/src/main/java/com/alibaba/fastjson/annotation/JSONType.java
+++ b/src/main/java/com/alibaba/fastjson/annotation/JSONType.java
@@ -65,7 +65,7 @@ public @interface JSONType {
 
     boolean serializeEnumAsJavaBean() default false;
 
-    PropertyNamingStrategy naming() default PropertyNamingStrategy.CamelCase;
+    PropertyNamingStrategy naming() default PropertyNamingStrategy.NeverUseThisValueExceptDefaultValue;
 
     /**
      * @since 1.2.49

--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -349,7 +349,7 @@ public class TypeUtils{
         }
         return new BigDecimal(strVal);
     }
-    
+
     public static BigInteger castToBigInteger(Object value) {
         if (value == null) {
             return null;
@@ -1777,7 +1777,7 @@ public class TypeUtils{
             }
 
             PropertyNamingStrategy jsonTypeNaming = jsonType.naming();
-            if (jsonTypeNaming != PropertyNamingStrategy.CamelCase) {
+            if (jsonTypeNaming != PropertyNamingStrategy.NeverUseThisValueExceptDefaultValue) {
                 propertyNamingStrategy = jsonTypeNaming;
             }
 

--- a/src/test/java/com/alibaba/json/bvt/issue_3600/Issue3652.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3600/Issue3652.java
@@ -1,0 +1,89 @@
+package com.alibaba.json.bvt.issue_3600;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.PropertyNamingStrategy;
+import com.alibaba.fastjson.annotation.JSONType;
+import com.alibaba.fastjson.serializer.SerializeConfig;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Issue3652 {
+
+    @Test
+    public void test_SerializeConfig_different_Class_Annotation() {
+        Object[] models = new Object[]{
+                new Model1("hello,world"),
+                new Model2("hello,world"),
+                new Model3("hello,world"),
+                new Model4("hello,world"),
+        };
+        for (int i = 0; i < 4; i++) {
+            String[] toStrings = new String[PropertyNamingStrategy.values().length];
+            for (int j = 0; j < toStrings.length; j++) {
+                SerializeConfig config = new SerializeConfig();
+                config.propertyNamingStrategy = PropertyNamingStrategy.values()[j];
+                toStrings[j] = JSON.toJSONString(models[i], config);
+            }
+            for (int j = 1; j < toStrings.length; j++) {
+                Assert.assertEquals(toStrings[j], toStrings[j - 1]);
+                System.out.println(toStrings[j - 1]);
+            }
+        }
+    }
+
+    @Test
+    public void test_different_Class_Annotation() {
+        Object[] models = new Object[]{
+                new Model1("hello,world"),
+                new Model2("hello,world"),
+                new Model3("hello,world"),
+                new Model4("hello,world"),
+        };
+        String[] JsonStrings = new String[]{
+                "{\"goodBoy\":\"hello,world\"}",
+                "{\"GoodBoy\":\"hello,world\"}",
+                "{\"good_boy\":\"hello,world\"}",
+                "{\"good-boy\":\"hello,world\"}"};
+        /* PS: Order is
+         CamelCase,
+         PascalCase,
+         SnakeCase,
+         KebabCase,*/
+        for (int i = 0; i < models.length; i++) {
+            String[] toStrings = new String[PropertyNamingStrategy.values().length];
+            toStrings[i] = JSON.toJSONString(models[i]);
+            Assert.assertEquals(JsonStrings[i], toStrings[i]);
+        }
+    }
+
+    @JSONType(naming = PropertyNamingStrategy.CamelCase)
+    @Data
+    @AllArgsConstructor
+    public class Model1 {
+        private String goodBoy;
+    }
+
+    @JSONType(naming = PropertyNamingStrategy.PascalCase)
+    @Data
+    @AllArgsConstructor
+    public class Model2 {
+        private String goodBoy;
+    }
+
+    @JSONType(naming = PropertyNamingStrategy.SnakeCase)
+    @Data
+    @AllArgsConstructor
+    public class Model3 {
+        private String goodBoy;
+    }
+
+    @JSONType(naming = PropertyNamingStrategy.KebabCase)
+    @Data
+    @AllArgsConstructor
+    public class Model4 {
+        private String goodBoy;
+    }
+
+}


### PR DESCRIPTION
Add new Enum value for PropertyNamingStrategy, use it as JSONtype's
naming's default value.


- [x] Bug fix
- [x] new Test
- [x] Breaking change
- [x] This change requires a documentation update

之前被不同的JSONType.naming注解的类,与SerializeConfig中不同propertyNamingStrategy的情况是

横 JSONType(naming = \*)
竖 config.propertyNamingStrategy = \*
| Result     | CamelCase  | PascalCase | SnakeCase | KebabCase |
| :--------- | :--------: | :--------: | :-------: | :-------: |
| CamelCase  | CamelCase  | PascalCase | SnakeCase | KebabCase |
| PascalCase | PascalCase | PascalCase | SnakeCase | KebabCase |
| SnakeCase  | SnakeCase  | PascalCase | SnakeCase | KebabCase |
| KebabCase  | KebabCase  | PascalCase | SnakeCase | KebabCase |

现在为
| Result     | CamelCase | PascalCase | SnakeCase | KebabCase |
| :--------- | :-------: | :--------: | :-------: | :-------: |
| CamelCase  | CamelCase | PascalCase | SnakeCase | KebabCase |
| PascalCase | CamelCase | PascalCase | SnakeCase | KebabCase |
| SnakeCase  | CamelCase | PascalCase | SnakeCase | KebabCase |
| KebabCase  | CamelCase | PascalCase | SnakeCase | KebabCase |