### PR TITLE
delete Cloneable from JSONValidator

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONValidator.java
+++ b/src/main/java/com/alibaba/fastjson/JSONValidator.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 
-public abstract class JSONValidator implements Cloneable, Closeable {
+public abstract class JSONValidator implements Closeable {
     public enum Type {
         Object, Array, Value
     }


### PR DESCRIPTION
Or is there any reason not to do so?