### PR TITLE
Enhance : add new parseObject method to config default feature.

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -287,6 +287,34 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         return (T) parseObject(json, (Type) clazz, ParserConfig.global, null, DEFAULT_PARSER_FEATURE, features);
     }
 
+    /**
+     * This method allow you to enable or unable features based on the DEFAULT_PARSER_FEATURE.
+     *
+     * @param json             the string from which the object is to be deserialized
+     * @param clazz            the class of T
+     * @param isFeaturesEnable whether enable or unable those features, it will be ignored when no input features.
+     * @param features         parser features
+     * @return an object of type T from the string
+     * classOfT
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T parseObject(String json, Class<T> clazz, boolean isFeaturesEnable, Feature... features) {
+        if (features != null) {
+            if (isFeaturesEnable) {
+                return (T) parseObject(json, (Type) clazz, ParserConfig.global, null, DEFAULT_PARSER_FEATURE, features);
+            }
+
+            int featureValues = DEFAULT_PARSER_FEATURE;
+            for (Feature feature : features) {
+                featureValues &= ~feature.mask;
+            }
+
+            return parseObject(json, clazz, featureValues, new Feature[0]);
+        }
+
+        return (T) parseObject(json, clazz);
+    }
+
     @SuppressWarnings("unchecked")
     public static <T> T parseObject(String text, Class<T> clazz, ParseProcess processor, Feature... features) {
         return (T) parseObject(text, (Type) clazz, ParserConfig.global, processor, DEFAULT_PARSER_FEATURE,

--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -306,7 +306,9 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
 
             int featureValues = DEFAULT_PARSER_FEATURE;
             for (Feature feature : features) {
-                featureValues &= ~feature.mask;
+                if (feature.mask < featureValues) {
+                    featureValues &= ~feature.mask;
+                }
             }
 
             return parseObject(json, clazz, featureValues, new Feature[0]);

--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -306,9 +306,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
 
             int featureValues = DEFAULT_PARSER_FEATURE;
             for (Feature feature : features) {
-                if (feature.mask < featureValues) {
-                    featureValues &= ~feature.mask;
-                }
+                featureValues &= ~feature.mask;
             }
 
             return parseObject(json, clazz, featureValues, new Feature[0]);

--- a/src/test/java/com/alibaba/json/bvt/JSONTest2.java
+++ b/src/test/java/com/alibaba/json/bvt/JSONTest2.java
@@ -5,7 +5,12 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Map;
 
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.JSONPath;
+import com.alibaba.fastjson.JSONPathException;
+import com.alibaba.fastjson.parser.Feature;
 import junit.framework.TestCase;
 
 import org.apache.commons.io.IOUtils;
@@ -78,5 +83,32 @@ public class JSONTest2 extends TestCase {
     
     public void test_7() throws Exception {
         Assert.assertNull(JSON.parseObject(null, new TypeReference<Integer>() {}.getType(), 0));
+    }
+
+    public void test_8() {
+        String val = "{\"a\":1,,,\"b\":2}";
+        Map<String, Integer> map = JSON.parseObject(val, Map.class);
+        Assert.assertEquals(2, map.size());
+        Assert.assertEquals(Integer.valueOf(1), map.get("a"));
+        Assert.assertEquals(Integer.valueOf(2), map.get("b"));
+    }
+
+    public void test_9() {
+        String val = "{\"a\":1,,,\"b\":2}";
+        Map<String, Integer> map = JSON.parseObject(val, Map.class, false);
+        Assert.assertEquals(2, map.size());
+        Assert.assertEquals(Integer.valueOf(1), map.get("a"));
+        Assert.assertEquals(Integer.valueOf(2), map.get("b"));
+    }
+
+    public void test_10() {
+        String val = "{\"a\":1,,,\"b\":2}";
+        Exception error = null;
+        try {
+            JSON.parseObject(val, Map.class, false, Feature.AllowArbitraryCommas);
+        } catch (JSONException ex) {
+            error = ex;
+        }
+        assertNotNull(error);
     }
 }


### PR DESCRIPTION
目前对于DEFAULT_PARSER_FEATURE的配置项目前没有很方便关闭某几个Feature的方法，比如关闭`Feature.AllowArbitraryCommas`所以新增了一个方法主要是针对DEFAULT_PARSER_FEATURE配置，同时兼容其他配置。
```java
parseObject(String json, Class<T> clazz, boolean isFeaturesEnable, Feature... features)
```
如果可以，后面会继续同样增强其他parse方法。