### PR TITLE
Remove final modifier of field SerializeConfig.globalInstance

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeConfig.java
@@ -50,7 +50,7 @@ import java.util.regex.Pattern;
  */
 public class SerializeConfig {
 
-    public final static SerializeConfig                   globalInstance  = new SerializeConfig();
+    public static SerializeConfig                         globalInstance  = new SerializeConfig();
 
     private static boolean                                awtError        = false;
     private static boolean                                jdk8Error       = false;


### PR DESCRIPTION
@wenshao  移除字段  SerializeConfig.globalInstance 的 final 修饰符, 以便运行时可以修改全局的序列化配置. ref  #3630