### PR TITLE
Update TypeUtils.java

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -1877,7 +1877,12 @@ public class TypeUtils{
         String[] paramNames = null;
         short[] paramNameMapping = null;
         Method[] methods = clazz.getMethods();
-        Arrays.sort(methods, new MethodInheritanceComparator());
+        Map<Boolean, List<Method>> list = Arrays.stream(methods).collect(Collectors.groupingBy(s -> s.getReturnType().isPrimitive()));
+        List<Method> list1 = list.get(true);
+        List<Method> list2 = list.get(false);
+        Collections.sort(list2, new MethodInheritanceComparator());
+        list2.addAll(list1);
+        methods = list2.toArray(new Method[0]);
         for(Method method : methods){
             String methodName = method.getName();
             int ordinal = 0, serialzeFeatures = 0, parserFeatures = 0;


### PR DESCRIPTION
修复偶尔出现的Comparison method violates its general contract!问题
MethodInheritanceComparator在特定数据下没有满足了Comparator要求自反性，对称性，传递性这些原则。
java.lang.IllegalArgumentException: Comparison method violates its general contract!
	at java.util.TimSort.mergeHi(TimSort.java:899)
	at java.util.TimSort.mergeAt(TimSort.java:516)
	at java.util.TimSort.mergeCollapse(TimSort.java:441)
	at java.util.TimSort.sort(TimSort.java:245)
	at java.util.Arrays.sort(Arrays.java:1512)
	at java.util.ArrayList.sort(ArrayList.java:1464)
	at java.util.Collections.sort(Collections.java:177)