### PR TITLE
bug fix for parsing invalid array json string

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
+++ b/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
@@ -799,6 +799,10 @@ public class DefaultJSONParser implements Closeable {
                     lexer.nextToken(deserializer.getFastMatchToken());
                     continue;
                 }
+                if (lexer.token() != RBRACKET) {
+                    // token is NOT `COMMA` and `RBRACKET`
+                    throw new JSONException("syntax error, expect `,` or `]`, but found `" + JSONToken.name(lexer.token()) + "`");
+                }
             }
         } finally {
             this.setContext(context);
@@ -1275,6 +1279,10 @@ public class DefaultJSONParser implements Closeable {
                 if (lexer.token() == JSONToken.COMMA) {
                     lexer.nextToken(JSONToken.LITERAL_STRING);
                     continue;
+                }
+                if (lexer.token() != RBRACKET) {
+                    // token is NOT `COMMA` and `RBRACKET`
+                    throw new JSONException("syntax error, expect `,` or `]`, but found `" + JSONToken.name(lexer.token()) + "`");
                 }
             }
         } catch (ClassCastException e) {

--- a/src/test/java/com/alibaba/json/bvt/JSONArrayTest.java
+++ b/src/test/java/com/alibaba/json/bvt/JSONArrayTest.java
@@ -193,6 +193,28 @@ public class JSONArrayTest extends TestCase {
         Assert.assertEquals(123, array.getObject(0, User.class).getId());
     }
 
+    public void test_error_array() {
+        String errorJson = "[{\"a\":1}{\"b\":2}null undefined 676]";
+        Exception ex = null;
+        try {
+            JSONObject.parseArray(errorJson);
+        } catch (Exception e) {
+            ex = e;
+        }
+        Assert.assertNotNull("An exception must be thrown, because syntax error has occurred in `" + errorJson + "`", ex);
+    }
+
+    public void test_error_obj_arr() {
+        String errorJson = "[213, 235, 122, null null, 5]";
+        Exception ex = null;
+        try {
+            JSONObject.parseArray(errorJson, Integer.class);
+        } catch (Exception e) {
+            ex = e;
+        }
+        Assert.assertNotNull("An exception must be thrown, because syntax error has occurred in `" + errorJson + "`", ex);
+    }
+
     public static class User {
 
         private long   id;

--- a/src/test/java/com/alibaba/json/bvt/parser/DefaultExtJSONParserTest_4.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/DefaultExtJSONParserTest_4.java
@@ -16,7 +16,8 @@ public class DefaultExtJSONParserTest_4 extends TestCase {
 
     public void test_0() throws Exception {
         List<?> res = Arrays.asList(1, 2, 3);
-        String[] tests = { "[1,2,3]", "[1,,2,3]", "[1,2,,,3]", "[1 2,,,3]", "[1 2 3]", "[1, 2, 3,,]", "[,,1, 2, 3,,]", };
+        // String[] tests = { "[1,2,3]", "[1,,2,3]", "[1,2,,,3]", "[1 2,,,3]", "[1 2 3]", "[1, 2, 3,,]", "[,,1, 2, 3,,]", };
+        String[] tests = { "[1,2,3]", "[1,,2,3]", "[1,2,,,3]", "[1 ,2,,,3]", "[1 ,2 ,3]", "[1, 2, 3,,]", "[,,1, 2, 3,,]", };
 
         for (String t : tests) {
             DefaultJSONParser ext = new DefaultJSONParser(t);


### PR DESCRIPTION
本次PR主要内容：

1. 解析数组时，增加json格式验证
2. 添加相关测试用例
3. 更改旧的测试用例，因为其中包含了非法json的解析

相关issue： #3950, #3946, #3950