### PR TITLE
Fix #3804

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONValidator.java
+++ b/src/main/java/com/alibaba/fastjson/JSONValidator.java
@@ -539,7 +539,9 @@ public abstract class JSONValidator implements Cloneable, Closeable {
                     next();
                     break;
                 }
-                else {
+                else if(eof){
+                    break;
+                }else {
                     next();
                 }
             }

--- a/src/test/java/com/alibaba/fastjson/deserializer/issue3804/TestIssue3804.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issue3804/TestIssue3804.java
@@ -1,0 +1,16 @@
+package com.alibaba.fastjson.deserializer.issue3804;
+import com.alibaba.fastjson.JSONValidator;
+import org.junit.Test;
+
+public class TestIssue3804 {
+    @Test
+    public void testIssue3804() {
+        String textResponse="{\"error\":false,\"code\":0}";
+        JSONValidator validator = JSONValidator.from(textResponse);
+        if (validator.validate() && validator.getType() == JSONValidator.Type.Object) {
+            System.out.println("Yes, it is Object");
+        } else {
+            System.out.println("No, it is not Object");
+        }
+    }
+}

--- a/src/test/java/com/alibaba/fastjson/deserializer/issue3804/TestIssue3804.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issue3804/TestIssue3804.java
@@ -5,7 +5,8 @@ import org.junit.Test;
 public class TestIssue3804 {
     @Test
     public void testIssue3804() {
-        String textResponse="{\"error\":false,\"code\":0}";
+        //String textResponse="{\"error\":false,\"code\":0}";
+        String textResponse="{\"error\":false,\"code";
         JSONValidator validator = JSONValidator.from(textResponse);
         if (validator.validate() && validator.getType() == JSONValidator.Type.Object) {
             System.out.println("Yes, it is Object");


### PR DESCRIPTION
报告参见[#3804 ](https://github.com/alibaba/fastjson/issues/3804)
若某些传入的字符串不符合约定，当pos >= str.length()时，对最后引号的判断会陷入死循环，最终导致pos的数值越界