### PR TITLE
Fix issue 3796 类的字段过多时，生成的字节码错误

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/ASMDeserializerFactory.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/ASMDeserializerFactory.java
@@ -699,7 +699,12 @@ public class ASMDeserializerFactory implements Opcodes {
         mw.visitVarInsn(ALOAD, context.var("lexer"));
         mw.visitFieldInsn(GETFIELD, JSONLexerBase, "matchStat", "I");
         mw.visitLdcInsn(com.alibaba.fastjson.parser.JSONLexerBase.END);
-        mw.visitJumpInsn(IF_ICMPEQ, return_);
+        //mw.visitJumpInsn(IF_ICMPEQ, return_);
+
+        Label continue_3 = new Label();
+        mw.visitJumpInsn(IF_ICMPNE, continue_3);
+        mw.visitJumpInsn(GOTO_W, return_);
+        mw.visitLabel(continue_3);
 
         mw.visitInsn(ICONST_0); // UNKOWN
         mw.visitIntInsn(ISTORE, context.var("matchStat"));

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/TestIssues3796.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/TestIssues3796.java
@@ -1,0 +1,18 @@
+package com.alibaba.fastjson.deserializer.issues3796;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.deserializer.issues3796.bean.LargeJavaBean;
+import org.junit.Test;
+
+/**
+ * @author kurisu9az
+ * @description 修复issues3796
+ * @date 2021/6/2 18:48
+ **/
+public class TestIssues3796 {
+
+    @Test
+    public void testIssues3796() {
+        JSON.parseObject("{}", LargeJavaBean.class);
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/CommonObject.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/CommonObject.java
@@ -1,0 +1,44 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+public class CommonObject {
+
+	private int a;
+
+	private int b;
+
+
+	private int c;
+
+	public CommonObject() {
+	}
+
+	public CommonObject(int a, int b) {
+		this.a = a;
+		this.b = b;
+	}
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/CommonObject2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/CommonObject2.java
@@ -1,0 +1,25 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+public class CommonObject2 {
+	
+	private int a;
+	
+	private long b;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public long getB() {
+		return b;
+	}
+
+	public void setB(long b) {
+		this.b = b;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/CommonObject3.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/CommonObject3.java
@@ -1,0 +1,34 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+public class CommonObject3 {
+	
+	private long a;
+	
+	private long b;
+	
+	private int c;
+
+	public long getA() {
+		return a;
+	}
+
+	public void setA(long a) {
+		this.a = a;
+	}
+
+	public long getB() {
+		return b;
+	}
+
+	public void setB(long b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/LargeJavaBean.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/LargeJavaBean.java
@@ -1,0 +1,1431 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import com.alibaba.fastjson.annotation.JSONField;
+
+import java.util.List;
+
+public class LargeJavaBean {
+	public static final String testName = "testName";
+	
+	@JSONField(name = "_id")
+	private long id;
+	
+	private String a = "null";
+
+	
+	private String b = "null";
+	
+	private String c = "null";
+
+	private int d = -1;
+	
+	private String e = "null";
+	
+	private String f = "null";
+	
+	private String g = "null";
+
+	
+	@JSONField(serialize = false)
+	private ObjectA h = new ObjectA();
+
+	private int i;
+
+	private int j;
+
+	
+	private String k;
+	
+	private String l;
+
+	
+	private ObjectB m = new ObjectB();
+
+	
+	private int n;
+
+	
+	private String o;
+
+	
+	private int p;
+
+	
+	private long q;
+
+	
+	private long r;
+	
+	private long s;
+
+	
+	private long t;
+	
+	private long u;
+	
+	private long v;
+
+	
+	private int w = 0;
+	
+	private int x = 0;
+	
+	private boolean y = false;
+
+	private List<ObjectC> z;
+
+	
+	private List<ObjectD> a1;
+
+	
+	private List<ObjectE> b1;
+
+	
+	private List<CommonObject> c1;
+
+	
+	private List<ObjectF> d1;
+
+	
+	@JSONField(serialize = false)
+	private List<ObjectG> e1;
+
+	
+	private long f1;
+
+	
+	private long g1;
+
+	
+	private List<ObjectH> h1;
+
+	
+
+	private List<Integer> j1;
+
+	
+	private ObjectI k1;
+	
+	private List<Integer> l1;
+	
+	private List<ObjectJ> m1;
+
+	
+	private ObjectL n1;
+	
+	private List<ObjectM> o1;
+
+	
+	private ObjectN p1;
+
+	
+	private int q1;
+
+	
+	private long r1;
+
+	
+	private long[] s1;
+
+	@JSONField(serialize = false)
+	private ObjectO t1;
+
+	@JSONField(serialize = false)
+	private ObjectP u1;
+
+	
+	private List<ObjectQ> v1;
+
+	
+	private List<Integer> w1;
+	
+	private List<ObjectR> x1;
+	
+	private List<Integer> y1;
+	
+	private List<ObjectS> z1;
+
+	
+	private ObjectT a2 = new ObjectT();
+	
+	private List<ObjectU> b2;
+	
+	private ObjectV c2 = new ObjectV();
+	
+	private List<ObjectW> d2;
+
+	
+	private List<ObjectW> e2;
+
+	
+	private ObjectX f2;
+
+	
+	private ObjectY g2;
+
+	
+	private ObjectZ h2;
+
+	
+	private int i2 = 0;
+
+	
+	private ObjectA1 j2;
+
+	
+	private List<CommonObject2> k2;
+
+	
+	private ObjectB1 l2;
+
+	
+	private List<ObjectC1> m2;
+
+	
+	private int n2;
+
+	
+	private ObjectD1 o2;
+
+	
+	private int p2;
+
+	
+	long q2;
+
+	
+	long r2;
+
+	
+	int s2;
+
+	
+	int t2;
+
+	
+	int u2;
+
+	
+	int v2;
+
+	
+	int w2;
+
+	
+	private List<ObjectE1> x2;
+
+	
+	private List<ObjectE1> y2;
+
+	ObjectF1 z2 = new ObjectF1();
+	
+	private List<Integer> a3;
+
+	
+	private List<ObjectG1> b3;
+	
+	private List<Integer> c3;
+	
+	private ObjectH1 d3;
+
+	
+	private List <CommonObject> e3;
+
+	
+	private ObjectI1 f3;
+
+	
+	private ObjectJ1 g3;
+
+	
+	private ObjectK1 h3;
+
+
+	ObjectL1 i3 = new ObjectL1();
+
+	
+	private ObjectM1 j3;
+	
+	private ObjectN1 k3;
+
+	
+	private List<CommonObject> l3;
+
+	
+	private List<ObjectO1> m3;
+
+	
+	private ObjectP1 n3;
+
+	
+	private List<ObjectQ1> o3;
+
+	
+	private ObjectR1 p3;
+
+	
+	private ObjectS1 q3;
+
+	
+	private List<ObjectT1> r3;
+
+	
+	private List<ObjectU1> s3;
+
+	
+	private ObjectV1 t3;
+
+	
+	private List<Integer> u3;
+
+	
+	private int v3;
+
+	
+	private ObjectW1 w3;
+
+	
+	private List<ObjectX1>  x3;
+	
+	private List<Integer> y3;
+	
+	private List<Integer> z3;
+	
+	private int a4;
+	
+	private List<ObjectY1> b4;
+
+	
+	private ObjectZ1 c4;
+
+	
+	private List<ObjectA2> d4;
+
+	
+	private ObjectB2 e4;
+
+	
+	private List<ObjectC2> f4;
+	
+	private List<ObjectD2> g4 ;
+
+	
+	private List<ObjectE2> h4;
+
+	
+	private ObjectF2 i4;
+
+	
+	private ObjectG2 j4;
+	
+	private ObjectH2 k4;
+	
+	private ObjectI2 l4;
+	
+	private int m4;
+	
+	private ObjectJ2 n4;
+	
+	private List<ObjectK2> o4;
+	private int p4;
+	private int q4;
+	private List<Integer> r4;
+
+	
+	private List<String> s4;
+
+	
+	private int t4;
+	private boolean u4 = false;
+	
+	private List<ObjectL2> v4;
+
+	
+	private int w4;
+
+	
+	private ObjectM2 x4;
+
+	
+	private ObjectM2 y4;
+
+	
+	private List<ObjectN2> z4;
+
+	
+	private List<CommonObject> a5;
+
+	
+	private boolean[] b5;
+
+	
+	private ObjectO2 c5;
+
+	public static String getTestName() {
+		return testName;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getA() {
+		return a;
+	}
+
+	public void setA(String a) {
+		this.a = a;
+	}
+
+	public String getB() {
+		return b;
+	}
+
+	public void setB(String b) {
+		this.b = b;
+	}
+
+	public String getC() {
+		return c;
+	}
+
+	public void setC(String c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public String getE() {
+		return e;
+	}
+
+	public void setE(String e) {
+		this.e = e;
+	}
+
+	public String getF() {
+		return f;
+	}
+
+	public void setF(String f) {
+		this.f = f;
+	}
+
+	public String getG() {
+		return g;
+	}
+
+	public void setG(String g) {
+		this.g = g;
+	}
+
+	public ObjectA getH() {
+		return h;
+	}
+
+	public void setH(ObjectA h) {
+		this.h = h;
+	}
+
+	public int getI() {
+		return i;
+	}
+
+	public void setI(int i) {
+		this.i = i;
+	}
+
+	public int getJ() {
+		return j;
+	}
+
+	public void setJ(int j) {
+		this.j = j;
+	}
+
+	public String getK() {
+		return k;
+	}
+
+	public void setK(String k) {
+		this.k = k;
+	}
+
+	public String getL() {
+		return l;
+	}
+
+	public void setL(String l) {
+		this.l = l;
+	}
+
+	public ObjectB getM() {
+		return m;
+	}
+
+	public void setM(ObjectB m) {
+		this.m = m;
+	}
+
+	public int getN() {
+		return n;
+	}
+
+	public void setN(int n) {
+		this.n = n;
+	}
+
+	public String getO() {
+		return o;
+	}
+
+	public void setO(String o) {
+		this.o = o;
+	}
+
+	public int getP() {
+		return p;
+	}
+
+	public void setP(int p) {
+		this.p = p;
+	}
+
+	public long getQ() {
+		return q;
+	}
+
+	public void setQ(long q) {
+		this.q = q;
+	}
+
+	public long getR() {
+		return r;
+	}
+
+	public void setR(long r) {
+		this.r = r;
+	}
+
+	public long getS() {
+		return s;
+	}
+
+	public void setS(long s) {
+		this.s = s;
+	}
+
+	public long getT() {
+		return t;
+	}
+
+	public void setT(long t) {
+		this.t = t;
+	}
+
+	public long getU() {
+		return u;
+	}
+
+	public void setU(long u) {
+		this.u = u;
+	}
+
+	public long getV() {
+		return v;
+	}
+
+	public void setV(long v) {
+		this.v = v;
+	}
+
+	public int getW() {
+		return w;
+	}
+
+	public void setW(int w) {
+		this.w = w;
+	}
+
+	public int getX() {
+		return x;
+	}
+
+	public void setX(int x) {
+		this.x = x;
+	}
+
+	public boolean isY() {
+		return y;
+	}
+
+	public void setY(boolean y) {
+		this.y = y;
+	}
+
+	public List<ObjectC> getZ() {
+		return z;
+	}
+
+	public void setZ(List<ObjectC> z) {
+		this.z = z;
+	}
+
+	public List<ObjectD> getA1() {
+		return a1;
+	}
+
+	public void setA1(List<ObjectD> a1) {
+		this.a1 = a1;
+	}
+
+	public List<ObjectE> getB1() {
+		return b1;
+	}
+
+	public void setB1(List<ObjectE> b1) {
+		this.b1 = b1;
+	}
+
+	public List<CommonObject> getC1() {
+		return c1;
+	}
+
+	public void setC1(List<CommonObject> c1) {
+		this.c1 = c1;
+	}
+
+	public List<ObjectF> getD1() {
+		return d1;
+	}
+
+	public void setD1(List<ObjectF> d1) {
+		this.d1 = d1;
+	}
+
+	public List<ObjectG> getE1() {
+		return e1;
+	}
+
+	public void setE1(List<ObjectG> e1) {
+		this.e1 = e1;
+	}
+
+	public long getF1() {
+		return f1;
+	}
+
+	public void setF1(long f1) {
+		this.f1 = f1;
+	}
+
+	public long getG1() {
+		return g1;
+	}
+
+	public void setG1(long g1) {
+		this.g1 = g1;
+	}
+
+	public List<ObjectH> getH1() {
+		return h1;
+	}
+
+	public void setH1(List<ObjectH> h1) {
+		this.h1 = h1;
+	}
+
+	public List<Integer> getJ1() {
+		return j1;
+	}
+
+	public void setJ1(List<Integer> j1) {
+		this.j1 = j1;
+	}
+
+	public ObjectI getK1() {
+		return k1;
+	}
+
+	public void setK1(ObjectI k1) {
+		this.k1 = k1;
+	}
+
+	public List<Integer> getL1() {
+		return l1;
+	}
+
+	public void setL1(List<Integer> l1) {
+		this.l1 = l1;
+	}
+
+	public List<ObjectJ> getM1() {
+		return m1;
+	}
+
+	public void setM1(List<ObjectJ> m1) {
+		this.m1 = m1;
+	}
+
+	public ObjectL getN1() {
+		return n1;
+	}
+
+	public void setN1(ObjectL n1) {
+		this.n1 = n1;
+	}
+
+	public List<ObjectM> getO1() {
+		return o1;
+	}
+
+	public void setO1(List<ObjectM> o1) {
+		this.o1 = o1;
+	}
+
+	public ObjectN getP1() {
+		return p1;
+	}
+
+	public void setP1(ObjectN p1) {
+		this.p1 = p1;
+	}
+
+	public int getQ1() {
+		return q1;
+	}
+
+	public void setQ1(int q1) {
+		this.q1 = q1;
+	}
+
+	public long getR1() {
+		return r1;
+	}
+
+	public void setR1(long r1) {
+		this.r1 = r1;
+	}
+
+	public long[] getS1() {
+		return s1;
+	}
+
+	public void setS1(long[] s1) {
+		this.s1 = s1;
+	}
+
+	public ObjectO getT1() {
+		return t1;
+	}
+
+	public void setT1(ObjectO t1) {
+		this.t1 = t1;
+	}
+
+	public ObjectP getU1() {
+		return u1;
+	}
+
+	public void setU1(ObjectP u1) {
+		this.u1 = u1;
+	}
+
+	public List<ObjectQ> getV1() {
+		return v1;
+	}
+
+	public void setV1(List<ObjectQ> v1) {
+		this.v1 = v1;
+	}
+
+	public List<Integer> getW1() {
+		return w1;
+	}
+
+	public void setW1(List<Integer> w1) {
+		this.w1 = w1;
+	}
+
+	public List<ObjectR> getX1() {
+		return x1;
+	}
+
+	public void setX1(List<ObjectR> x1) {
+		this.x1 = x1;
+	}
+
+	public List<Integer> getY1() {
+		return y1;
+	}
+
+	public void setY1(List<Integer> y1) {
+		this.y1 = y1;
+	}
+
+	public List<ObjectS> getZ1() {
+		return z1;
+	}
+
+	public void setZ1(List<ObjectS> z1) {
+		this.z1 = z1;
+	}
+
+	public ObjectT getA2() {
+		return a2;
+	}
+
+	public void setA2(ObjectT a2) {
+		this.a2 = a2;
+	}
+
+	public List<ObjectU> getB2() {
+		return b2;
+	}
+
+	public void setB2(List<ObjectU> b2) {
+		this.b2 = b2;
+	}
+
+	public ObjectV getC2() {
+		return c2;
+	}
+
+	public void setC2(ObjectV c2) {
+		this.c2 = c2;
+	}
+
+	public List<ObjectW> getD2() {
+		return d2;
+	}
+
+	public void setD2(List<ObjectW> d2) {
+		this.d2 = d2;
+	}
+
+	public List<ObjectW> getE2() {
+		return e2;
+	}
+
+	public void setE2(List<ObjectW> e2) {
+		this.e2 = e2;
+	}
+
+	public ObjectX getF2() {
+		return f2;
+	}
+
+	public void setF2(ObjectX f2) {
+		this.f2 = f2;
+	}
+
+	public ObjectY getG2() {
+		return g2;
+	}
+
+	public void setG2(ObjectY g2) {
+		this.g2 = g2;
+	}
+
+	public ObjectZ getH2() {
+		return h2;
+	}
+
+	public void setH2(ObjectZ h2) {
+		this.h2 = h2;
+	}
+
+	public int getI2() {
+		return i2;
+	}
+
+	public void setI2(int i2) {
+		this.i2 = i2;
+	}
+
+	public ObjectA1 getJ2() {
+		return j2;
+	}
+
+	public void setJ2(ObjectA1 j2) {
+		this.j2 = j2;
+	}
+
+	public List<CommonObject2> getK2() {
+		return k2;
+	}
+
+	public void setK2(List<CommonObject2> k2) {
+		this.k2 = k2;
+	}
+
+	public ObjectB1 getL2() {
+		return l2;
+	}
+
+	public void setL2(ObjectB1 l2) {
+		this.l2 = l2;
+	}
+
+	public List<ObjectC1> getM2() {
+		return m2;
+	}
+
+	public void setM2(List<ObjectC1> m2) {
+		this.m2 = m2;
+	}
+
+	public int getN2() {
+		return n2;
+	}
+
+	public void setN2(int n2) {
+		this.n2 = n2;
+	}
+
+	public ObjectD1 getO2() {
+		return o2;
+	}
+
+	public void setO2(ObjectD1 o2) {
+		this.o2 = o2;
+	}
+
+	public int getP2() {
+		return p2;
+	}
+
+	public void setP2(int p2) {
+		this.p2 = p2;
+	}
+
+	public long getQ2() {
+		return q2;
+	}
+
+	public void setQ2(long q2) {
+		this.q2 = q2;
+	}
+
+	public long getR2() {
+		return r2;
+	}
+
+	public void setR2(long r2) {
+		this.r2 = r2;
+	}
+
+	public int getS2() {
+		return s2;
+	}
+
+	public void setS2(int s2) {
+		this.s2 = s2;
+	}
+
+	public int getT2() {
+		return t2;
+	}
+
+	public void setT2(int t2) {
+		this.t2 = t2;
+	}
+
+	public int getU2() {
+		return u2;
+	}
+
+	public void setU2(int u2) {
+		this.u2 = u2;
+	}
+
+	public int getV2() {
+		return v2;
+	}
+
+	public void setV2(int v2) {
+		this.v2 = v2;
+	}
+
+	public int getW2() {
+		return w2;
+	}
+
+	public void setW2(int w2) {
+		this.w2 = w2;
+	}
+
+	public List<ObjectE1> getX2() {
+		return x2;
+	}
+
+	public void setX2(List<ObjectE1> x2) {
+		this.x2 = x2;
+	}
+
+	public List<ObjectE1> getY2() {
+		return y2;
+	}
+
+	public void setY2(List<ObjectE1> y2) {
+		this.y2 = y2;
+	}
+
+	public ObjectF1 getZ2() {
+		return z2;
+	}
+
+	public void setZ2(ObjectF1 z2) {
+		this.z2 = z2;
+	}
+
+	public List<Integer> getA3() {
+		return a3;
+	}
+
+	public void setA3(List<Integer> a3) {
+		this.a3 = a3;
+	}
+
+	public List<ObjectG1> getB3() {
+		return b3;
+	}
+
+	public void setB3(List<ObjectG1> b3) {
+		this.b3 = b3;
+	}
+
+	public List<Integer> getC3() {
+		return c3;
+	}
+
+	public void setC3(List<Integer> c3) {
+		this.c3 = c3;
+	}
+
+	public ObjectH1 getD3() {
+		return d3;
+	}
+
+	public void setD3(ObjectH1 d3) {
+		this.d3 = d3;
+	}
+
+	public List<CommonObject> getE3() {
+		return e3;
+	}
+
+	public void setE3(List<CommonObject> e3) {
+		this.e3 = e3;
+	}
+
+	public ObjectI1 getF3() {
+		return f3;
+	}
+
+	public void setF3(ObjectI1 f3) {
+		this.f3 = f3;
+	}
+
+	public ObjectJ1 getG3() {
+		return g3;
+	}
+
+	public void setG3(ObjectJ1 g3) {
+		this.g3 = g3;
+	}
+
+	public ObjectK1 getH3() {
+		return h3;
+	}
+
+	public void setH3(ObjectK1 h3) {
+		this.h3 = h3;
+	}
+
+	public ObjectL1 getI3() {
+		return i3;
+	}
+
+	public void setI3(ObjectL1 i3) {
+		this.i3 = i3;
+	}
+
+	public ObjectM1 getJ3() {
+		return j3;
+	}
+
+	public void setJ3(ObjectM1 j3) {
+		this.j3 = j3;
+	}
+
+	public ObjectN1 getK3() {
+		return k3;
+	}
+
+	public void setK3(ObjectN1 k3) {
+		this.k3 = k3;
+	}
+
+	public List<CommonObject> getL3() {
+		return l3;
+	}
+
+	public void setL3(List<CommonObject> l3) {
+		this.l3 = l3;
+	}
+
+	public List<ObjectO1> getM3() {
+		return m3;
+	}
+
+	public void setM3(List<ObjectO1> m3) {
+		this.m3 = m3;
+	}
+
+	public ObjectP1 getN3() {
+		return n3;
+	}
+
+	public void setN3(ObjectP1 n3) {
+		this.n3 = n3;
+	}
+
+	public List<ObjectQ1> getO3() {
+		return o3;
+	}
+
+	public void setO3(List<ObjectQ1> o3) {
+		this.o3 = o3;
+	}
+
+	public ObjectR1 getP3() {
+		return p3;
+	}
+
+	public void setP3(ObjectR1 p3) {
+		this.p3 = p3;
+	}
+
+	public ObjectS1 getQ3() {
+		return q3;
+	}
+
+	public void setQ3(ObjectS1 q3) {
+		this.q3 = q3;
+	}
+
+	public List<ObjectT1> getR3() {
+		return r3;
+	}
+
+	public void setR3(List<ObjectT1> r3) {
+		this.r3 = r3;
+	}
+
+	public List<ObjectU1> getS3() {
+		return s3;
+	}
+
+	public void setS3(List<ObjectU1> s3) {
+		this.s3 = s3;
+	}
+
+	public ObjectV1 getT3() {
+		return t3;
+	}
+
+	public void setT3(ObjectV1 t3) {
+		this.t3 = t3;
+	}
+
+	public List<Integer> getU3() {
+		return u3;
+	}
+
+	public void setU3(List<Integer> u3) {
+		this.u3 = u3;
+	}
+
+	public int getV3() {
+		return v3;
+	}
+
+	public void setV3(int v3) {
+		this.v3 = v3;
+	}
+
+	public ObjectW1 getW3() {
+		return w3;
+	}
+
+	public void setW3(ObjectW1 w3) {
+		this.w3 = w3;
+	}
+
+	public List<ObjectX1> getX3() {
+		return x3;
+	}
+
+	public void setX3(List<ObjectX1> x3) {
+		this.x3 = x3;
+	}
+
+	public List<Integer> getY3() {
+		return y3;
+	}
+
+	public void setY3(List<Integer> y3) {
+		this.y3 = y3;
+	}
+
+	public List<Integer> getZ3() {
+		return z3;
+	}
+
+	public void setZ3(List<Integer> z3) {
+		this.z3 = z3;
+	}
+
+	public int getA4() {
+		return a4;
+	}
+
+	public void setA4(int a4) {
+		this.a4 = a4;
+	}
+
+	public List<ObjectY1> getB4() {
+		return b4;
+	}
+
+	public void setB4(List<ObjectY1> b4) {
+		this.b4 = b4;
+	}
+
+	public ObjectZ1 getC4() {
+		return c4;
+	}
+
+	public void setC4(ObjectZ1 c4) {
+		this.c4 = c4;
+	}
+
+	public List<ObjectA2> getD4() {
+		return d4;
+	}
+
+	public void setD4(List<ObjectA2> d4) {
+		this.d4 = d4;
+	}
+
+	public ObjectB2 getE4() {
+		return e4;
+	}
+
+	public void setE4(ObjectB2 e4) {
+		this.e4 = e4;
+	}
+
+	public List<ObjectC2> getF4() {
+		return f4;
+	}
+
+	public void setF4(List<ObjectC2> f4) {
+		this.f4 = f4;
+	}
+
+	public List<ObjectD2> getG4() {
+		return g4;
+	}
+
+	public void setG4(List<ObjectD2> g4) {
+		this.g4 = g4;
+	}
+
+	public List<ObjectE2> getH4() {
+		return h4;
+	}
+
+	public void setH4(List<ObjectE2> h4) {
+		this.h4 = h4;
+	}
+
+	public ObjectF2 getI4() {
+		return i4;
+	}
+
+	public void setI4(ObjectF2 i4) {
+		this.i4 = i4;
+	}
+
+	public ObjectG2 getJ4() {
+		return j4;
+	}
+
+	public void setJ4(ObjectG2 j4) {
+		this.j4 = j4;
+	}
+
+	public ObjectH2 getK4() {
+		return k4;
+	}
+
+	public void setK4(ObjectH2 k4) {
+		this.k4 = k4;
+	}
+
+	public ObjectI2 getL4() {
+		return l4;
+	}
+
+	public void setL4(ObjectI2 l4) {
+		this.l4 = l4;
+	}
+
+	public int getM4() {
+		return m4;
+	}
+
+	public void setM4(int m4) {
+		this.m4 = m4;
+	}
+
+	public ObjectJ2 getN4() {
+		return n4;
+	}
+
+	public void setN4(ObjectJ2 n4) {
+		this.n4 = n4;
+	}
+
+	public List<ObjectK2> getO4() {
+		return o4;
+	}
+
+	public void setO4(List<ObjectK2> o4) {
+		this.o4 = o4;
+	}
+
+	public int getP4() {
+		return p4;
+	}
+
+	public void setP4(int p4) {
+		this.p4 = p4;
+	}
+
+	public int getQ4() {
+		return q4;
+	}
+
+	public void setQ4(int q4) {
+		this.q4 = q4;
+	}
+
+	public List<Integer> getR4() {
+		return r4;
+	}
+
+	public void setR4(List<Integer> r4) {
+		this.r4 = r4;
+	}
+
+	public List<String> getS4() {
+		return s4;
+	}
+
+	public void setS4(List<String> s4) {
+		this.s4 = s4;
+	}
+
+	public int getT4() {
+		return t4;
+	}
+
+	public void setT4(int t4) {
+		this.t4 = t4;
+	}
+
+	public boolean isU4() {
+		return u4;
+	}
+
+	public void setU4(boolean u4) {
+		this.u4 = u4;
+	}
+
+	public List<ObjectL2> getV4() {
+		return v4;
+	}
+
+	public void setV4(List<ObjectL2> v4) {
+		this.v4 = v4;
+	}
+
+	public int getW4() {
+		return w4;
+	}
+
+	public void setW4(int w4) {
+		this.w4 = w4;
+	}
+
+	public ObjectM2 getX4() {
+		return x4;
+	}
+
+	public void setX4(ObjectM2 x4) {
+		this.x4 = x4;
+	}
+
+	public ObjectM2 getY4() {
+		return y4;
+	}
+
+	public void setY4(ObjectM2 y4) {
+		this.y4 = y4;
+	}
+
+	public List<ObjectN2> getZ4() {
+		return z4;
+	}
+
+	public void setZ4(List<ObjectN2> z4) {
+		this.z4 = z4;
+	}
+
+	public List<CommonObject> getA5() {
+		return a5;
+	}
+
+	public void setA5(List<CommonObject> a5) {
+		this.a5 = a5;
+	}
+
+	public boolean[] getB5() {
+		return b5;
+	}
+
+	public void setB5(boolean[] b5) {
+		this.b5 = b5;
+	}
+
+	public ObjectO2 getC5() {
+		return c5;
+	}
+
+	public void setC5(ObjectO2 c5) {
+		this.c5 = c5;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectA.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectA.java
@@ -1,0 +1,270 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+public class ObjectA {
+
+    private static final String NULL = "NULL";
+    
+    private String a = NULL;
+
+    private String b = NULL;
+
+    private String c = NULL;
+    
+    private String d = NULL;
+
+    
+    
+    private String e = NULL;
+
+    
+    
+    private int f;
+
+    
+    
+    private int g;
+
+    
+    
+    private float h;
+
+    
+    
+    private String i = NULL;
+
+    
+    
+    private int j;
+
+    
+    
+    private String k = NULL;
+
+    
+    
+    private String l = NULL;
+
+    
+    
+    private String m = NULL;
+
+    
+    
+    private int n = 1;
+
+    
+
+    private String o = NULL;
+
+    
+    
+    private String p = NULL;
+
+    
+    
+    private int q;
+
+    
+    
+    private int r;
+
+    
+    
+    private String s = "NULL";
+
+
+    
+    
+    private String t = "NULL";
+
+    
+    
+    private String u = "NULL";
+
+    
+    
+    private String v = "NULL";
+
+
+    public static String getNULL() {
+        return NULL;
+    }
+
+    public String getA() {
+        return a;
+    }
+
+    public void setA(String a) {
+        this.a = a;
+    }
+
+    public String getB() {
+        return b;
+    }
+
+    public void setB(String b) {
+        this.b = b;
+    }
+
+    public String getC() {
+        return c;
+    }
+
+    public void setC(String c) {
+        this.c = c;
+    }
+
+    public String getD() {
+        return d;
+    }
+
+    public void setD(String d) {
+        this.d = d;
+    }
+
+    public String getE() {
+        return e;
+    }
+
+    public void setE(String e) {
+        this.e = e;
+    }
+
+    public int getF() {
+        return f;
+    }
+
+    public void setF(int f) {
+        this.f = f;
+    }
+
+    public int getG() {
+        return g;
+    }
+
+    public void setG(int g) {
+        this.g = g;
+    }
+
+    public float getH() {
+        return h;
+    }
+
+    public void setH(float h) {
+        this.h = h;
+    }
+
+    public String getI() {
+        return i;
+    }
+
+    public void setI(String i) {
+        this.i = i;
+    }
+
+    public int getJ() {
+        return j;
+    }
+
+    public void setJ(int j) {
+        this.j = j;
+    }
+
+    public String getK() {
+        return k;
+    }
+
+    public void setK(String k) {
+        this.k = k;
+    }
+
+    public String getL() {
+        return l;
+    }
+
+    public void setL(String l) {
+        this.l = l;
+    }
+
+    public String getM() {
+        return m;
+    }
+
+    public void setM(String m) {
+        this.m = m;
+    }
+
+    public int getN() {
+        return n;
+    }
+
+    public void setN(int n) {
+        this.n = n;
+    }
+
+    public String getO() {
+        return o;
+    }
+
+    public void setO(String o) {
+        this.o = o;
+    }
+
+    public String getP() {
+        return p;
+    }
+
+    public void setP(String p) {
+        this.p = p;
+    }
+
+    public int getQ() {
+        return q;
+    }
+
+    public void setQ(int q) {
+        this.q = q;
+    }
+
+    public int getR() {
+        return r;
+    }
+
+    public void setR(int r) {
+        this.r = r;
+    }
+
+    public String getS() {
+        return s;
+    }
+
+    public void setS(String s) {
+        this.s = s;
+    }
+
+    public String getT() {
+        return t;
+    }
+
+    public void setT(String t) {
+        this.t = t;
+    }
+
+    public String getU() {
+        return u;
+    }
+
+    public void setU(String u) {
+        this.u = u;
+    }
+
+    public String getV() {
+        return v;
+    }
+
+    public void setV(String v) {
+        this.v = v;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectA1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectA1.java
@@ -1,0 +1,61 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import java.util.List;
+
+
+public class ObjectA1 {
+	
+	private List<CommonObject> a;
+	
+	private CommonObject b;
+
+
+	
+	private CommonObject c;
+
+	
+	private List<CommonObject> d;
+
+	
+	private boolean e = true;
+
+	public List<CommonObject> getA() {
+		return a;
+	}
+
+	public void setA(List<CommonObject> a) {
+		this.a = a;
+	}
+
+	public CommonObject getB() {
+		return b;
+	}
+
+	public void setB(CommonObject b) {
+		this.b = b;
+	}
+
+	public CommonObject getC() {
+		return c;
+	}
+
+	public void setC(CommonObject c) {
+		this.c = c;
+	}
+
+	public List<CommonObject> getD() {
+		return d;
+	}
+
+	public void setD(List<CommonObject> d) {
+		this.d = d;
+	}
+
+	public boolean isE() {
+		return e;
+	}
+
+	public void setE(boolean e) {
+		this.e = e;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectA2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectA2.java
@@ -1,0 +1,47 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+public class ObjectA2 {
+	
+	private int a;
+	
+	private int b;
+
+	
+	private long c;
+
+	
+	private int d;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public long getC() {
+		return c;
+	}
+
+	public void setC(long c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectB.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectB.java
@@ -1,0 +1,183 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+public class ObjectB {
+	
+	private long a;
+	
+	private long b;
+	
+	private long c;
+	
+	private long d;
+	
+	private long e;
+	
+	private long f;
+	
+	private long g;
+
+	
+	private long h;
+
+	
+	private long i;
+
+	
+	private long j;
+
+	
+	private long k = 0;
+
+	
+	private long l = 0;
+	
+	private long m = 0;
+
+	
+	private long n;
+
+	
+	private long o;
+
+	
+	private long p;
+
+	
+	private int q;
+
+	public long getA() {
+		return a;
+	}
+
+	public void setA(long a) {
+		this.a = a;
+	}
+
+	public long getB() {
+		return b;
+	}
+
+	public void setB(long b) {
+		this.b = b;
+	}
+
+	public long getC() {
+		return c;
+	}
+
+	public void setC(long c) {
+		this.c = c;
+	}
+
+	public long getD() {
+		return d;
+	}
+
+	public void setD(long d) {
+		this.d = d;
+	}
+
+	public long getE() {
+		return e;
+	}
+
+	public void setE(long e) {
+		this.e = e;
+	}
+
+	public long getF() {
+		return f;
+	}
+
+	public void setF(long f) {
+		this.f = f;
+	}
+
+	public long getG() {
+		return g;
+	}
+
+	public void setG(long g) {
+		this.g = g;
+	}
+
+	public long getH() {
+		return h;
+	}
+
+	public void setH(long h) {
+		this.h = h;
+	}
+
+	public long getI() {
+		return i;
+	}
+
+	public void setI(long i) {
+		this.i = i;
+	}
+
+	public long getJ() {
+		return j;
+	}
+
+	public void setJ(long j) {
+		this.j = j;
+	}
+
+	public long getK() {
+		return k;
+	}
+
+	public void setK(long k) {
+		this.k = k;
+	}
+
+	public long getL() {
+		return l;
+	}
+
+	public void setL(long l) {
+		this.l = l;
+	}
+
+	public long getM() {
+		return m;
+	}
+
+	public void setM(long m) {
+		this.m = m;
+	}
+
+	public long getN() {
+		return n;
+	}
+
+	public void setN(long n) {
+		this.n = n;
+	}
+
+	public long getO() {
+		return o;
+	}
+
+	public void setO(long o) {
+		this.o = o;
+	}
+
+	public long getP() {
+		return p;
+	}
+
+	public void setP(long p) {
+		this.p = p;
+	}
+
+	public int getQ() {
+		return q;
+	}
+
+	public void setQ(int q) {
+		this.q = q;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectB1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectB1.java
@@ -1,0 +1,27 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import java.util.List;
+
+public class ObjectB1 {
+    
+    List<ObjectI_A> a;
+
+    
+    private int b;
+
+    public List<ObjectI_A> getA() {
+        return a;
+    }
+
+    public void setA(List<ObjectI_A> a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectB2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectB2.java
@@ -1,0 +1,56 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import com.alibaba.fastjson.annotation.JSONField;
+
+import java.util.List;
+
+public class ObjectB2 {
+
+
+    
+    @JSONField(serialize = false)
+    private int a = 1;
+
+
+    
+    @JSONField(serialize = false)
+    private long b;
+
+
+    private List<Boolean> c;
+
+
+    private List<Integer> d;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public long getB() {
+        return b;
+    }
+
+    public void setB(long b) {
+        this.b = b;
+    }
+
+    public List<Boolean> getC() {
+        return c;
+    }
+
+    public void setC(List<Boolean> c) {
+        this.c = c;
+    }
+
+    public List<Integer> getD() {
+        return d;
+    }
+
+    public void setD(List<Integer> d) {
+        this.d = d;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectC.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectC.java
@@ -1,0 +1,44 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+public class ObjectC {
+	
+	private int a;
+	
+	private int b = 0;
+	
+	private long c;
+	
+	private int d;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public long getC() {
+		return c;
+	}
+
+	public void setC(long c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectC1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectC1.java
@@ -1,0 +1,55 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+public class ObjectC1 {
+	
+	private int a;
+
+	
+	private int b;
+	
+	private int c;
+	
+	private int d;
+
+	private int e;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectC2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectC2.java
@@ -1,0 +1,23 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+public class ObjectC2 {
+    private int a;
+
+    private boolean b;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public boolean isB() {
+        return b;
+    }
+
+    public void setB(boolean b) {
+        this.b = b;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectD.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectD.java
@@ -1,0 +1,178 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import java.util.List;
+
+public class ObjectD {
+	
+	private int a;
+
+	
+	private int b;
+
+	
+	private int c;
+
+	
+	private int d;
+
+	
+	private boolean e;
+
+	
+	private List<ObjectD_A> f;
+
+	
+	private int g;
+
+	
+	private int h;
+
+	
+	private long i;
+
+	
+	private long j;
+
+	
+	private int k;
+
+	
+	private int l;
+
+	
+	private ObjectD_B m;
+	
+	private long n;
+	
+	private long o;
+	
+	private long dieFans;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public boolean isE() {
+		return e;
+	}
+
+	public void setE(boolean e) {
+		this.e = e;
+	}
+
+	public List<ObjectD_A> getF() {
+		return f;
+	}
+
+	public void setF(List<ObjectD_A> f) {
+		this.f = f;
+	}
+
+	public int getG() {
+		return g;
+	}
+
+	public void setG(int g) {
+		this.g = g;
+	}
+
+	public int getH() {
+		return h;
+	}
+
+	public void setH(int h) {
+		this.h = h;
+	}
+
+	public long getI() {
+		return i;
+	}
+
+	public void setI(long i) {
+		this.i = i;
+	}
+
+	public long getJ() {
+		return j;
+	}
+
+	public void setJ(long j) {
+		this.j = j;
+	}
+
+	public int getK() {
+		return k;
+	}
+
+	public void setK(int k) {
+		this.k = k;
+	}
+
+	public int getL() {
+		return l;
+	}
+
+	public void setL(int l) {
+		this.l = l;
+	}
+
+	public ObjectD_B getM() {
+		return m;
+	}
+
+	public void setM(ObjectD_B m) {
+		this.m = m;
+	}
+
+	public long getN() {
+		return n;
+	}
+
+	public void setN(long n) {
+		this.n = n;
+	}
+
+	public long getO() {
+		return o;
+	}
+
+	public void setO(long o) {
+		this.o = o;
+	}
+
+	public long getDieFans() {
+		return dieFans;
+	}
+
+	public void setDieFans(long dieFans) {
+		this.dieFans = dieFans;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectD1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectD1.java
@@ -1,0 +1,36 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import java.util.List;
+
+public class ObjectD1 {
+	
+	private int a;
+	
+	private int b;
+	
+	private List<ObjectD1_A> c;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public List<ObjectD1_A> getC() {
+		return c;
+	}
+
+	public void setC(List<ObjectD1_A> c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectD1_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectD1_A.java
@@ -1,0 +1,69 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import java.util.List;
+
+public class ObjectD1_A {
+	
+	private int a;
+	
+	private List<Integer> b;
+	
+	private int c;
+
+	
+	private CommonObject d;
+
+	
+	private int e;
+
+	
+	private int f;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public List<Integer> getB() {
+		return b;
+	}
+
+	public void setB(List<Integer> b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public CommonObject getD() {
+		return d;
+	}
+
+	public void setD(CommonObject d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public int getF() {
+		return f;
+	}
+
+	public void setF(int f) {
+		this.f = f;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectD2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectD2.java
@@ -1,0 +1,151 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import java.util.List;
+
+
+public class ObjectD2 {
+	
+	private int a;
+	
+	private int b;
+	
+	private int c;
+	
+	private List<Integer> d;
+	private List<Integer> e;
+	private List<Integer> f;
+	private List<Integer> g;
+	private List<Integer> h;
+	
+	private List<CommonObject> i;
+	
+	private int j;
+	
+	private int k;
+	
+	private int l;
+	private boolean m;
+	private boolean n;
+	
+	private int o;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public List<Integer> getD() {
+		return d;
+	}
+
+	public void setD(List<Integer> d) {
+		this.d = d;
+	}
+
+	public List<Integer> getE() {
+		return e;
+	}
+
+	public void setE(List<Integer> e) {
+		this.e = e;
+	}
+
+	public List<Integer> getF() {
+		return f;
+	}
+
+	public void setF(List<Integer> f) {
+		this.f = f;
+	}
+
+	public List<Integer> getG() {
+		return g;
+	}
+
+	public void setG(List<Integer> g) {
+		this.g = g;
+	}
+
+	public List<Integer> getH() {
+		return h;
+	}
+
+	public void setH(List<Integer> h) {
+		this.h = h;
+	}
+
+	public List<CommonObject> getI() {
+		return i;
+	}
+
+	public void setI(List<CommonObject> i) {
+		this.i = i;
+	}
+
+	public int getJ() {
+		return j;
+	}
+
+	public void setJ(int j) {
+		this.j = j;
+	}
+
+	public int getK() {
+		return k;
+	}
+
+	public void setK(int k) {
+		this.k = k;
+	}
+
+	public int getL() {
+		return l;
+	}
+
+	public void setL(int l) {
+		this.l = l;
+	}
+
+	public boolean isM() {
+		return m;
+	}
+
+	public void setM(boolean m) {
+		this.m = m;
+	}
+
+	public boolean isN() {
+		return n;
+	}
+
+	public void setN(boolean n) {
+		this.n = n;
+	}
+
+	public int getO() {
+		return o;
+	}
+
+	public void setO(int o) {
+		this.o = o;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectD_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectD_A.java
@@ -1,0 +1,29 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectD_A {
+	
+	private int a;
+
+	
+	private boolean b;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public boolean isB() {
+		return b;
+	}
+
+	public void setB(boolean b) {
+		this.b = b;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectD_B.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectD_B.java
@@ -1,0 +1,49 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectD_B {
+	
+	private int a;
+	
+	private int b;
+	
+	private int c;
+	
+	private int d;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectE.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectE.java
@@ -1,0 +1,112 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectE {
+	
+	private int a;
+
+	
+	private int b;
+
+	
+	private int c;
+
+	
+	private int d;
+
+	
+	private int e;
+
+	
+	private boolean f;
+
+	
+	private long g;
+
+	
+	private int h;
+
+	
+	private int i;
+
+	
+	public int j() {
+		return -1;
+	}
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public boolean isF() {
+		return f;
+	}
+
+	public void setF(boolean f) {
+		this.f = f;
+	}
+
+	public long getG() {
+		return g;
+	}
+
+	public void setG(long g) {
+		this.g = g;
+	}
+
+	public int getH() {
+		return h;
+	}
+
+	public void setH(int h) {
+		this.h = h;
+	}
+
+	public int getI() {
+		return i;
+	}
+
+	public void setI(int i) {
+		this.i = i;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectE1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectE1.java
@@ -1,0 +1,110 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+
+public class ObjectE1 {
+	
+	private int a;
+	
+	private int b;
+
+	private int c;
+	
+	private int d;
+	
+	private long e;
+	
+	private long f;
+	
+	private boolean g;
+	
+	private int h;
+	
+	private int i;
+	
+	private int j;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public long getE() {
+		return e;
+	}
+
+	public void setE(long e) {
+		this.e = e;
+	}
+
+	public long getF() {
+		return f;
+	}
+
+	public void setF(long f) {
+		this.f = f;
+	}
+
+	public boolean isG() {
+		return g;
+	}
+
+	public void setG(boolean g) {
+		this.g = g;
+	}
+
+	public int getH() {
+		return h;
+	}
+
+	public void setH(int h) {
+		this.h = h;
+	}
+
+	public int getI() {
+		return i;
+	}
+
+	public void setI(int i) {
+		this.i = i;
+	}
+
+	public int getJ() {
+		return j;
+	}
+
+	public void setJ(int j) {
+		this.j = j;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectE2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectE2.java
@@ -1,0 +1,29 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectE2 {
+	
+	private int a;
+
+	
+	private boolean b;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public boolean isB() {
+		return b;
+	}
+
+	public void setB(boolean b) {
+		this.b = b;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectF.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectF.java
@@ -1,0 +1,177 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import java.util.List;
+
+
+public class ObjectF {
+	
+	protected long a;
+
+	
+	protected int b;
+
+	
+	protected  int c;
+
+	
+	protected long d;
+
+	
+	protected long e;
+
+	
+	protected String f = "";
+
+	
+	protected long g;
+	
+	protected String h = "";
+	
+	protected String i = "";
+	
+	protected int j;
+	
+	protected long k;
+
+	
+	protected int l;
+
+	
+	private int m;
+	
+	protected List<Integer> n;
+
+	
+	protected List<String> o;
+
+	
+	protected List<CommonObject> p;
+
+	public long getA() {
+		return a;
+	}
+
+	public void setA(long a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public long getD() {
+		return d;
+	}
+
+	public void setD(long d) {
+		this.d = d;
+	}
+
+	public long getE() {
+		return e;
+	}
+
+	public void setE(long e) {
+		this.e = e;
+	}
+
+	public String getF() {
+		return f;
+	}
+
+	public void setF(String f) {
+		this.f = f;
+	}
+
+	public long getG() {
+		return g;
+	}
+
+	public void setG(long g) {
+		this.g = g;
+	}
+
+	public String getH() {
+		return h;
+	}
+
+	public void setH(String h) {
+		this.h = h;
+	}
+
+	public String getI() {
+		return i;
+	}
+
+	public void setI(String i) {
+		this.i = i;
+	}
+
+	public int getJ() {
+		return j;
+	}
+
+	public void setJ(int j) {
+		this.j = j;
+	}
+
+	public long getK() {
+		return k;
+	}
+
+	public void setK(long k) {
+		this.k = k;
+	}
+
+	public int getL() {
+		return l;
+	}
+
+	public void setL(int l) {
+		this.l = l;
+	}
+
+	public int getM() {
+		return m;
+	}
+
+	public void setM(int m) {
+		this.m = m;
+	}
+
+	public List<Integer> getN() {
+		return n;
+	}
+
+	public void setN(List<Integer> n) {
+		this.n = n;
+	}
+
+	public List<String> getO() {
+		return o;
+	}
+
+	public void setO(List<String> o) {
+		this.o = o;
+	}
+
+	public List<CommonObject> getP() {
+		return p;
+	}
+
+	public void setP(List<CommonObject> p) {
+		this.p = p;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectF1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectF1.java
@@ -1,0 +1,187 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import com.alibaba.fastjson.annotation.JSONField;
+
+import java.util.List;
+
+
+public class ObjectF1 {
+    
+    long a = -1;
+    int b = 0;
+    
+    long c = 0;
+    
+    int d = 0;
+    
+    int e = 0;
+
+
+    @JSONField(serialize = false)
+    String f = "";
+
+    transient boolean g;
+    
+    long h;
+
+    
+    long i;
+
+    
+    int j;
+    
+    int k;
+    
+    int l;
+
+    
+    int m;
+
+    
+    int n;
+
+    
+    List<Long> o;
+
+    
+    int p;
+
+    
+    int q;
+
+    public long getA() {
+        return a;
+    }
+
+    public void setA(long a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public long getC() {
+        return c;
+    }
+
+    public void setC(long c) {
+        this.c = c;
+    }
+
+    public int getD() {
+        return d;
+    }
+
+    public void setD(int d) {
+        this.d = d;
+    }
+
+    public int getE() {
+        return e;
+    }
+
+    public void setE(int e) {
+        this.e = e;
+    }
+
+    public String getF() {
+        return f;
+    }
+
+    public void setF(String f) {
+        this.f = f;
+    }
+
+    public boolean isG() {
+        return g;
+    }
+
+    public void setG(boolean g) {
+        this.g = g;
+    }
+
+    public long getH() {
+        return h;
+    }
+
+    public void setH(long h) {
+        this.h = h;
+    }
+
+    public long getI() {
+        return i;
+    }
+
+    public void setI(long i) {
+        this.i = i;
+    }
+
+    public int getJ() {
+        return j;
+    }
+
+    public void setJ(int j) {
+        this.j = j;
+    }
+
+    public int getK() {
+        return k;
+    }
+
+    public void setK(int k) {
+        this.k = k;
+    }
+
+    public int getL() {
+        return l;
+    }
+
+    public void setL(int l) {
+        this.l = l;
+    }
+
+    public int getM() {
+        return m;
+    }
+
+    public void setM(int m) {
+        this.m = m;
+    }
+
+    public int getN() {
+        return n;
+    }
+
+    public void setN(int n) {
+        this.n = n;
+    }
+
+    public List<Long> getO() {
+        return o;
+    }
+
+    public void setO(List<Long> o) {
+        this.o = o;
+    }
+
+    public int getP() {
+        return p;
+    }
+
+    public void setP(int p) {
+        this.p = p;
+    }
+
+    public int getQ() {
+        return q;
+    }
+
+    public void setQ(int q) {
+        this.q = q;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectF2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectF2.java
@@ -1,0 +1,51 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import java.util.List;
+
+
+public class ObjectF2 {
+
+	
+	private int a;
+
+	
+	private int b;
+
+	
+	private List<Integer> c;
+
+	
+	private boolean d;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public List<Integer> getC() {
+		return c;
+	}
+
+	public void setC(List<Integer> c) {
+		this.c = c;
+	}
+
+	public boolean isD() {
+		return d;
+	}
+
+	public void setD(boolean d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectG.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectG.java
@@ -1,0 +1,43 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import com.alibaba.fastjson.annotation.JSONField;
+
+
+public class ObjectG {
+
+	public static final String tesdt = "tesdt";
+
+
+	@JSONField(name = "a")
+	private long a;
+
+
+	private long b;
+
+
+	private ObjectF c;
+
+	public long getA() {
+		return a;
+	}
+
+	public void setA(long a) {
+		this.a = a;
+	}
+
+	public long getB() {
+		return b;
+	}
+
+	public void setB(long b) {
+		this.b = b;
+	}
+
+	public ObjectF getC() {
+		return c;
+	}
+
+	public void setC(ObjectF c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectG1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectG1.java
@@ -1,0 +1,12 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectG1 {
+	private int a;
+	private int b;
+	private int c;
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectG2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectG2.java
@@ -1,0 +1,40 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+import java.util.List;
+
+
+public class ObjectG2 {
+	
+	private int a;
+
+	
+	private boolean b = true;
+
+	
+	private List<CommonObject> c;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public boolean isB() {
+		return b;
+	}
+
+	public void setB(boolean b) {
+		this.b = b;
+	}
+
+	public List<CommonObject> getC() {
+		return c;
+	}
+
+	public void setC(List<CommonObject> c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectH.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectH.java
@@ -1,0 +1,192 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectH {
+	
+	private int a;
+
+	
+	private long b;
+	
+	private int c;
+	
+	private int d;
+	
+	private int e;
+	
+	private int f;
+	
+	private int g;
+	
+	private int h;
+	
+	private int i;
+	
+	private int j;
+
+	
+
+	private int k;
+
+	
+
+	private int l;
+
+	
+
+	private List<ObjectH_A> m;
+
+	
+
+	private int n;
+
+	
+	private int o;
+
+	
+	private boolean p = false;
+
+	
+	private boolean q = false;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public long getB() {
+		return b;
+	}
+
+	public void setB(long b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public int getF() {
+		return f;
+	}
+
+	public void setF(int f) {
+		this.f = f;
+	}
+
+	public int getG() {
+		return g;
+	}
+
+	public void setG(int g) {
+		this.g = g;
+	}
+
+	public int getH() {
+		return h;
+	}
+
+	public void setH(int h) {
+		this.h = h;
+	}
+
+	public int getI() {
+		return i;
+	}
+
+	public void setI(int i) {
+		this.i = i;
+	}
+
+	public int getJ() {
+		return j;
+	}
+
+	public void setJ(int j) {
+		this.j = j;
+	}
+
+	public int getK() {
+		return k;
+	}
+
+	public void setK(int k) {
+		this.k = k;
+	}
+
+	public int getL() {
+		return l;
+	}
+
+	public void setL(int l) {
+		this.l = l;
+	}
+
+	public List<ObjectH_A> getM() {
+		return m;
+	}
+
+	public void setM(List<ObjectH_A> m) {
+		this.m = m;
+	}
+
+	public int getN() {
+		return n;
+	}
+
+	public void setN(int n) {
+		this.n = n;
+	}
+
+	public int getO() {
+		return o;
+	}
+
+	public void setO(int o) {
+		this.o = o;
+	}
+
+	public boolean isP() {
+		return p;
+	}
+
+	public void setP(boolean p) {
+		this.p = p;
+	}
+
+	public boolean isQ() {
+		return q;
+	}
+
+	public void setQ(boolean q) {
+		this.q = q;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectH1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectH1.java
@@ -1,0 +1,163 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectH1 {
+
+	
+	private List<Integer> a;
+
+	
+	private List<Integer> b;
+	
+	private List<Integer> c;
+	
+	private List<Integer> d;
+	
+	private int e;
+
+	
+	private int f;
+	
+	private int g;
+	
+	private int h;
+	
+	private int i;
+	
+	private int j;
+	
+	private int k;
+	
+	private int l;
+	
+	private List<Integer> m;
+	
+	private List<Integer> n;
+	
+	private List<Integer> o;
+
+	public List<Integer> getA() {
+		return a;
+	}
+
+	public void setA(List<Integer> a) {
+		this.a = a;
+	}
+
+	public List<Integer> getB() {
+		return b;
+	}
+
+	public void setB(List<Integer> b) {
+		this.b = b;
+	}
+
+	public List<Integer> getC() {
+		return c;
+	}
+
+	public void setC(List<Integer> c) {
+		this.c = c;
+	}
+
+	public List<Integer> getD() {
+		return d;
+	}
+
+	public void setD(List<Integer> d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public int getF() {
+		return f;
+	}
+
+	public void setF(int f) {
+		this.f = f;
+	}
+
+	public int getG() {
+		return g;
+	}
+
+	public void setG(int g) {
+		this.g = g;
+	}
+
+	public int getH() {
+		return h;
+	}
+
+	public void setH(int h) {
+		this.h = h;
+	}
+
+	public int getI() {
+		return i;
+	}
+
+	public void setI(int i) {
+		this.i = i;
+	}
+
+	public int getJ() {
+		return j;
+	}
+
+	public void setJ(int j) {
+		this.j = j;
+	}
+
+	public int getK() {
+		return k;
+	}
+
+	public void setK(int k) {
+		this.k = k;
+	}
+
+	public int getL() {
+		return l;
+	}
+
+	public void setL(int l) {
+		this.l = l;
+	}
+
+	public List<Integer> getM() {
+		return m;
+	}
+
+	public void setM(List<Integer> m) {
+		this.m = m;
+	}
+
+	public List<Integer> getN() {
+		return n;
+	}
+
+	public void setN(List<Integer> n) {
+		this.n = n;
+	}
+
+	public List<Integer> getO() {
+		return o;
+	}
+
+	public void setO(List<Integer> o) {
+		this.o = o;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectH2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectH2.java
@@ -1,0 +1,63 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import java.util.List;
+
+
+public class ObjectH2 {
+
+    
+    private boolean a;
+
+
+    
+    private int b;
+
+    
+    private int c;
+
+    
+    private boolean d;
+
+    
+    private List<CommonObject> e;
+
+    public boolean isA() {
+        return a;
+    }
+
+    public void setA(boolean a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public int getC() {
+        return c;
+    }
+
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public boolean isD() {
+        return d;
+    }
+
+    public void setD(boolean d) {
+        this.d = d;
+    }
+
+    public List<CommonObject> getE() {
+        return e;
+    }
+
+    public void setE(List<CommonObject> e) {
+        this.e = e;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectH_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectH_A.java
@@ -1,0 +1,39 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectH_A {
+	
+	private int a;
+	
+	private int b;
+	
+	private int c;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectI.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectI.java
@@ -1,0 +1,133 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectI {
+	
+	private String a;
+	
+	private int b;
+	
+	private long c;
+	
+	private int d;
+	
+	private int e;
+	
+	private int f;
+
+	
+	private int g;
+
+	
+	private List<ObjectI_A> h;
+
+	
+	private List<Integer> i;
+
+	
+	private int j;
+
+	private int k;
+	private int l;
+
+	public String getA() {
+		return a;
+	}
+
+	public void setA(String a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public long getC() {
+		return c;
+	}
+
+	public void setC(long c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public int getF() {
+		return f;
+	}
+
+	public void setF(int f) {
+		this.f = f;
+	}
+
+	public int getG() {
+		return g;
+	}
+
+	public void setG(int g) {
+		this.g = g;
+	}
+
+	public List<ObjectI_A> getH() {
+		return h;
+	}
+
+	public void setH(List<ObjectI_A> h) {
+		this.h = h;
+	}
+
+	public List<Integer> getI() {
+		return i;
+	}
+
+	public void setI(List<Integer> i) {
+		this.i = i;
+	}
+
+	public int getJ() {
+		return j;
+	}
+
+	public void setJ(int j) {
+		this.j = j;
+	}
+
+	public int getK() {
+		return k;
+	}
+
+	public void setK(int k) {
+		this.k = k;
+	}
+
+	public int getL() {
+		return l;
+	}
+
+	public void setL(int l) {
+		this.l = l;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectI1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectI1.java
@@ -1,0 +1,52 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectI1 {
+	
+	private int a = 0;
+	
+	private long b = 0;
+
+	
+	private int c = 0;
+
+	
+	private List<Integer> d;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public long getB() {
+		return b;
+	}
+
+	public void setB(long b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public List<Integer> getD() {
+		return d;
+	}
+
+	public void setD(List<Integer> d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectI2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectI2.java
@@ -1,0 +1,38 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import java.util.List;
+
+
+public class ObjectI2 {
+    private int a;
+
+    
+    private List<Integer> b;
+
+    
+    private boolean c;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public List<Integer> getB() {
+        return b;
+    }
+
+    public void setB(List<Integer> b) {
+        this.b = b;
+    }
+
+    public boolean isC() {
+        return c;
+    }
+
+    public void setC(boolean c) {
+        this.c = c;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectI_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectI_A.java
@@ -1,0 +1,32 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+public class ObjectI_A {
+    int a;
+    int b;
+    boolean c;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public boolean isC() {
+        return c;
+    }
+
+    public void setC(boolean c) {
+        this.c = c;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ.java
@@ -1,0 +1,333 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectJ {
+	
+	private long a;
+	
+	private int b;
+
+	
+	private int c;
+	
+	private int d;
+
+	
+	private int e;
+
+	
+
+	private int f;
+	
+
+	private int g;
+	
+
+	private int h;
+	
+	private List<CommonObject3> i;
+	
+	private int j;
+	
+	private int k;
+
+	
+	private int l;
+	
+	private int m;
+	
+	private List<CommonObject> n;
+
+	
+	private List<Integer> o;
+	
+	private int p;
+	
+	private int q;
+	
+	private int r;
+	
+	private int s;
+	
+	private int t;
+	
+	private int x;
+
+	
+	private int y;
+	
+	private int z;
+	
+	private int a1;
+
+	
+	private int b1;
+	
+	private List<ObjectJ_A> c1;
+
+	private List<ObjectK> d1;
+	
+	private List<Long> e1;
+
+	
+	private int f1;
+
+	
+	private int g1;
+
+	
+	boolean  h1;
+
+	public long getA() {
+		return a;
+	}
+
+	public void setA(long a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public int getF() {
+		return f;
+	}
+
+	public void setF(int f) {
+		this.f = f;
+	}
+
+	public int getG() {
+		return g;
+	}
+
+	public void setG(int g) {
+		this.g = g;
+	}
+
+	public int getH() {
+		return h;
+	}
+
+	public void setH(int h) {
+		this.h = h;
+	}
+
+	public List<CommonObject3> getI() {
+		return i;
+	}
+
+	public void setI(List<CommonObject3> i) {
+		this.i = i;
+	}
+
+	public int getJ() {
+		return j;
+	}
+
+	public void setJ(int j) {
+		this.j = j;
+	}
+
+	public int getK() {
+		return k;
+	}
+
+	public void setK(int k) {
+		this.k = k;
+	}
+
+	public int getL() {
+		return l;
+	}
+
+	public void setL(int l) {
+		this.l = l;
+	}
+
+	public int getM() {
+		return m;
+	}
+
+	public void setM(int m) {
+		this.m = m;
+	}
+
+	public List<CommonObject> getN() {
+		return n;
+	}
+
+	public void setN(List<CommonObject> n) {
+		this.n = n;
+	}
+
+	public List<Integer> getO() {
+		return o;
+	}
+
+	public void setO(List<Integer> o) {
+		this.o = o;
+	}
+
+	public int getP() {
+		return p;
+	}
+
+	public void setP(int p) {
+		this.p = p;
+	}
+
+	public int getQ() {
+		return q;
+	}
+
+	public void setQ(int q) {
+		this.q = q;
+	}
+
+	public int getR() {
+		return r;
+	}
+
+	public void setR(int r) {
+		this.r = r;
+	}
+
+	public int getS() {
+		return s;
+	}
+
+	public void setS(int s) {
+		this.s = s;
+	}
+
+	public int getT() {
+		return t;
+	}
+
+	public void setT(int t) {
+		this.t = t;
+	}
+
+	public int getX() {
+		return x;
+	}
+
+	public void setX(int x) {
+		this.x = x;
+	}
+
+	public int getY() {
+		return y;
+	}
+
+	public void setY(int y) {
+		this.y = y;
+	}
+
+	public int getZ() {
+		return z;
+	}
+
+	public void setZ(int z) {
+		this.z = z;
+	}
+
+	public int getA1() {
+		return a1;
+	}
+
+	public void setA1(int a1) {
+		this.a1 = a1;
+	}
+
+	public int getB1() {
+		return b1;
+	}
+
+	public void setB1(int b1) {
+		this.b1 = b1;
+	}
+
+	public List<ObjectJ_A> getC1() {
+		return c1;
+	}
+
+	public void setC1(List<ObjectJ_A> c1) {
+		this.c1 = c1;
+	}
+
+	public List<ObjectK> getD1() {
+		return d1;
+	}
+
+	public void setD1(List<ObjectK> d1) {
+		this.d1 = d1;
+	}
+
+	public List<Long> getE1() {
+		return e1;
+	}
+
+	public void setE1(List<Long> e1) {
+		this.e1 = e1;
+	}
+
+	public int getF1() {
+		return f1;
+	}
+
+	public void setF1(int f1) {
+		this.f1 = f1;
+	}
+
+	public int getG1() {
+		return g1;
+	}
+
+	public void setG1(int g1) {
+		this.g1 = g1;
+	}
+
+	public boolean isH1() {
+		return h1;
+	}
+
+	public void setH1(boolean h1) {
+		this.h1 = h1;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ1.java
@@ -1,0 +1,100 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectJ1 {
+	
+	private int a = 0;
+	
+	private int b = 0;
+	
+	private List<ObjectJ1_A> c;
+	
+	private int d = 0;
+	
+	private List<CommonObject> e;
+	
+	private List<Integer> f;
+	
+	private List<Integer> g;
+	
+	private List<Integer> h;
+	
+	private boolean i = false;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public List<ObjectJ1_A> getC() {
+		return c;
+	}
+
+	public void setC(List<ObjectJ1_A> c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public List<CommonObject> getE() {
+		return e;
+	}
+
+	public void setE(List<CommonObject> e) {
+		this.e = e;
+	}
+
+	public List<Integer> getF() {
+		return f;
+	}
+
+	public void setF(List<Integer> f) {
+		this.f = f;
+	}
+
+	public List<Integer> getG() {
+		return g;
+	}
+
+	public void setG(List<Integer> g) {
+		this.g = g;
+	}
+
+	public List<Integer> getH() {
+		return h;
+	}
+
+	public void setH(List<Integer> h) {
+		this.h = h;
+	}
+
+	public boolean isI() {
+		return i;
+	}
+
+	public void setI(boolean i) {
+		this.i = i;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ1_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ1_A.java
@@ -1,0 +1,80 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectJ1_A {
+	
+	private int a = 0;
+	
+	private int b = 0;
+	
+	private int c = 0;
+	
+	private int d = 0;
+	
+	private int e = 0;
+	
+	private List<CommonObject> f;
+	
+	private List<ObjectJ1_C> g;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public List<CommonObject> getF() {
+		return f;
+	}
+
+	public void setF(List<CommonObject> f) {
+		this.f = f;
+	}
+
+	public List<ObjectJ1_C> getG() {
+		return g;
+	}
+
+	public void setG(List<ObjectJ1_C> g) {
+		this.g = g;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ1_C.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ1_C.java
@@ -1,0 +1,59 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectJ1_C {
+	
+	private int a = 0;
+	
+	private int b = 0;
+	
+	private int c = 0;
+	
+	private int d = 0;
+	
+	private boolean e = false;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public boolean isE() {
+		return e;
+	}
+
+	public void setE(boolean e) {
+		this.e = e;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ2.java
@@ -1,0 +1,31 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectJ2 {
+
+    
+    private boolean a;
+
+    
+    private boolean b;
+
+    public boolean isA() {
+        return a;
+    }
+
+    public void setA(boolean a) {
+        this.a = a;
+    }
+
+    public boolean isB() {
+        return b;
+    }
+
+    public void setB(boolean b) {
+        this.b = b;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ_A.java
@@ -1,0 +1,153 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectJ_A {
+
+	
+	private long a;
+
+	
+	private int b;
+
+	
+	private int c;
+
+	
+	private int d;
+
+	
+	private int e;
+
+	
+	private int f;
+
+	
+	private int g;
+
+	
+	private int h;
+
+	
+	private int i;
+
+	
+	private List<ObjectJ_B> j;
+
+	
+	private List<ObjectC> k;
+
+	
+	private List<ObjectJ_C> l;
+
+	
+	private List<CommonObject> m;
+
+	public long getA() {
+		return a;
+	}
+
+	public void setA(long a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public int getF() {
+		return f;
+	}
+
+	public void setF(int f) {
+		this.f = f;
+	}
+
+	public int getG() {
+		return g;
+	}
+
+	public void setG(int g) {
+		this.g = g;
+	}
+
+	public int getH() {
+		return h;
+	}
+
+	public void setH(int h) {
+		this.h = h;
+	}
+
+	public int getI() {
+		return i;
+	}
+
+	public void setI(int i) {
+		this.i = i;
+	}
+
+	public List<ObjectJ_B> getJ() {
+		return j;
+	}
+
+	public void setJ(List<ObjectJ_B> j) {
+		this.j = j;
+	}
+
+	public List<ObjectC> getK() {
+		return k;
+	}
+
+	public void setK(List<ObjectC> k) {
+		this.k = k;
+	}
+
+	public List<ObjectJ_C> getL() {
+		return l;
+	}
+
+	public void setL(List<ObjectJ_C> l) {
+		this.l = l;
+	}
+
+	public List<CommonObject> getM() {
+		return m;
+	}
+
+	public void setM(List<CommonObject> m) {
+		this.m = m;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ_B.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ_B.java
@@ -1,0 +1,100 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+
+public class ObjectJ_B {
+
+	private long a;
+
+	private int b;
+
+	private long c;
+
+	private int d;
+
+	private int e;
+
+	private int f;
+
+	private int g;
+
+	private int h;
+
+	private int i;
+
+	public long getA() {
+		return a;
+	}
+
+	public void setA(long a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public long getC() {
+		return c;
+	}
+
+	public void setC(long c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public int getF() {
+		return f;
+	}
+
+	public void setF(int f) {
+		this.f = f;
+	}
+
+	public int getG() {
+		return g;
+	}
+
+	public void setG(int g) {
+		this.g = g;
+	}
+
+	public int getH() {
+		return h;
+	}
+
+	public void setH(int h) {
+		this.h = h;
+	}
+
+	public int getI() {
+		return i;
+	}
+
+	public void setI(int i) {
+		this.i = i;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ_C.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectJ_C.java
@@ -1,0 +1,29 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectJ_C {
+	
+	private int a;
+
+	
+	private int b;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectK.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectK.java
@@ -1,0 +1,48 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectK {
+
+	private int a;
+
+	private int b = 0;
+
+	private int c = 0;
+
+	private int d = 0;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectK1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectK1.java
@@ -1,0 +1,106 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectK1 {
+
+	
+	private int a = 0;
+	
+	private boolean b = false;
+	
+	private int c = 0;
+	
+	private int d = 0;
+	
+	private int e = 0;
+	
+	private List<CommonObject> f;
+	
+	private List<ObjectK1_A> g;
+
+
+
+
+
+	
+	private int h = 0;
+	
+	private List<ObjectK1_C> i;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public boolean isB() {
+		return b;
+	}
+
+	public void setB(boolean b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public List<CommonObject> getF() {
+		return f;
+	}
+
+	public void setF(List<CommonObject> f) {
+		this.f = f;
+	}
+
+	public List<ObjectK1_A> getG() {
+		return g;
+	}
+
+	public void setG(List<ObjectK1_A> g) {
+		this.g = g;
+	}
+
+	public int getH() {
+		return h;
+	}
+
+	public void setH(int h) {
+		this.h = h;
+	}
+
+	public List<ObjectK1_C> getI() {
+		return i;
+	}
+
+	public void setI(List<ObjectK1_C> i) {
+		this.i = i;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectK1_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectK1_A.java
@@ -1,0 +1,49 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectK1_A {
+	
+	private int a = 0;
+	
+	private int b = 0;
+	
+	private int c = 0;
+	
+	private int d = 0;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectK1_C.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectK1_C.java
@@ -1,0 +1,39 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectK1_C {
+	
+	private int a = 0;
+	
+	private int b = 0;
+	
+	private boolean c = false;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public boolean isC() {
+		return c;
+	}
+
+	public void setC(boolean c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectK2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectK2.java
@@ -1,0 +1,27 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+import java.util.List;
+
+
+public class ObjectK2 {
+    private int a;
+    private List<ObjectK2_A> b;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public List<ObjectK2_A> getB() {
+        return b;
+    }
+
+    public void setB(List<ObjectK2_A> b) {
+        this.b = b;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectK2_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectK2_A.java
@@ -1,0 +1,54 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectK2_A {
+    private int a;
+    private int b;
+    private int c;
+    private int d;
+    private int e;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public int getC() {
+        return c;
+    }
+
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public int getD() {
+        return d;
+    }
+
+    public void setD(int d) {
+        this.d = d;
+    }
+
+    public int getE() {
+        return e;
+    }
+
+    public void setE(int e) {
+        this.e = e;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL.java
@@ -1,0 +1,41 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+import java.util.List;
+
+
+public class ObjectL {
+
+	private List<ObjectL_A> a;
+
+
+	private List<ObjectL_B> b;
+
+
+	private List<Integer> c;
+
+	public List<ObjectL_A> getA() {
+		return a;
+	}
+
+	public void setA(List<ObjectL_A> a) {
+		this.a = a;
+	}
+
+	public List<ObjectL_B> getB() {
+		return b;
+	}
+
+	public void setB(List<ObjectL_B> b) {
+		this.b = b;
+	}
+
+	public List<Integer> getC() {
+		return c;
+	}
+
+	public void setC(List<Integer> c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL1.java
@@ -1,0 +1,113 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.HashMap;
+import java.util.List;
+
+
+public class ObjectL1 {
+    
+    
+    List<ObjectL1_A> a;
+    
+    int b;
+    
+    int c;
+    
+    int d;
+
+    
+    long e;
+
+    long f;
+
+    List<ObjectL2_B> g;
+    
+    List<CommonObject> h;
+
+    HashMap<Integer, HashMap<Integer, ObjectL2_C>> i;
+    
+    boolean j = false;
+
+    public List<ObjectL1_A> getA() {
+        return a;
+    }
+
+    public void setA(List<ObjectL1_A> a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public int getC() {
+        return c;
+    }
+
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public int getD() {
+        return d;
+    }
+
+    public void setD(int d) {
+        this.d = d;
+    }
+
+    public long getE() {
+        return e;
+    }
+
+    public void setE(long e) {
+        this.e = e;
+    }
+
+    public long getF() {
+        return f;
+    }
+
+    public void setF(long f) {
+        this.f = f;
+    }
+
+    public List<ObjectL2_B> getG() {
+        return g;
+    }
+
+    public void setG(List<ObjectL2_B> g) {
+        this.g = g;
+    }
+
+    public List<CommonObject> getH() {
+        return h;
+    }
+
+    public void setH(List<CommonObject> h) {
+        this.h = h;
+    }
+
+    public HashMap<Integer, HashMap<Integer, ObjectL2_C>> getI() {
+        return i;
+    }
+
+    public void setI(HashMap<Integer, HashMap<Integer, ObjectL2_C>> i) {
+        this.i = i;
+    }
+
+    public boolean isJ() {
+        return j;
+    }
+
+    public void setJ(boolean j) {
+        this.j = j;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL1_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL1_A.java
@@ -1,0 +1,48 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectL1_A {
+    
+    protected int a;
+    
+    protected int b;
+    
+    protected int c;
+    
+    protected int d;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public int getC() {
+        return c;
+    }
+
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public int getD() {
+        return d;
+    }
+
+    public void setD(int d) {
+        this.d = d;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL2.java
@@ -1,0 +1,49 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+import java.util.List;
+
+
+public class ObjectL2 {
+
+	int a;
+
+	ObjectL2_A b;
+
+	List<ObjectL2_A> c ;
+
+	int d;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public ObjectL2_A getB() {
+		return b;
+	}
+
+	public void setB(ObjectL2_A b) {
+		this.b = b;
+	}
+
+	public List<ObjectL2_A> getC() {
+		return c;
+	}
+
+	public void setC(List<ObjectL2_A> c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL2_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL2_A.java
@@ -1,0 +1,48 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectL2_A {
+	int a = 1;
+
+	int b = 2;
+
+	int c = 4;
+
+	int d = 5;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL2_B.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL2_B.java
@@ -1,0 +1,28 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectL2_B {
+    
+    int a;
+    
+    int b;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL2_C.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL2_C.java
@@ -1,0 +1,26 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectL2_C {
+    int a;
+    int b;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL_A.java
@@ -1,0 +1,40 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectL_A {
+	
+	private int a;
+
+	
+	private int b;
+
+	
+	private long c;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public long getC() {
+		return c;
+	}
+
+	public void setC(long c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL_B.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectL_B.java
@@ -1,0 +1,51 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectL_B {
+
+	
+	private int a;
+	
+	private List<Integer> b;
+	
+	private List<Integer> c;
+	
+	private long d;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public List<Integer> getB() {
+		return b;
+	}
+
+	public void setB(List<Integer> b) {
+		this.b = b;
+	}
+
+	public List<Integer> getC() {
+		return c;
+	}
+
+	public void setC(List<Integer> c) {
+		this.c = c;
+	}
+
+	public long getD() {
+		return d;
+	}
+
+	public void setD(long d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM.java
@@ -1,0 +1,114 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectM {
+	
+	private int a;
+	
+	private int b;
+	
+	private String c = "";
+	
+	private long d;
+	
+	private int e;
+	
+	private int f;
+
+	
+	private List<ObjectM_A> g;
+
+	
+	private List<ObjectM_B> h;
+
+	
+	private ObjectM_B i;
+
+	
+	private long j;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public String getC() {
+		return c;
+	}
+
+	public void setC(String c) {
+		this.c = c;
+	}
+
+	public long getD() {
+		return d;
+	}
+
+	public void setD(long d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public int getF() {
+		return f;
+	}
+
+	public void setF(int f) {
+		this.f = f;
+	}
+
+	public List<ObjectM_A> getG() {
+		return g;
+	}
+
+	public void setG(List<ObjectM_A> g) {
+		this.g = g;
+	}
+
+	public List<ObjectM_B> getH() {
+		return h;
+	}
+
+	public void setH(List<ObjectM_B> h) {
+		this.h = h;
+	}
+
+	public ObjectM_B getI() {
+		return i;
+	}
+
+	public void setI(ObjectM_B i) {
+		this.i = i;
+	}
+
+	public long getJ() {
+		return j;
+	}
+
+	public void setJ(long j) {
+		this.j = j;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM1.java
@@ -1,0 +1,219 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectM1 {
+
+	
+	private int a;
+
+	
+	private int b;
+
+	
+	private int c;
+
+	
+	private int d;
+
+	
+	private List<ObjectM1_A> e;
+
+	
+	private List<ObjectM1_B> f;
+
+	
+	private int g;
+	
+	private int h;
+	
+	private int i;
+	
+	private int j;
+	
+	private int k;
+	
+	private boolean l;
+	
+	private int m;
+	
+	private int n;
+
+	
+	private int o;
+	
+	private int p;
+	
+	private boolean q;
+	
+	private CommonObject r;
+	
+	private int s;
+
+	
+	private long t;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public List<ObjectM1_A> getE() {
+		return e;
+	}
+
+	public void setE(List<ObjectM1_A> e) {
+		this.e = e;
+	}
+
+	public List<ObjectM1_B> getF() {
+		return f;
+	}
+
+	public void setF(List<ObjectM1_B> f) {
+		this.f = f;
+	}
+
+	public int getG() {
+		return g;
+	}
+
+	public void setG(int g) {
+		this.g = g;
+	}
+
+	public int getH() {
+		return h;
+	}
+
+	public void setH(int h) {
+		this.h = h;
+	}
+
+	public int getI() {
+		return i;
+	}
+
+	public void setI(int i) {
+		this.i = i;
+	}
+
+	public int getJ() {
+		return j;
+	}
+
+	public void setJ(int j) {
+		this.j = j;
+	}
+
+	public int getK() {
+		return k;
+	}
+
+	public void setK(int k) {
+		this.k = k;
+	}
+
+	public boolean isL() {
+		return l;
+	}
+
+	public void setL(boolean l) {
+		this.l = l;
+	}
+
+	public int getM() {
+		return m;
+	}
+
+	public void setM(int m) {
+		this.m = m;
+	}
+
+	public int getN() {
+		return n;
+	}
+
+	public void setN(int n) {
+		this.n = n;
+	}
+
+	public int getO() {
+		return o;
+	}
+
+	public void setO(int o) {
+		this.o = o;
+	}
+
+	public int getP() {
+		return p;
+	}
+
+	public void setP(int p) {
+		this.p = p;
+	}
+
+	public boolean isQ() {
+		return q;
+	}
+
+	public void setQ(boolean q) {
+		this.q = q;
+	}
+
+	public CommonObject getR() {
+		return r;
+	}
+
+	public void setR(CommonObject r) {
+		this.r = r;
+	}
+
+	public int getS() {
+		return s;
+	}
+
+	public void setS(int s) {
+		this.s = s;
+	}
+
+	public long getT() {
+		return t;
+	}
+
+	public void setT(long t) {
+		this.t = t;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM1_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM1_A.java
@@ -1,0 +1,28 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectM1_A {
+    
+    private int a;
+    
+    private int b;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM1_B.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM1_B.java
@@ -1,0 +1,137 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectM1_B {
+    
+    private long a;
+    
+    private String b;
+    
+    private String c;
+    
+    private int d;
+
+    
+    private long e;
+    
+    private int f;
+
+    
+    private int g;
+
+    
+    private List<Integer> h;
+
+    
+    private List<ObjectM1_C> i;
+
+    
+    private int j;
+
+    
+    private int k;
+
+    
+    private boolean l;
+
+    public long getA() {
+        return a;
+    }
+
+    public void setA(long a) {
+        this.a = a;
+    }
+
+    public String getB() {
+        return b;
+    }
+
+    public void setB(String b) {
+        this.b = b;
+    }
+
+    public String getC() {
+        return c;
+    }
+
+    public void setC(String c) {
+        this.c = c;
+    }
+
+    public int getD() {
+        return d;
+    }
+
+    public void setD(int d) {
+        this.d = d;
+    }
+
+    public long getE() {
+        return e;
+    }
+
+    public void setE(long e) {
+        this.e = e;
+    }
+
+    public int getF() {
+        return f;
+    }
+
+    public void setF(int f) {
+        this.f = f;
+    }
+
+    public int getG() {
+        return g;
+    }
+
+    public void setG(int g) {
+        this.g = g;
+    }
+
+    public List<Integer> getH() {
+        return h;
+    }
+
+    public void setH(List<Integer> h) {
+        this.h = h;
+    }
+
+    public List<ObjectM1_C> getI() {
+        return i;
+    }
+
+    public void setI(List<ObjectM1_C> i) {
+        this.i = i;
+    }
+
+    public int getJ() {
+        return j;
+    }
+
+    public void setJ(int j) {
+        this.j = j;
+    }
+
+    public int getK() {
+        return k;
+    }
+
+    public void setK(int k) {
+        this.k = k;
+    }
+
+    public boolean isL() {
+        return l;
+    }
+
+    public void setL(boolean l) {
+        this.l = l;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM1_C.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM1_C.java
@@ -1,0 +1,175 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectM1_C {
+    
+    private int a;
+
+    
+    private int b;
+
+    
+    private int c;
+
+
+    
+    private int d;
+
+    
+    private int e;
+
+    
+    private int f;
+
+    
+    private int g;
+
+    
+    private List<Integer> h;
+
+    
+    private List<Integer> i;
+
+    
+    private int j;
+
+    
+    private int k;
+
+    
+    private int l;
+
+    
+    private int m;
+
+    
+    private int n;
+
+    
+    private int o;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public int getC() {
+        return c;
+    }
+
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public int getD() {
+        return d;
+    }
+
+    public void setD(int d) {
+        this.d = d;
+    }
+
+    public int getE() {
+        return e;
+    }
+
+    public void setE(int e) {
+        this.e = e;
+    }
+
+    public int getF() {
+        return f;
+    }
+
+    public void setF(int f) {
+        this.f = f;
+    }
+
+    public int getG() {
+        return g;
+    }
+
+    public void setG(int g) {
+        this.g = g;
+    }
+
+    public List<Integer> getH() {
+        return h;
+    }
+
+    public void setH(List<Integer> h) {
+        this.h = h;
+    }
+
+    public List<Integer> getI() {
+        return i;
+    }
+
+    public void setI(List<Integer> i) {
+        this.i = i;
+    }
+
+    public int getJ() {
+        return j;
+    }
+
+    public void setJ(int j) {
+        this.j = j;
+    }
+
+    public int getK() {
+        return k;
+    }
+
+    public void setK(int k) {
+        this.k = k;
+    }
+
+    public int getL() {
+        return l;
+    }
+
+    public void setL(int l) {
+        this.l = l;
+    }
+
+    public int getM() {
+        return m;
+    }
+
+    public void setM(int m) {
+        this.m = m;
+    }
+
+    public int getN() {
+        return n;
+    }
+
+    public void setN(int n) {
+        this.n = n;
+    }
+
+    public int getO() {
+        return o;
+    }
+
+    public void setO(int o) {
+        this.o = o;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM2.java
@@ -1,0 +1,65 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectM2 {
+
+    
+    private long a;
+
+    
+    private int b;
+
+    
+    private boolean c;
+
+    
+    private int d;
+
+    
+    private List<ObjectM2_A> e;
+
+    public long getA() {
+        return a;
+    }
+
+    public void setA(long a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public boolean isC() {
+        return c;
+    }
+
+    public void setC(boolean c) {
+        this.c = c;
+    }
+
+    public int getD() {
+        return d;
+    }
+
+    public void setD(int d) {
+        this.d = d;
+    }
+
+    public List<ObjectM2_A> getE() {
+        return e;
+    }
+
+    public void setE(List<ObjectM2_A> e) {
+        this.e = e;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM2_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM2_A.java
@@ -1,0 +1,19 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectM2_A {
+
+    
+    private int a;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM_A.java
@@ -1,0 +1,38 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectM_A {
+	
+	private int a;
+	
+	private int b;
+	
+	private long c;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public long getC() {
+		return c;
+	}
+
+	public void setC(long c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM_B.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectM_B.java
@@ -1,0 +1,59 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+import java.util.List;
+
+
+public class ObjectM_B {
+
+	private int a;
+
+	private int b;
+
+	private int c;
+
+	private long d;
+
+	private List<Integer> e;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public long getD() {
+		return d;
+	}
+
+	public void setD(long d) {
+		this.d = d;
+	}
+
+	public List<Integer> getE() {
+		return e;
+	}
+
+	public void setE(List<Integer> e) {
+		this.e = e;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectN.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectN.java
@@ -1,0 +1,142 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+import java.util.List;
+
+
+public class ObjectN {
+
+	private List<Long> a;
+
+	private List<Long> b;
+
+
+	private List<CommonObject3> c;
+
+
+	private List<CommonObject3> d;
+
+
+	private List<Long> e;
+
+
+	private List<String> f;
+
+
+	private List<Long> g;
+
+
+	private List<OjectN_A> h;
+
+
+	private List<CommonObject3> i;
+
+
+	private List<Long> j;
+
+
+	private List<String> k;
+
+
+	private List<CommonObject3> l;
+
+	public List<Long> getA() {
+		return a;
+	}
+
+	public void setA(List<Long> a) {
+		this.a = a;
+	}
+
+	public List<Long> getB() {
+		return b;
+	}
+
+	public void setB(List<Long> b) {
+		this.b = b;
+	}
+
+	public List<CommonObject3> getC() {
+		return c;
+	}
+
+	public void setC(List<CommonObject3> c) {
+		this.c = c;
+	}
+
+	public List<CommonObject3> getD() {
+		return d;
+	}
+
+	public void setD(List<CommonObject3> d) {
+		this.d = d;
+	}
+
+	public List<Long> getE() {
+		return e;
+	}
+
+	public void setE(List<Long> e) {
+		this.e = e;
+	}
+
+	public List<String> getF() {
+		return f;
+	}
+
+	public void setF(List<String> f) {
+		this.f = f;
+	}
+
+	public List<Long> getG() {
+		return g;
+	}
+
+	public void setG(List<Long> g) {
+		this.g = g;
+	}
+
+	public List<OjectN_A> getH() {
+		return h;
+	}
+
+	public void setH(List<OjectN_A> h) {
+		this.h = h;
+	}
+
+	public List<CommonObject3> getI() {
+		return i;
+	}
+
+	public void setI(List<CommonObject3> i) {
+		this.i = i;
+	}
+
+	public List<Long> getJ() {
+		return j;
+	}
+
+	public void setJ(List<Long> j) {
+		this.j = j;
+	}
+
+	public List<String> getK() {
+		return k;
+	}
+
+	public void setK(List<String> k) {
+		this.k = k;
+	}
+
+	public List<CommonObject3> getL() {
+		return l;
+	}
+
+	public void setL(List<CommonObject3> l) {
+		this.l = l;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectN1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectN1.java
@@ -1,0 +1,52 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+public class ObjectN1 {
+    
+    private int a;
+    private int b;
+    
+    private boolean c;
+    private boolean d;
+    
+    private int e;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public boolean isC() {
+        return c;
+    }
+
+    public void setC(boolean c) {
+        this.c = c;
+    }
+
+    public boolean isD() {
+        return d;
+    }
+
+    public void setD(boolean d) {
+        this.d = d;
+    }
+
+    public int getE() {
+        return e;
+    }
+
+    public void setE(int e) {
+        this.e = e;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectN2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectN2.java
@@ -1,0 +1,51 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectN2 {
+    
+    private int a;
+
+    private int b;
+
+    
+    private long c;
+
+    
+    private int d;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public long getC() {
+        return c;
+    }
+
+    public void setC(long c) {
+        this.c = c;
+    }
+
+    public int getD() {
+        return d;
+    }
+
+    public void setD(int d) {
+        this.d = d;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectO.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectO.java
@@ -1,0 +1,31 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import com.alibaba.fastjson.annotation.JSONField;
+
+import java.util.List;
+
+
+public class ObjectO {
+	public static final String tstN = "tstN";
+
+	@JSONField(name = "a")
+	private long a;
+
+	private List<ObjectO_A> b;
+
+	public long getA() {
+		return a;
+	}
+
+	public void setA(long a) {
+		this.a = a;
+	}
+
+	public List<ObjectO_A> getB() {
+		return b;
+	}
+
+	public void setB(List<ObjectO_A> b) {
+		this.b = b;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectO1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectO1.java
@@ -1,0 +1,39 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+
+public class ObjectO1 implements Serializable {
+	
+	int a;
+	
+	int b;
+	
+	List<ObjectO1_A> c;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public List<ObjectO1_A> getC() {
+		return c;
+	}
+
+	public void setC(List<ObjectO1_A> c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectO1_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectO1_A.java
@@ -1,0 +1,49 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+import java.io.Serializable;
+
+
+public class ObjectO1_A implements Serializable {
+	
+	int a;
+	
+	int b;
+	
+	int c;
+	
+	int d;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectO2.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectO2.java
@@ -1,0 +1,36 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+public class ObjectO2 {
+	
+	private int a;
+
+	
+	private boolean b = true;
+
+	
+	private int c;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public boolean isB() {
+		return b;
+	}
+
+	public void setB(boolean b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectO_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectO_A.java
@@ -1,0 +1,69 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectO_A {
+	
+	private int a;
+	
+	private int b;
+	
+	private int c;
+	
+	private int d;
+	
+	private int e;
+	
+	private int f;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public int getF() {
+		return f;
+	}
+
+	public void setF(int f) {
+		this.f = f;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectP.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectP.java
@@ -1,0 +1,36 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+import com.alibaba.fastjson.annotation.JSONField;
+
+import java.util.List;
+
+
+public class ObjectP {
+
+	public static final String tsnst = "tsnst";
+
+	@JSONField(name = "a")
+	private long a;
+
+	private List<ObjectP_A> b;
+
+	public static String getTsnst() {
+		return tsnst;
+	}
+
+	public long getA() {
+		return a;
+	}
+
+	public void setA(long a) {
+		this.a = a;
+	}
+
+	public List<ObjectP_A> getB() {
+		return b;
+	}
+
+	public void setB(List<ObjectP_A> b) {
+		this.b = b;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectP1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectP1.java
@@ -1,0 +1,110 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectP1 {
+    
+    private int a;
+    
+    private int b;
+    
+    private int c;
+    
+    private List<Long> d;
+    
+    private int e = 0;
+    
+    private int f = 0;
+    
+    private List<ObjectP1_A> g;
+    
+    private List<Integer> h;
+    
+    private List<ObjectP1_B> i;
+    
+    private boolean j = true;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public int getC() {
+        return c;
+    }
+
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public List<Long> getD() {
+        return d;
+    }
+
+    public void setD(List<Long> d) {
+        this.d = d;
+    }
+
+    public int getE() {
+        return e;
+    }
+
+    public void setE(int e) {
+        this.e = e;
+    }
+
+    public int getF() {
+        return f;
+    }
+
+    public void setF(int f) {
+        this.f = f;
+    }
+
+    public List<ObjectP1_A> getG() {
+        return g;
+    }
+
+    public void setG(List<ObjectP1_A> g) {
+        this.g = g;
+    }
+
+    public List<Integer> getH() {
+        return h;
+    }
+
+    public void setH(List<Integer> h) {
+        this.h = h;
+    }
+
+    public List<ObjectP1_B> getI() {
+        return i;
+    }
+
+    public void setI(List<ObjectP1_B> i) {
+        this.i = i;
+    }
+
+    public boolean isJ() {
+        return j;
+    }
+
+    public void setJ(boolean j) {
+        this.j = j;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectP1_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectP1_A.java
@@ -1,0 +1,69 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectP1_A {
+    
+    private int a = 0;
+    
+    private int b = 0;
+    
+    private int c = 0;
+    
+    private boolean d = false;
+    
+    private int e = 0;
+    
+    private int f = 0;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public int getC() {
+        return c;
+    }
+
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public boolean isD() {
+        return d;
+    }
+
+    public void setD(boolean d) {
+        this.d = d;
+    }
+
+    public int getE() {
+        return e;
+    }
+
+    public void setE(int e) {
+        this.e = e;
+    }
+
+    public int getF() {
+        return f;
+    }
+
+    public void setF(int f) {
+        this.f = f;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectP1_B.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectP1_B.java
@@ -1,0 +1,89 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectP1_B {
+    
+    private long a = 0;
+    
+    private int b = 0;
+	
+	private int c = 0;
+    
+    private int d = 0;
+	
+	private int e = 0;
+	
+	private int f = 0;
+    
+    private long g = 0;
+    
+    private boolean h = true;
+
+    public long getA() {
+        return a;
+    }
+
+    public void setA(long a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public int getC() {
+        return c;
+    }
+
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public int getD() {
+        return d;
+    }
+
+    public void setD(int d) {
+        this.d = d;
+    }
+
+    public int getE() {
+        return e;
+    }
+
+    public void setE(int e) {
+        this.e = e;
+    }
+
+    public int getF() {
+        return f;
+    }
+
+    public void setF(int f) {
+        this.f = f;
+    }
+
+    public long getG() {
+        return g;
+    }
+
+    public void setG(long g) {
+        this.g = g;
+    }
+
+    public boolean isH() {
+        return h;
+    }
+
+    public void setH(boolean h) {
+        this.h = h;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectP_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectP_A.java
@@ -1,0 +1,69 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectP_A {
+	
+	private int a;
+	
+	private int b;
+	
+	private int c;
+	
+	private boolean d;
+	
+	private boolean e;
+	
+	private boolean f;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public boolean isD() {
+		return d;
+	}
+
+	public void setD(boolean d) {
+		this.d = d;
+	}
+
+	public boolean isE() {
+		return e;
+	}
+
+	public void setE(boolean e) {
+		this.e = e;
+	}
+
+	public boolean isF() {
+		return f;
+	}
+
+	public void setF(boolean f) {
+		this.f = f;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectQ.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectQ.java
@@ -1,0 +1,50 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectQ {
+	
+	private int a;
+	
+	private int b;
+	
+	private boolean c = false;
+	
+	private List<CommonObject> d;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public boolean isC() {
+		return c;
+	}
+
+	public void setC(boolean c) {
+		this.c = c;
+	}
+
+	public List<CommonObject> getD() {
+		return d;
+	}
+
+	public void setD(List<CommonObject> d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectQ1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectQ1.java
@@ -1,0 +1,201 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+import java.util.List;
+
+
+public class ObjectQ1 {
+	
+	private int a;
+
+	
+	private int b;
+	
+	private long c;
+	
+	private int d;
+	
+	private int e;
+	
+	private int f;
+	
+	private int g;
+	
+	private int h;
+
+	
+	private int i;
+	
+	private int j;
+	
+	private int k;
+	
+	private int l;
+	
+	private int m;
+	
+	private List<ObjectK> n;
+	
+	private int o;
+	
+	private long p;
+	
+	private int q;
+	
+	private int r;
+	
+	private int s;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public long getC() {
+		return c;
+	}
+
+	public void setC(long c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public int getF() {
+		return f;
+	}
+
+	public void setF(int f) {
+		this.f = f;
+	}
+
+	public int getG() {
+		return g;
+	}
+
+	public void setG(int g) {
+		this.g = g;
+	}
+
+	public int getH() {
+		return h;
+	}
+
+	public void setH(int h) {
+		this.h = h;
+	}
+
+	public int getI() {
+		return i;
+	}
+
+	public void setI(int i) {
+		this.i = i;
+	}
+
+	public int getJ() {
+		return j;
+	}
+
+	public void setJ(int j) {
+		this.j = j;
+	}
+
+	public int getK() {
+		return k;
+	}
+
+	public void setK(int k) {
+		this.k = k;
+	}
+
+	public int getL() {
+		return l;
+	}
+
+	public void setL(int l) {
+		this.l = l;
+	}
+
+	public int getM() {
+		return m;
+	}
+
+	public void setM(int m) {
+		this.m = m;
+	}
+
+	public List<ObjectK> getN() {
+		return n;
+	}
+
+	public void setN(List<ObjectK> n) {
+		this.n = n;
+	}
+
+	public int getO() {
+		return o;
+	}
+
+	public void setO(int o) {
+		this.o = o;
+	}
+
+	public long getP() {
+		return p;
+	}
+
+	public void setP(long p) {
+		this.p = p;
+	}
+
+	public int getQ() {
+		return q;
+	}
+
+	public void setQ(int q) {
+		this.q = q;
+	}
+
+	public int getR() {
+		return r;
+	}
+
+	public void setR(int r) {
+		this.r = r;
+	}
+
+	public int getS() {
+		return s;
+	}
+
+	public void setS(int s) {
+		this.s = s;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectQ1_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectQ1_A.java
@@ -1,0 +1,64 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectQ1_A {
+    
+    private int a;
+
+    
+    private List<ObjectQ1_B> b;
+
+    
+    private int c;
+
+    
+    private boolean d;
+
+    
+    private boolean e;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public List<ObjectQ1_B> getB() {
+        return b;
+    }
+
+    public void setB(List<ObjectQ1_B> b) {
+        this.b = b;
+    }
+
+    public int getC() {
+        return c;
+    }
+
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public boolean isD() {
+        return d;
+    }
+
+    public void setD(boolean d) {
+        this.d = d;
+    }
+
+    public boolean isE() {
+        return e;
+    }
+
+    public void setE(boolean e) {
+        this.e = e;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectQ1_B.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectQ1_B.java
@@ -1,0 +1,30 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectQ1_B {
+
+
+    private int a;
+
+
+    private boolean b;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public boolean isB() {
+        return b;
+    }
+
+    public void setB(boolean b) {
+        this.b = b;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectR.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectR.java
@@ -1,0 +1,63 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+import java.util.List;
+
+
+public class ObjectR {
+    private int a;
+    private int b;
+    private int c;
+    private int d;
+    private List<Integer> e;
+    private int f;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public int getC() {
+        return c;
+    }
+
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public int getD() {
+        return d;
+    }
+
+    public void setD(int d) {
+        this.d = d;
+    }
+
+    public List<Integer> getE() {
+        return e;
+    }
+
+    public void setE(List<Integer> e) {
+        this.e = e;
+    }
+
+    public int getF() {
+        return f;
+    }
+
+    public void setF(int f) {
+        this.f = f;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectR1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectR1.java
@@ -1,0 +1,129 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectR1 {
+    
+    private List<Integer> a;
+
+    
+    private int b;
+
+    
+    private List<ObjectQ1_A> c;
+
+    private boolean d;
+
+    
+    private boolean e;
+
+    
+    private int f;
+
+    
+    private int g;
+
+    
+    private boolean h;
+
+    
+    private long i;
+
+    
+    private long j;
+
+    
+    private List<ObjectM1_A> k;
+
+    public List<Integer> getA() {
+        return a;
+    }
+
+    public void setA(List<Integer> a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public List<ObjectQ1_A> getC() {
+        return c;
+    }
+
+    public void setC(List<ObjectQ1_A> c) {
+        this.c = c;
+    }
+
+    public boolean isD() {
+        return d;
+    }
+
+    public void setD(boolean d) {
+        this.d = d;
+    }
+
+    public boolean isE() {
+        return e;
+    }
+
+    public void setE(boolean e) {
+        this.e = e;
+    }
+
+    public int getF() {
+        return f;
+    }
+
+    public void setF(int f) {
+        this.f = f;
+    }
+
+    public int getG() {
+        return g;
+    }
+
+    public void setG(int g) {
+        this.g = g;
+    }
+
+    public boolean isH() {
+        return h;
+    }
+
+    public void setH(boolean h) {
+        this.h = h;
+    }
+
+    public long getI() {
+        return i;
+    }
+
+    public void setI(long i) {
+        this.i = i;
+    }
+
+    public long getJ() {
+        return j;
+    }
+
+    public void setJ(long j) {
+        this.j = j;
+    }
+
+    public List<ObjectM1_A> getK() {
+        return k;
+    }
+
+    public void setK(List<ObjectM1_A> k) {
+        this.k = k;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectS.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectS.java
@@ -1,0 +1,29 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectS {
+	
+	private int a;
+	
+	private int b;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectS1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectS1.java
@@ -1,0 +1,131 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+import java.util.List;
+
+
+public class ObjectS1 {
+	
+	private int a;
+
+	
+	private int b;
+
+	
+	private int c = 0;
+
+	
+	private int d;
+
+	
+	private int e;
+
+	
+	private List<ObjectS1_A> f;
+
+	
+	private boolean g = false;
+
+	
+	private List<ObjectK> h;
+
+	
+	private List<ObjectK> i;
+
+	
+	private List<ObjectK> j;
+
+	
+	private boolean k = true;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public List<ObjectS1_A> getF() {
+		return f;
+	}
+
+	public void setF(List<ObjectS1_A> f) {
+		this.f = f;
+	}
+
+	public boolean isG() {
+		return g;
+	}
+
+	public void setG(boolean g) {
+		this.g = g;
+	}
+
+	public List<ObjectK> getH() {
+		return h;
+	}
+
+	public void setH(List<ObjectK> h) {
+		this.h = h;
+	}
+
+	public List<ObjectK> getI() {
+		return i;
+	}
+
+	public void setI(List<ObjectK> i) {
+		this.i = i;
+	}
+
+	public List<ObjectK> getJ() {
+		return j;
+	}
+
+	public void setJ(List<ObjectK> j) {
+		this.j = j;
+	}
+
+	public boolean isK() {
+		return k;
+	}
+
+	public void setK(boolean k) {
+		this.k = k;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectS1_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectS1_A.java
@@ -1,0 +1,50 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectS1_A {
+	
+	private int a;
+	
+	private int b;
+	
+	private int c;
+
+	
+	private boolean d;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public boolean isD() {
+		return d;
+	}
+
+	public void setD(boolean d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectT.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectT.java
@@ -1,0 +1,130 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectT {
+	
+	private int a = 0;
+
+	
+	private int b = 0;
+	
+	private int c = 0;
+
+	
+	private List<ObjectT_A> d;
+
+	
+	private int e = 0;
+
+	
+	private int f;
+
+	
+	private int g;
+
+	
+	private int h;
+
+	
+	private int i;
+
+	
+	private int j;
+
+	
+	private boolean k = false;
+
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public List<ObjectT_A> getD() {
+		return d;
+	}
+
+	public void setD(List<ObjectT_A> d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public int getF() {
+		return f;
+	}
+
+	public void setF(int f) {
+		this.f = f;
+	}
+
+	public int getG() {
+		return g;
+	}
+
+	public void setG(int g) {
+		this.g = g;
+	}
+
+	public int getH() {
+		return h;
+	}
+
+	public void setH(int h) {
+		this.h = h;
+	}
+
+	public int getI() {
+		return i;
+	}
+
+	public void setI(int i) {
+		this.i = i;
+	}
+
+	public int getJ() {
+		return j;
+	}
+
+	public void setJ(int j) {
+		this.j = j;
+	}
+
+	public boolean isK() {
+		return k;
+	}
+
+	public void setK(boolean k) {
+		this.k = k;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectT1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectT1.java
@@ -1,0 +1,100 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectT1 {
+	
+	private int a;
+
+	
+	private int b;
+	
+	private int c;
+	
+	private int d;
+	
+	private int e;
+	
+	private int f;
+	
+	private int g;
+	
+	private int h;
+	
+	private long i;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public int getF() {
+		return f;
+	}
+
+	public void setF(int f) {
+		this.f = f;
+	}
+
+	public int getG() {
+		return g;
+	}
+
+	public void setG(int g) {
+		this.g = g;
+	}
+
+	public int getH() {
+		return h;
+	}
+
+	public void setH(int h) {
+		this.h = h;
+	}
+
+	public long getI() {
+		return i;
+	}
+
+	public void setI(long i) {
+		this.i = i;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectT_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectT_A.java
@@ -1,0 +1,40 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectT_A {
+	
+	private int a;
+
+	
+	private boolean b;
+
+	
+	private long c;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public boolean isB() {
+		return b;
+	}
+
+	public void setB(boolean b) {
+		this.b = b;
+	}
+
+	public long getC() {
+		return c;
+	}
+
+	public void setC(long c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectU.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectU.java
@@ -1,0 +1,81 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectU {
+	
+	private int a;
+
+	
+	private Integer b;
+	
+	private int c;
+
+	
+	private int d;
+	
+	private int e;
+
+	
+	private int f;
+	
+	private boolean g;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public Integer getB() {
+		return b;
+	}
+
+	public void setB(Integer b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public int getF() {
+		return f;
+	}
+
+	public void setF(int f) {
+		this.f = f;
+	}
+
+	public boolean isG() {
+		return g;
+	}
+
+	public void setG(boolean g) {
+		this.g = g;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectU1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectU1.java
@@ -1,0 +1,140 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectU1 {
+	
+	private int a;
+	
+	private String b = "";
+	
+	private String c = "";
+	
+	private String d = "";
+	
+	private List<ObjectU1_A> e;
+	
+	private List<ObjectU1_B> f;
+	
+	private long g;
+	
+	private long h;
+	
+	private long i;
+	
+	private long j;
+	
+	private long k;
+	
+	private long l;
+	
+	private List<ObjectV1_A> m;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public String getB() {
+		return b;
+	}
+
+	public void setB(String b) {
+		this.b = b;
+	}
+
+	public String getC() {
+		return c;
+	}
+
+	public void setC(String c) {
+		this.c = c;
+	}
+
+	public String getD() {
+		return d;
+	}
+
+	public void setD(String d) {
+		this.d = d;
+	}
+
+	public List<ObjectU1_A> getE() {
+		return e;
+	}
+
+	public void setE(List<ObjectU1_A> e) {
+		this.e = e;
+	}
+
+	public List<ObjectU1_B> getF() {
+		return f;
+	}
+
+	public void setF(List<ObjectU1_B> f) {
+		this.f = f;
+	}
+
+	public long getG() {
+		return g;
+	}
+
+	public void setG(long g) {
+		this.g = g;
+	}
+
+	public long getH() {
+		return h;
+	}
+
+	public void setH(long h) {
+		this.h = h;
+	}
+
+	public long getI() {
+		return i;
+	}
+
+	public void setI(long i) {
+		this.i = i;
+	}
+
+	public long getJ() {
+		return j;
+	}
+
+	public void setJ(long j) {
+		this.j = j;
+	}
+
+	public long getK() {
+		return k;
+	}
+
+	public void setK(long k) {
+		this.k = k;
+	}
+
+	public long getL() {
+		return l;
+	}
+
+	public void setL(long l) {
+		this.l = l;
+	}
+
+	public List<ObjectV1_A> getM() {
+		return m;
+	}
+
+	public void setM(List<ObjectV1_A> m) {
+		this.m = m;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectU1_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectU1_A.java
@@ -1,0 +1,38 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectU1_A {
+	
+	private int a;
+	
+	private long b;
+	
+	private int c;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public long getB() {
+		return b;
+	}
+
+	public void setB(long b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectU1_B.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectU1_B.java
@@ -1,0 +1,59 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+import java.util.List;
+
+
+public class ObjectU1_B {
+	
+	private int a;
+	
+	private long b;
+	
+	private List<ObjectU1_C> c;
+	
+	private boolean d;
+	
+	private boolean e;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public long getB() {
+		return b;
+	}
+
+	public void setB(long b) {
+		this.b = b;
+	}
+
+	public List<ObjectU1_C> getC() {
+		return c;
+	}
+
+	public void setC(List<ObjectU1_C> c) {
+		this.c = c;
+	}
+
+	public boolean isD() {
+		return d;
+	}
+
+	public void setD(boolean d) {
+		this.d = d;
+	}
+
+	public boolean isE() {
+		return e;
+	}
+
+	public void setE(boolean e) {
+		this.e = e;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectU1_C.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectU1_C.java
@@ -1,0 +1,28 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectU1_C {
+	
+	private int a;
+	
+	private boolean b;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public boolean isB() {
+		return b;
+	}
+
+	public void setB(boolean b) {
+		this.b = b;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectV.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectV.java
@@ -1,0 +1,31 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectV {
+	
+	private List<ObjectV_A> a;
+
+	
+	private List<ObjectV_A> b;
+
+	public List<ObjectV_A> getA() {
+		return a;
+	}
+
+	public void setA(List<ObjectV_A> a) {
+		this.a = a;
+	}
+
+	public List<ObjectV_A> getB() {
+		return b;
+	}
+
+	public void setB(List<ObjectV_A> b) {
+		this.b = b;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectV1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectV1.java
@@ -1,0 +1,50 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectV1 {
+	
+	private int a;
+	
+	private int b;
+	
+	private List<ObjectK> c;
+	
+	private List<ObjectV1_A> d;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public List<ObjectK> getC() {
+		return c;
+	}
+
+	public void setC(List<ObjectK> c) {
+		this.c = c;
+	}
+
+	public List<ObjectV1_A> getD() {
+		return d;
+	}
+
+	public void setD(List<ObjectV1_A> d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectV1_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectV1_A.java
@@ -1,0 +1,40 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectV1_A {
+	
+	private int a;
+	
+	private List<Integer> b;
+	
+	private boolean c;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public List<Integer> getB() {
+		return b;
+	}
+
+	public void setB(List<Integer> b) {
+		this.b = b;
+	}
+
+	public boolean isC() {
+		return c;
+	}
+
+	public void setC(boolean c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectV_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectV_A.java
@@ -1,0 +1,49 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectV_A {
+	
+	private int a;
+
+	
+	private int b;
+	
+	private int c;
+	
+	private int d;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectW.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectW.java
@@ -1,0 +1,72 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectW {
+	
+	private long a;
+
+	
+	private int b;
+	
+	private long c;
+
+	
+	private int d;
+	
+	private String e;
+
+	
+	private long f;
+
+	public long getA() {
+		return a;
+	}
+
+	public void setA(long a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public long getC() {
+		return c;
+	}
+
+	public void setC(long c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public String getE() {
+		return e;
+	}
+
+	public void setE(String e) {
+		this.e = e;
+	}
+
+	public long getF() {
+		return f;
+	}
+
+	public void setF(long f) {
+		this.f = f;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectW1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectW1.java
@@ -1,0 +1,76 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectW1 {
+
+    
+    private int a;
+
+    
+    private int b;
+
+    
+    private List<Boolean> c;
+
+    
+    private boolean d;
+
+    
+    private List<CommonObject> e;
+
+    
+    private int f = 0;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public List<Boolean> getC() {
+        return c;
+    }
+
+    public void setC(List<Boolean> c) {
+        this.c = c;
+    }
+
+    public boolean isD() {
+        return d;
+    }
+
+    public void setD(boolean d) {
+        this.d = d;
+    }
+
+    public List<CommonObject> getE() {
+        return e;
+    }
+
+    public void setE(List<CommonObject> e) {
+        this.e = e;
+    }
+
+    public int getF() {
+        return f;
+    }
+
+    public void setF(int f) {
+        this.f = f;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectX.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectX.java
@@ -1,0 +1,96 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+import java.util.List;
+
+
+public class ObjectX {
+
+	
+	private long a = 0;
+	
+	private int b;
+
+	
+	private List<Integer> c;
+
+	
+	private int d = 0;
+
+	
+	private int e;
+
+	
+	private List<Integer> f;
+
+	
+	private List<String> g;
+	
+	private List<Integer> h;
+
+	public long getA() {
+		return a;
+	}
+
+	public void setA(long a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public List<Integer> getC() {
+		return c;
+	}
+
+	public void setC(List<Integer> c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public List<Integer> getF() {
+		return f;
+	}
+
+	public void setF(List<Integer> f) {
+		this.f = f;
+	}
+
+	public List<String> getG() {
+		return g;
+	}
+
+	public void setG(List<String> g) {
+		this.g = g;
+	}
+
+	public List<Integer> getH() {
+		return h;
+	}
+
+	public void setH(List<Integer> h) {
+		this.h = h;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectX1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectX1.java
@@ -1,0 +1,60 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+
+public class ObjectX1 {
+    
+    int a;
+    
+    int b;
+    
+    String c;
+    
+    String d;
+    
+    long e;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public String getC() {
+        return c;
+    }
+
+    public void setC(String c) {
+        this.c = c;
+    }
+
+    public String getD() {
+        return d;
+    }
+
+    public void setD(String d) {
+        this.d = d;
+    }
+
+    public long getE() {
+        return e;
+    }
+
+    public void setE(long e) {
+        this.e = e;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectY.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectY.java
@@ -1,0 +1,130 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+import java.util.List;
+
+
+public class ObjectY {
+	
+	private List<ObjectY_A> a;
+
+	
+	private long b;
+
+	
+	private int c = 0;
+
+	
+	private boolean d = false;
+
+	
+	private int e = -1;
+
+	
+	private int f = 0;
+
+	
+	private int g = 0;
+
+	
+
+	
+	private int h;
+	
+	private boolean i =false;
+	
+	private List<Integer> j;
+	
+	private List<Integer> k;
+
+	public List<ObjectY_A> getA() {
+		return a;
+	}
+
+	public void setA(List<ObjectY_A> a) {
+		this.a = a;
+	}
+
+	public long getB() {
+		return b;
+	}
+
+	public void setB(long b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public boolean isD() {
+		return d;
+	}
+
+	public void setD(boolean d) {
+		this.d = d;
+	}
+
+	public int getE() {
+		return e;
+	}
+
+	public void setE(int e) {
+		this.e = e;
+	}
+
+	public int getF() {
+		return f;
+	}
+
+	public void setF(int f) {
+		this.f = f;
+	}
+
+	public int getG() {
+		return g;
+	}
+
+	public void setG(int g) {
+		this.g = g;
+	}
+
+	public int getH() {
+		return h;
+	}
+
+	public void setH(int h) {
+		this.h = h;
+	}
+
+	public boolean isI() {
+		return i;
+	}
+
+	public void setI(boolean i) {
+		this.i = i;
+	}
+
+	public List<Integer> getJ() {
+		return j;
+	}
+
+	public void setJ(List<Integer> j) {
+		this.j = j;
+	}
+
+	public List<Integer> getK() {
+		return k;
+	}
+
+	public void setK(List<Integer> k) {
+		this.k = k;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectY1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectY1.java
@@ -1,0 +1,40 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectY1 {
+	
+	private int a;
+
+	
+	private int b;
+	
+	private int c;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectY_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectY_A.java
@@ -1,0 +1,53 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectY_A {
+
+	
+	private int a = 0;
+
+	
+	private int b;
+
+	
+	private int c;
+
+	
+	private int d;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public int getB() {
+		return b;
+	}
+
+	public void setB(int b) {
+		this.b = b;
+	}
+
+	public int getC() {
+		return c;
+	}
+
+	public void setC(int c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectZ.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectZ.java
@@ -1,0 +1,28 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+public class ObjectZ {
+	
+	private int a;
+	
+	private long b;
+
+	public int getA() {
+		return a;
+	}
+
+	public void setA(int a) {
+		this.a = a;
+	}
+
+	public long getB() {
+		return b;
+	}
+
+	public void setB(long b) {
+		this.b = b;
+	}
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectZ1.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectZ1.java
@@ -1,0 +1,106 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+import java.util.List;
+
+
+public class ObjectZ1 {
+    private int a;
+
+
+    private int b;
+
+
+    private int c;
+
+
+    private int d;
+
+
+    private int e;
+
+
+    private List<Integer> f;
+
+
+    private List<Integer> g;
+
+
+    private List<Integer> h;
+
+
+    private List<ObjectZ1_A> i;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public int getC() {
+        return c;
+    }
+
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public int getD() {
+        return d;
+    }
+
+    public void setD(int d) {
+        this.d = d;
+    }
+
+    public int getE() {
+        return e;
+    }
+
+    public void setE(int e) {
+        this.e = e;
+    }
+
+    public List<Integer> getF() {
+        return f;
+    }
+
+    public void setF(List<Integer> f) {
+        this.f = f;
+    }
+
+    public List<Integer> getG() {
+        return g;
+    }
+
+    public void setG(List<Integer> g) {
+        this.g = g;
+    }
+
+    public List<Integer> getH() {
+        return h;
+    }
+
+    public void setH(List<Integer> h) {
+        this.h = h;
+    }
+
+    public List<ObjectZ1_A> getI() {
+        return i;
+    }
+
+    public void setI(List<ObjectZ1_A> i) {
+        this.i = i;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectZ1_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/ObjectZ1_A.java
@@ -1,0 +1,41 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+
+
+
+
+
+public class ObjectZ1_A {
+    
+    private int a;
+
+    
+    private int b;
+
+    
+    private int c;
+
+    public int getA() {
+        return a;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public int getC() {
+        return c;
+    }
+
+    public void setC(int c) {
+        this.c = c;
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/OjectN_A.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issues3796/bean/OjectN_A.java
@@ -1,0 +1,49 @@
+package com.alibaba.fastjson.deserializer.issues3796.bean;
+
+public class OjectN_A {
+	private long a;
+	private String b;
+	private String c;
+	private int d;
+	private String e;
+
+	public long getA() {
+		return a;
+	}
+
+	public void setA(long a) {
+		this.a = a;
+	}
+
+	public String getB() {
+		return b;
+	}
+
+	public void setB(String b) {
+		this.b = b;
+	}
+
+	public String getC() {
+		return c;
+	}
+
+	public void setC(String c) {
+		this.c = c;
+	}
+
+	public int getD() {
+		return d;
+	}
+
+	public void setD(int d) {
+		this.d = d;
+	}
+
+	public String getE() {
+		return e;
+	}
+
+	public void setE(String e) {
+		this.e = e;
+	}
+}


### PR DESCRIPTION
bug报告参见#3796
java bean类过大时，生成的字节码地址可能为负数，即

```if_icmpeq     -32586```

这个提交修复了该问题，将if_icmpeq转换为if_icmpne+gotow语句。

提供了一个测试用例