### PR TITLE
Avoid inefficient usage of arraylist

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/SerializeFilterable.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializeFilterable.java
@@ -1,7 +1,7 @@
 package com.alibaba.fastjson.serializer;
 
 import java.text.DecimalFormat;
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 import com.alibaba.fastjson.JSON;
@@ -21,7 +21,7 @@ public abstract class SerializeFilterable {
 
     public List<BeforeFilter> getBeforeFilters() {
         if (beforeFilters == null) {
-            beforeFilters = new ArrayList<BeforeFilter>();
+            beforeFilters = new LinkedList<BeforeFilter>();
             writeDirect = false;
         }
 
@@ -30,7 +30,7 @@ public abstract class SerializeFilterable {
 
     public List<AfterFilter> getAfterFilters() {
         if (afterFilters == null) {
-            afterFilters = new ArrayList<AfterFilter>();
+            afterFilters = new LinkedList<AfterFilter>();
             writeDirect = false;
         }
 
@@ -39,7 +39,7 @@ public abstract class SerializeFilterable {
 
     public List<NameFilter> getNameFilters() {
         if (nameFilters == null) {
-            nameFilters = new ArrayList<NameFilter>();
+            nameFilters = new LinkedList<NameFilter>();
             writeDirect = false;
         }
 
@@ -48,7 +48,7 @@ public abstract class SerializeFilterable {
 
     public List<PropertyPreFilter> getPropertyPreFilters() {
         if (propertyPreFilters == null) {
-            propertyPreFilters = new ArrayList<PropertyPreFilter>();
+            propertyPreFilters = new LinkedList<PropertyPreFilter>();
             writeDirect = false;
         }
 
@@ -57,7 +57,7 @@ public abstract class SerializeFilterable {
 
     public List<LabelFilter> getLabelFilters() {
         if (labelFilters == null) {
-            labelFilters = new ArrayList<LabelFilter>();
+            labelFilters = new LinkedList<LabelFilter>();
             writeDirect = false;
         }
 
@@ -66,7 +66,7 @@ public abstract class SerializeFilterable {
 
     public List<PropertyFilter> getPropertyFilters() {
         if (propertyFilters == null) {
-            propertyFilters = new ArrayList<PropertyFilter>();
+            propertyFilters = new LinkedList<PropertyFilter>();
             writeDirect = false;
         }
 
@@ -75,7 +75,7 @@ public abstract class SerializeFilterable {
 
     public List<ContextValueFilter> getContextValueFilters() {
         if (contextValueFilters == null) {
-            contextValueFilters = new ArrayList<ContextValueFilter>();
+            contextValueFilters = new LinkedList<ContextValueFilter>();
             writeDirect = false;
         }
 
@@ -84,7 +84,7 @@ public abstract class SerializeFilterable {
 
     public List<ValueFilter> getValueFilters() {
         if (valueFilters == null) {
-            valueFilters = new ArrayList<ValueFilter>();
+            valueFilters = new LinkedList<ValueFilter>();
             writeDirect = false;
         }
 

--- a/src/test/java/com/alibaba/json/bvtVO/wuqi/SchemaResult.java
+++ b/src/test/java/com/alibaba/json/bvtVO/wuqi/SchemaResult.java
@@ -1,6 +1,6 @@
 package com.alibaba.json.bvtVO.wuqi;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -27,8 +27,8 @@ public class SchemaResult {
     }
 
     public SchemaResult() {
-        data = new ArrayList<InstanceSchema>();
-        extra = new ArrayList<Map<String, Object>>();
+        data = new LinkedList<InstanceSchema>();
+        extra = new LinkedList<Map<String, Object>>();
     }
 
     public int getCode() {


### PR DESCRIPTION
Hi,
We find that there are ten ArrayList objects which are not manipulated by random access. Due to the memory reallocation triggered in the successive insertions, the time complexity of add method of ArrayList is amortized O(1). We notice that these objects are only used for traversal and the retrieval for the first or the last element.

This functionality can be implemented by LinkedList. Moreover, the insertion of LinkedList is strictly O(1) time complexity because no memory reallocation occurs.

We discovered this inefficient usage of containers by our tool Ditto. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.

Bests

Ditto