### PR TITLE
增加了一个工具类，专门用于打印JSON格式日志

### DIFF
--- a/src/main/java/com/alibaba/fastjson/PrettyString.java
+++ b/src/main/java/com/alibaba/fastjson/PrettyString.java
@@ -1,0 +1,111 @@
+package com.alibaba.fastjson;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Map;
+
+/**
+ * Convert java object to JSON String, reduce large fields automatically
+ * <p>
+ * <b>For log printing</b>
+ * </p>
+ * 
+ * @author xiaqy[xia061106@qq.com]
+ */
+public class PrettyString {
+    private final Object ref;
+    private final int maxStringLength;
+    private final int maxItemsCount;
+
+    public PrettyString(Object javaObject, int maxItemsCount, int maxStringLength) {
+        this.ref = javaObject;
+        this.maxItemsCount = maxItemsCount;
+        this.maxStringLength = maxStringLength;
+    }
+
+    public PrettyString(Object javaObject) {
+        this(javaObject, 20, 512);
+    }
+
+    @Override
+    public String toString() {
+        try {
+            Object object = JSON.toJSON(ref);
+            if (object instanceof JSON) {
+                return toPrettyStringForLog((JSON) object);
+            } else {
+                return String.valueOf(object);
+            }
+        } catch (Exception e) {
+            StringWriter sw = new StringWriter();
+            e.printStackTrace(new PrintWriter(sw));
+            return sw.toString();
+        }
+    }
+
+    private String toPrettyStringForLog(JSON json) {
+        StringBuilder sb = new StringBuilder(512);
+        if (json instanceof JSONObject) {
+            sb.append("{");
+            for (Map.Entry<String, Object> entry : ((JSONObject) json).entrySet()) {
+                sb.append("\"").append(entry.getKey()).append("\"");
+                sb.append(":");
+                if (entry.getValue() instanceof JSON) {
+                    sb.append(toPrettyStringForLog((JSON) entry.getValue()));
+                } else if (entry.getValue() instanceof String) {
+                    sb.append("\"");
+                    String text = (String) entry.getValue();
+                    if (text.length() <= maxStringLength) {
+                        sb.append(text);
+                    } else {
+                        String prefix = text.substring(0, maxStringLength / 2 - 3);
+                        sb.append(prefix);
+                        sb.append("......");
+                        sb.append(text.substring(text.length() - maxStringLength + prefix.length() + 6));
+                    }
+                    sb.append("\"");
+                } else {
+                    sb.append(entry.getValue());
+                }
+                sb.append(",");
+            }
+            if (sb.charAt(sb.length() - 1) == ',') {
+                sb.deleteCharAt(sb.length() - 1);
+            }
+            sb.append("}");
+        } else if (json instanceof JSONArray) {
+            JSONArray arr = (JSONArray) json;
+            sb.append("[");
+            if (arr.size() > maxItemsCount) {
+                sb.append("{\"//\":\"only first ").append(maxItemsCount).append(" of ").append(arr.size()).append(" objects are displayed\"},");
+            }
+            for (int i = 0; i < Math.min(arr.size(), maxItemsCount); i++) {
+                Object obj = arr.get(i);
+                if (obj instanceof JSON) {
+                    sb.append(toPrettyStringForLog((JSON) obj));
+                } else if (obj instanceof String) {
+                    sb.append("\"");
+                    String text = (String) obj;
+                    if (text.length() <= maxStringLength) {
+                        sb.append(text);
+                    } else {
+                        String prefix = text.substring(0, maxStringLength / 2 - 3);
+                        sb.append(prefix);
+                        sb.append("......");
+                        sb.append(text.substring(text.length() - maxStringLength + prefix.length() + 6));
+                    }
+                    sb.append("\"");
+                } else {
+                    sb.append(obj);
+                }
+                sb.append(",");
+            }
+            if (sb.charAt(sb.length() - 1) == ',') {
+                sb.deleteCharAt(sb.length() - 1);
+            }
+            sb.append("]");
+        }
+
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
看到项目里很多人用JSON.toJSONString打印，有几个问题：
1.打印大的列表开销还是挺大的，增加耗时
2.长列表很容易被日志工具截断，错过有用信息
3.提升日志级别，不执行DEBUG打印时，反序列化操作还是会执行

PrettyString通过toString()方法打印JSON格式日志，缩减了大列表长和字符串的输出，打印通用日志（入参出参长度大小不可控时）效果会比较好