### PR TITLE
Support write LocalDateTime to timestamp

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/Jdk8DateCodec.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/Jdk8DateCodec.java
@@ -532,8 +532,12 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
             }
 
             if (fieldType == LocalDateTime.class) {
-                final int mask = SerializerFeature.UseISO8601DateFormat.getMask();
                 LocalDateTime dateTime = (LocalDateTime) object;
+                if (serializer.isEnabled(SerializerFeature.WriteDateUseTimestamp)) {
+                    out.writeLong(dateTime.atZone(JSON.defaultTimeZone.toZoneId()).toInstant().toEpochMilli());
+                    return;
+                }
+                final int mask = SerializerFeature.UseISO8601DateFormat.getMask();
                 String format = serializer.getDateFormatPattern();
 
                 if (format == null) {

--- a/src/main/java/com/alibaba/fastjson/serializer/JodaCodec.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JodaCodec.java
@@ -453,8 +453,12 @@ public class JodaCodec implements ObjectSerializer, ContextObjectSerializer, Obj
             }
 
             if (fieldType == LocalDateTime.class) {
-                final int mask = SerializerFeature.UseISO8601DateFormat.getMask();
                 LocalDateTime dateTime = (LocalDateTime) object;
+                if (serializer.isEnabled(SerializerFeature.WriteDateUseTimestamp)) {
+                    out.writeLong(dateTime.toDate(JSON.defaultTimeZone).getTime());
+                    return;
+                }
+                final int mask = SerializerFeature.UseISO8601DateFormat.getMask();
                 String format = serializer.getDateFormatPattern();
 
                 if (format == null) {

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializerFeature.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializerFeature.java
@@ -152,7 +152,12 @@ public enum SerializerFeature {
     /**
      * @since 1.2.27
      */
-    MapSortField;
+    MapSortField,
+
+    /**
+     * @since 1.2.30
+     */
+    WriteDateUseTimestamp;
 
     SerializerFeature(){
         mask = (1 << ordinal());

--- a/src/test/java/com/alibaba/fastjson/serializer/issue4002/TestLocalDateTimeToTimestamp.java
+++ b/src/test/java/com/alibaba/fastjson/serializer/issue4002/TestLocalDateTimeToTimestamp.java
@@ -1,0 +1,46 @@
+package com.alibaba.fastjson.serializer.issue4002;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author freeman
+ * @see <a href="https://github.com/alibaba/fastjson/issues/4002">issue_4002</a>
+ */
+public class TestLocalDateTimeToTimestamp {
+
+    @Getter
+    @Setter
+    @Accessors(chain = true)
+    public static class DateTimeGroup {
+        private LocalDateTime jdk8DateTime;
+        private org.joda.time.LocalDateTime jodaDateTime;
+    }
+
+    @Test
+    public void testIssue4002() {
+        DateTimeGroup raw = new DateTimeGroup()
+                .setJdk8DateTime(LocalDateTime.now())
+                .setJodaDateTime(org.joda.time.LocalDateTime.now());
+        String dateFormat = JSON.toJSONString(raw);
+        String timestampFormat = JSON.toJSONString(raw, SerializerFeature.WriteDateUseTimestamp);
+        DateTimeGroup parsedObj = JSON.parseObject(timestampFormat, DateTimeGroup.class);
+
+        assertFalse(Pattern.matches(".*\\d{13,}.*", dateFormat));
+        assertTrue(Pattern.matches(".*\\d+-\\d+-\\d+T\\d+:\\d+:\\d+.*", dateFormat));
+        assertTrue(Pattern.matches(".*\\d{13,}.*", timestampFormat));
+        assertFalse(Pattern.matches(".*\\d+-\\d+-\\d+T\\d+:\\d+:\\d+.*", timestampFormat));
+        assertEquals(raw.getJodaDateTime(), parsedObj.getJodaDateTime());
+        assertEquals(raw.getJdk8DateTime(), parsedObj.getJdk8DateTime());
+    }
+}


### PR DESCRIPTION
支持序列化 LocalDateTime 为时间戳格式

Fixes #4002 

### usage
```java
  @Getter
  @Setter
  @Accessors(chain = true)
  public static class DateTimeGroup {
      private LocalDateTime jdk8DateTime;
      private org.joda.time.LocalDateTime jodaDateTime;
  }

  public static void main(String[] args) {
      DateTimeGroup raw = new DateTimeGroup()
              .setJdk8DateTime(LocalDateTime.now())
              .setJodaDateTime(org.joda.time.LocalDateTime.now());

      String dateFormat = JSON.toJSONString(raw);
      String timestampFormat = JSON.toJSONString(raw, SerializerFeature.WriteDateUseTimestamp);
      System.out.println(dateFormat); // {"jdk8DateTime":"2022-01-09T15:32:04.790","jodaDateTime":"2022-01-09T15:32:04.796000000"}
      System.out.println(timestampFormat); // {"jdk8DateTime":1641713524790,"jodaDateTime":1641713524796}
  }
```