### PR TITLE
枚举转换不支持自定义Deserializer

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -1338,7 +1338,7 @@ public class TypeUtils {
         }
 
         try {
-            if(obj instanceof String){
+            if (obj instanceof String) {
                 String name = (String) obj;
                 if (isDigitString(name)) {
                     // string is digital, search by ordinal
@@ -1358,13 +1358,13 @@ public class TypeUtils {
                         return (T) Enum.valueOf((Class<? extends Enum>) clazz, name);
                     }
                 }
-            } else if(obj instanceof BigDecimal){
+            } else if (obj instanceof BigDecimal) {
                 int ordinal = intValue((BigDecimal) obj);
                 Object[] values = clazz.getEnumConstants();
                 if (ordinal < values.length) {
                     return (T) values[ordinal];
                 }
-            } else if(obj instanceof Number){
+            } else if (obj instanceof Number) {
                 int ordinal = ((Number) obj).intValue();
                 Object[] values = clazz.getEnumConstants();
                 if (ordinal < values.length) {

--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -1290,6 +1290,14 @@ public class TypeUtils {
         // Change to no precondition, it will be called as soon as it is registered.
         // Because the number are not necessarily 'enum.ordinal', it may also be necessary to call deserializer.
 
+        // ParserConfig.getGlobalInstance().putDeserializer(UserState.class, new UserStateDeserializer());
+        // UserState is an enum
+        // TypeUtils.castToEnum(1, UserState.class);
+        // if UserStateDeserializer is an ObjectDeserializer,
+        // -- then only if value is a string/number/boolean, eventually call deserializer.deserialze(...)
+        // if UserStateDeserializer is an EnumDeserializer,
+        // -- then only if value is a string, eventually call enumDeserializer.getEnumByHashCode(...)
+
         ObjectDeserializer deserializer = mapping.getDeserializer(clazz);
         if (deserializer != null && !(deserializer instanceof EnumDeserializer)) {
             // EnumDeserializer is not actually an ObjectDeserializer, cannot enter this code,

--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -1271,10 +1271,41 @@ public class TypeUtils {
         return new Locale(items[0], items[1], items[2]);
     }
 
+    /**
+     * Object convert to Enum, support register enum Deserializer.<br>
+     * e.g. <code>ParserConfig.getGlobalInstance().putDeserializer(UserState.class, new UserStateDeserializer());</code><br>
+     * UserState is an enum;<br>
+     * <code>TypeUtils.castToEnum(1, UserState.class);</code><br>
+     * if UserStateDeserializer is an <code>ObjectDeserializer</code>,<br>
+     * -- then only if value is a string/number/boolean, eventually call deserializer.deserialze(...)<br>
+     * if UserStateDeserializer is an <code>EnumDeserializer</code>,<br>
+     * -- then only if value is a string, eventually call enumDeserializer.getEnumByHashCode(...)<br>
+     *
+     * @param obj source object
+     * @param clazz target enum type
+     * @param <T> class type
+     * @return Enum
+     */
     public static <T> T castToEnum(Object obj, Class<T> clazz) {
         return castToEnum(obj, clazz, null);
     }
 
+    /**
+     * Object convert to Enum, support register enum Deserializer.<br>
+     * e.g. <code>ParserConfig.getGlobalInstance().putDeserializer(UserState.class, new UserStateDeserializer());</code><br>
+     * UserState is an enum;<br>
+     * <code>TypeUtils.castToEnum(1, UserState.class);</code><br>
+     * if UserStateDeserializer is an <code>ObjectDeserializer</code>,<br>
+     * -- then only if value is a string/number/boolean, eventually call deserializer.deserialze(...)<br>
+     * if UserStateDeserializer is an <code>EnumDeserializer</code>,<br>
+     * -- then only if value is a string, eventually call enumDeserializer.getEnumByHashCode(...)<br>
+     *
+     * @param obj source object
+     * @param clazz target enum type
+     * @param <T> class type
+     * @param mapping ParserConfig
+     * @return Enum
+     */
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static <T> T castToEnum(Object obj, Class<T> clazz, ParserConfig mapping){
         if (obj == null || (obj instanceof String && ((String) obj).length() == 0)) {
@@ -1289,14 +1320,6 @@ public class TypeUtils {
         // Previously, deserializer was only checked if the object was a string.
         // Change to no precondition, it will be called as soon as it is registered.
         // Because the number are not necessarily 'enum.ordinal', it may also be necessary to call deserializer.
-
-        // ParserConfig.getGlobalInstance().putDeserializer(UserState.class, new UserStateDeserializer());
-        // UserState is an enum
-        // TypeUtils.castToEnum(1, UserState.class);
-        // if UserStateDeserializer is an ObjectDeserializer,
-        // -- then only if value is a string/number/boolean, eventually call deserializer.deserialze(...)
-        // if UserStateDeserializer is an EnumDeserializer,
-        // -- then only if value is a string, eventually call enumDeserializer.getEnumByHashCode(...)
 
         ObjectDeserializer deserializer = mapping.getDeserializer(clazz);
         if (deserializer != null && !(deserializer instanceof EnumDeserializer)) {
@@ -1338,17 +1361,17 @@ public class TypeUtils {
             } else if(obj instanceof BigDecimal){
                 int ordinal = intValue((BigDecimal) obj);
                 Object[] values = clazz.getEnumConstants();
-                if(ordinal < values.length){
+                if (ordinal < values.length) {
                     return (T) values[ordinal];
                 }
             } else if(obj instanceof Number){
                 int ordinal = ((Number) obj).intValue();
                 Object[] values = clazz.getEnumConstants();
-                if(ordinal < values.length){
+                if (ordinal < values.length) {
                     return (T) values[ordinal];
                 }
             }
-        } catch(Exception ex){
+        } catch (Exception ex) {
             throw new JSONException("can not cast " + obj + " to : " + clazz.getName(), ex);
         }
         throw new JSONException("can not cast " + obj + " to : " + clazz.getName());

--- a/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3372.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3372.java
@@ -1,0 +1,189 @@
+package com.alibaba.json.bvt.issue_3300;
+
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.parser.DefaultJSONParser;
+import com.alibaba.fastjson.parser.JSONLexer;
+import com.alibaba.fastjson.parser.JSONToken;
+import com.alibaba.fastjson.parser.ParserConfig;
+import com.alibaba.fastjson.parser.deserializer.ObjectDeserializer;
+import com.alibaba.fastjson.util.TypeUtils;
+import junit.framework.TestCase;
+
+/**
+ * Test of Deserializer customized for special enum
+ *
+ * @author zhaohuihua
+ * @version 20211219
+ */
+public class Issue3372 extends TestCase {
+
+    public static void main(String[] args) {
+        Issue3372 test = new Issue3372();
+        test.setUp();
+        test.testConvert();
+        test.testException();
+        System.out.println("test passed!");
+    }
+
+    protected void setUp() {
+        // Register a customized Deserializer for UserState
+        ParserConfig.getGlobalInstance().putDeserializer(UserState.class, new CodeEnumDeserializer());
+    }
+
+    public void testConvert() {
+        assertEquals(UserState.NORMAL, TypeUtils.castToEnum("NORMAL", UserState.class));
+        assertEquals(UserState.NORMAL, TypeUtils.castToEnum("1", UserState.class));
+        assertEquals(UserState.NORMAL, TypeUtils.castToEnum(1, UserState.class));
+        assertEquals(UserState.LOCKED, TypeUtils.castToEnum("LOCKED", UserState.class));
+        assertEquals(UserState.LOCKED, TypeUtils.castToEnum("2", UserState.class));
+        assertEquals(UserState.LOCKED, TypeUtils.castToEnum(2, UserState.class));
+        assertEquals(UserState.UNACTIVATED, TypeUtils.castToEnum("UNACTIVATED", UserState.class));
+        assertEquals(UserState.UNACTIVATED, TypeUtils.castToEnum("3", UserState.class));
+        assertEquals(UserState.UNACTIVATED, TypeUtils.castToEnum(3, UserState.class));
+        assertEquals(UserState.LOGOFF, TypeUtils.castToEnum("LOGOFF", UserState.class));
+        assertEquals(UserState.LOGOFF, TypeUtils.castToEnum("9", UserState.class));
+        assertEquals(UserState.LOGOFF, TypeUtils.castToEnum(9, UserState.class));
+    }
+
+    public void testException() {
+        try {
+            TypeUtils.castToEnum(0, UserState.class, null);
+        } catch (Exception e) {
+            assertEquals(JSONException.class, e.getClass());
+        }
+        try {
+            TypeUtils.castToEnum("AAA", UserState.class, null);
+        } catch (Exception e) {
+            assertEquals(JSONException.class, e.getClass());
+        }
+    }
+
+    /** Enum interface with customized code. **/
+    protected interface CodeEnum {
+        int code();
+    }
+
+    /** User state enum class **/
+    protected enum UserState implements CodeEnum {
+
+        /** 1.Normal **/
+        NORMAL(1),
+        /** 2.Locked **/
+        LOCKED(2),
+        /** 3.Unactivated **/
+        UNACTIVATED(3),
+        /** 9.Logoff **/
+        LOGOFF(9);
+
+        private final int code;
+
+        UserState(int code) {
+            this.code = code;
+        }
+
+        public int code() {
+            return this.code;
+        }
+    }
+
+    /** Returns a special Deserializer class for a customized code. **/
+    protected static class CodeEnumDeserializer implements ObjectDeserializer {
+
+        @SuppressWarnings("unchecked")
+        public <T> T deserialze(DefaultJSONParser parser, Type type, Object fieldName) {
+            JSONLexer lexer = parser.lexer;
+            if (lexer.token() == JSONToken.NULL) {
+                lexer.nextToken(JSONToken.COMMA);
+                return null;
+            }
+
+            Class<?> targetClass = TypeUtils.getRawClass(type);
+            if (!CodeEnum.class.isAssignableFrom(targetClass)) {
+                throw new JSONException("CodeEnumDeserializer do not support " + targetClass.getName());
+            }
+            if (!Enum.class.isAssignableFrom(targetClass)) {
+                throw new JSONException("CodeEnumDeserializer do not support " + targetClass.getName());
+            }
+            Enum<?>[] ordinalEnums = (Enum<?>[]) targetClass.getEnumConstants();
+            if (lexer.token() == JSONToken.LITERAL_INT) {
+                BigDecimal number = lexer.decimalValue();
+                lexer.nextToken(JSONToken.COMMA);
+                return (T) convertFromNumber(number, ordinalEnums, targetClass);
+            } else if (lexer.token() == JSONToken.LITERAL_FLOAT) {
+                BigDecimal number = lexer.decimalValue();
+                lexer.nextToken(JSONToken.COMMA);
+                return (T) convertFromNumber(number, ordinalEnums, targetClass);
+            } else if (lexer.token() == JSONToken.LITERAL_STRING) {
+                String string = lexer.stringVal();
+                if (isDigitString(string)) {
+                    BigDecimal number = new BigDecimal(string);
+                    return (T) convertFromNumber(number, ordinalEnums, targetClass);
+                } else {
+                    return (T) convertFromString(string, ordinalEnums, targetClass);
+                }
+            }
+
+            Object value = parser.parse();
+            String msg = "can not cast " + value + " to : " + targetClass.getName();
+            throw new JSONException(msg);
+        }
+
+        private Enum<?> convertFromNumber(BigDecimal number, Enum<?>[] enums, Class<?> type) {
+            // integer part
+            BigInteger integer = number.toBigInteger();
+            boolean isIntegral = number.compareTo(new BigDecimal(integer)) == 0;
+            if (!isIntegral) {
+                // Is not an integer
+                String msg = "can not cast " + number.toPlainString() + " to : " + type.getName();
+                throw new JSONException(msg);
+            }
+            BigInteger minInteger = BigInteger.valueOf(Integer.MIN_VALUE);
+            BigInteger maxInteger = BigInteger.valueOf(Integer.MAX_VALUE);
+            if (integer.compareTo(minInteger) < 0 || integer.compareTo(maxInteger) > 0) {
+                // Out of integer range
+                throw new JSONException("can not cast " + integer + "to : " + type.getName());
+            }
+            // search by code
+            int targetValue = number.intValue();
+            for (Enum<?> item : enums) {
+                if (((CodeEnum) item).code() == targetValue) {
+                    return item;
+                }
+            }
+            throw new JSONException("can not cast " + integer + "to : " + type.getName());
+        }
+
+        private Enum<?> convertFromString(String string, Enum<?>[] enums, Class<?> type) {
+            if (string.length() == 0) {
+                return null;
+            }
+            // search by name
+            for (Enum<?> item : enums) {
+                if (item.name().equals(string)) {
+                    return item;
+                }
+            }
+            throw new JSONException("can not cast " + string + "to : " + type.getName());
+        }
+
+        private boolean isDigitString(String string) {
+            if (string == null || string.length() == 0) {
+                return false;
+            }
+            for (int i = 0, z = string.length(); i < z; i++) {
+                char c = string.charAt(i);
+                if (c < '0' || c > '9') {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public int getFastMatchToken() {
+            return JSONToken.LITERAL_INT;
+        }
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3372.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3372.java
@@ -20,14 +20,6 @@ import junit.framework.TestCase;
  */
 public class Issue3372 extends TestCase {
 
-    public static void main(String[] args) {
-        Issue3372 test = new Issue3372();
-        test.setUp();
-        test.testConvert();
-        test.testException();
-        System.out.println("test passed!");
-    }
-
     protected void setUp() {
         // Register a customized Deserializer for UserState
         ParserConfig.getGlobalInstance().putDeserializer(UserState.class, new CodeEnumDeserializer());


### PR DESCRIPTION
注册了自定义的枚举Deserializer之后，TypeUtils.castToEnum并不会调用它。

原因是原先的逻辑有些问题：

只有转换string才会调用mapping.getDeserializer(clazz)，但有时数字也需要自定义转换逻辑；
自定义的Deserializer必须是EnumDeserializer才会调用，但ObjectDeserializer也应支持；
不支持数字型字符串按ordinal查找，这个不算问题但也可以优化一下，TypeUtils.castToEnum("1", XxxEnum.class)。

问题描述详见 Issues: #3372
有一并提供TestCase，详见 Issue3372.java