### PR TITLE
Update 修改了toJSON方法，现在toJSON返回值是传入对象的深克隆，避免传入对象的值随着toJSON返回值改变而被改变

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -1130,7 +1130,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         }
 
         if (javaObject instanceof JSON) {
-            return javaObject;
+            return JSON.parse(JSON.toJSONString(javaObject));
         }
 
         if (javaObject instanceof Map) {


### PR DESCRIPTION
你好，我看了一下toJSON的代码，发现了可能会导致出错的一些代码。当传入对象为JSONObject时候toJSON返回的是传入的对象。此时修改toJSON返回的对象，会导致传入对象的值一起改变。再次使用传入对象会出现传入值被修改的问题
下面是测试用例

        JSONObject object = new JSONObject();
        object.put("table", "simTable");

        JSONObject column = (JSONObject) JSON.toJSON(object); // 这里的本意应该是想通过toJSON生成一个新的对象
        column.put("type", "simNews"); // 这里修改column object也会被改变

        JSONObject item = new JSONObject();
        item.put("key", "simkey");

        JSONArray array = new JSONArray();
        array.add(item);

        object.put("nodeList", array); // object再次被使用里面的值是错误的

如果没问题的话可以帮忙merge 一下吗？