### PR TITLE
fastjson LocalTime序列化格式不定，LocalTime全局配置支持

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -720,15 +720,20 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
      */
     public static String toJSONStringWithDateFormat(Object object, String dateFormat,
                                                           SerializerFeature... features) {
-        return toJSONString(object, SerializeConfig.globalInstance, null, dateFormat, DEFAULT_GENERATE_FEATURE, features);
+        return toJSONString(object, SerializeConfig.globalInstance, null, dateFormat,null, DEFAULT_GENERATE_FEATURE, features);
+    }
+
+    public static String toJSONStringWithLocalTimeFormat(Object object,String LocalTimeFormat,
+        SerializerFeature... features) {
+        return toJSONString(object, SerializeConfig.globalInstance, null, null,LocalTimeFormat, DEFAULT_GENERATE_FEATURE, features);
     }
 
     public static String toJSONString(Object object, SerializeFilter filter, SerializerFeature... features) {
-        return toJSONString(object, SerializeConfig.globalInstance, new SerializeFilter[] {filter}, null, DEFAULT_GENERATE_FEATURE, features);
+        return toJSONString(object, SerializeConfig.globalInstance, new SerializeFilter[] {filter}, null,null, DEFAULT_GENERATE_FEATURE, features);
     }
 
     public static String toJSONString(Object object, SerializeFilter[] filters, SerializerFeature... features) {
-        return toJSONString(object, SerializeConfig.globalInstance, filters, null, DEFAULT_GENERATE_FEATURE, features);
+        return toJSONString(object, SerializeConfig.globalInstance, filters, null,null, DEFAULT_GENERATE_FEATURE, features);
     }
 
     public static byte[] toJSONBytes(Object object, SerializerFeature... features) {
@@ -754,14 +759,14 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
                                       SerializeConfig config, //
                                       SerializeFilter filter, //
                                       SerializerFeature... features) {
-        return toJSONString(object, config, new SerializeFilter[] {filter}, null, DEFAULT_GENERATE_FEATURE, features);
+        return toJSONString(object, config, new SerializeFilter[] {filter}, null,null, DEFAULT_GENERATE_FEATURE, features);
     }
 
     public static String toJSONString(Object object, //
                                       SerializeConfig config, //
                                       SerializeFilter[] filters, //
                                       SerializerFeature... features) {
-        return toJSONString(object, config, filters, null, DEFAULT_GENERATE_FEATURE, features);
+        return toJSONString(object, config, filters, null,null, DEFAULT_GENERATE_FEATURE, features);
     }
 
     /**
@@ -772,6 +777,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
                                       SerializeConfig config, // 
                                       SerializeFilter[] filters, // 
                                       String dateFormat, //
+                                      String localTimeFormat,
                                       int defaultFeatures, // 
                                       SerializerFeature... features) {
         SerializeWriter out = new SerializeWriter(null, defaultFeatures, features);
@@ -782,6 +788,11 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             if (dateFormat != null && dateFormat.length() != 0) {
                 serializer.setDateFormat(dateFormat);
                 serializer.config(SerializerFeature.WriteDateUseDateFormat, true);
+            }
+
+            if (localTimeFormat != null && localTimeFormat.length() != 0) {
+                serializer.setLocalTimeFormatPattern(localTimeFormat);
+                serializer.config(SerializerFeature.WriteLocalTimeUseLocalTimeFormat, true);
             }
 
             if (filters != null) {
@@ -802,7 +813,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
      * @deprecated
      */
     public static String toJSONStringZ(Object object, SerializeConfig mapping, SerializerFeature... features) {
-        return toJSONString(object, mapping, emptyFilters, null, 0, features);
+        return toJSONString(object, mapping, emptyFilters, null,null, 0, features);
     }
 
     /**
@@ -834,14 +845,14 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
      * @since 1.2.42
      */
     public static byte[] toJSONBytes(Object object, SerializeConfig config, SerializeFilter[] filters, int defaultFeatures, SerializerFeature... features) {
-        return toJSONBytes(object, config, filters, null, defaultFeatures, features);
+        return toJSONBytes(object, config, filters, null,null, defaultFeatures, features);
     }
 
     /**
      * @since 1.2.55
      */
-    public static byte[] toJSONBytes(Object object, SerializeConfig config, SerializeFilter[] filters, String dateFormat, int defaultFeatures, SerializerFeature... features) {
-        return toJSONBytes(IOUtils.UTF8, object, config, filters, dateFormat, defaultFeatures, features);
+    public static byte[] toJSONBytes(Object object, SerializeConfig config, SerializeFilter[] filters, String dateFormat,String localTimeFormat, int defaultFeatures, SerializerFeature... features) {
+        return toJSONBytes(IOUtils.UTF8, object, config, filters, dateFormat,localTimeFormat, defaultFeatures, features);
     }
 
     /**
@@ -852,6 +863,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
                                      SerializeConfig config, //
                                      SerializeFilter[] filters, //
                                      String dateFormat, //
+                                     String localTimeFormat, //
                                      int defaultFeatures, //
                                      SerializerFeature... features) {
         SerializeWriter out = new SerializeWriter(null, defaultFeatures, features);
@@ -862,6 +874,11 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             if (dateFormat != null && dateFormat.length() != 0) {
                 serializer.setDateFormat(dateFormat);
                 serializer.config(SerializerFeature.WriteDateUseDateFormat, true);
+            }
+
+            if (localTimeFormat != null && localTimeFormat.length() != 0) {
+                serializer.setLocalTimeFormatPattern(localTimeFormat);
+                serializer.config(SerializerFeature.WriteLocalTimeUseLocalTimeFormat, true);
             }
 
             if (filters != null) {
@@ -888,6 +905,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
                                      SerializeConfig config, //
                                      SerializeFilter[] filters, //
                                      String dateFormat, //
+                                     String locaTimeFormat, //
                                      int defaultFeatures, //
                                      SerializerFeature... features) {
         SerializeWriter out = new SerializeWriter(null, defaultFeatures, features);
@@ -898,6 +916,11 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             if (dateFormat != null && dateFormat.length() != 0) {
                 serializer.setFastJsonConfigDateFormatPattern(dateFormat);
                 serializer.config(SerializerFeature.WriteDateUseDateFormat, true);
+            }
+
+            if (locaTimeFormat != null && locaTimeFormat.length() != 0) {
+                serializer.setFastJsonConfigLocalTimeFormatPattern(locaTimeFormat);
+                serializer.config(SerializerFeature.WriteLocalTimeUseLocalTimeFormat, true);
             }
 
             if (filters != null) {
@@ -980,7 +1003,8 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
                               object, //
                               SerializeConfig.globalInstance, //
                               null, //
-                              null, // 
+                              null, //
+                              null, //
                               defaultFeatures, //
                               features);
     }
@@ -995,6 +1019,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
                                SerializeConfig.globalInstance, //
                                null, //
                                null, //
+                               null, //
                                DEFAULT_GENERATE_FEATURE, //
                                features);
     }
@@ -1005,6 +1030,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
                                              SerializeConfig config, //
                                              SerializeFilter[] filters, //
                                              String dateFormat, //
+                                             String localTimeFormat, //
                                              int defaultFeatures, //
                                              SerializerFeature... features) throws IOException {
         SerializeWriter writer = new SerializeWriter(null, defaultFeatures, features);
@@ -1015,6 +1041,11 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             if (dateFormat != null && dateFormat.length() != 0) {
                 serializer.setDateFormat(dateFormat);
                 serializer.config(SerializerFeature.WriteDateUseDateFormat, true);
+            }
+
+            if (localTimeFormat != null && localTimeFormat.length() != 0) {
+                serializer.setLocalTimeFormatPattern(localTimeFormat);
+                serializer.config(SerializerFeature.WriteLocalTimeUseLocalTimeFormat, true);
             }
 
             if (filters != null) {
@@ -1038,6 +1069,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
                                             SerializeConfig config, //
                                             SerializeFilter[] filters, //
                                             String dateFormat, //
+                                            String locaTimeFormat, //
                                             int defaultFeatures, //
                                             SerializerFeature... features) throws IOException {
         SerializeWriter writer = new SerializeWriter(null, defaultFeatures, features);
@@ -1048,6 +1080,11 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             if (dateFormat != null && dateFormat.length() != 0) {
                 serializer.setFastJsonConfigDateFormatPattern(dateFormat);
                 serializer.config(SerializerFeature.WriteDateUseDateFormat, true);
+            }
+
+            if (locaTimeFormat != null && locaTimeFormat.length() != 0) {
+                serializer.setFastJsonConfigLocalTimeFormatPattern(locaTimeFormat);
+                serializer.config(SerializerFeature.WriteLocalTimeUseLocalTimeFormat, true);
             }
 
             if (filters != null) {

--- a/src/main/java/com/alibaba/fastjson/serializer/JSONSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JSONSerializer.java
@@ -48,7 +48,11 @@ public class JSONSerializer extends SerializeFilterable {
     private String                                   dateFormatPattern;
     private DateFormat                               dateFormat;
 
+    private String                                   localTimeFormatPattern;
+
     private String                                   fastJsonConfigDateFormatPattern;
+
+    private String                                   fastJsonConfigLocalTimeFormatPattern;
 
     protected IdentityHashMap<Object, SerialContext> references  = null;
     protected SerialContext                          context;
@@ -78,6 +82,10 @@ public class JSONSerializer extends SerializeFilterable {
             return ((SimpleDateFormat) dateFormat).toPattern();
         }
         return dateFormatPattern;
+    }
+
+    public String getLocalTimeFormatPattern() {
+        return localTimeFormatPattern;
     }
 
     public DateFormat getDateFormat() {
@@ -111,6 +119,10 @@ public class JSONSerializer extends SerializeFilterable {
         }
     }
 
+    public void setLocalTimeFormatPattern(String localTimeFormatPattern) {
+        this.localTimeFormatPattern = localTimeFormatPattern;
+    }
+
     /**
      * Set global date format pattern in FastJsonConfig
      *
@@ -120,8 +132,21 @@ public class JSONSerializer extends SerializeFilterable {
         this.fastJsonConfigDateFormatPattern = dateFormatPattern;
     }
 
+    /**
+     * Set global LocalTime format pattern in FastJsonConfig
+     *
+     * @param fastJsonConfigLocalTimeFormatPattern global LocalTime format pattern
+     */
+    public void setFastJsonConfigLocalTimeFormatPattern(String fastJsonConfigLocalTimeFormatPattern) {
+        this.fastJsonConfigLocalTimeFormatPattern = fastJsonConfigLocalTimeFormatPattern;
+    }
+
     public String getFastJsonConfigDateFormatPattern() {
         return this.fastJsonConfigDateFormatPattern;
+    }
+
+    public String getFastJsonConfigLocalTimeFormatPattern() {
+        return this.fastJsonConfigLocalTimeFormatPattern;
     }
 
     public SerialContext getContext() {

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializerFeature.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializerFeature.java
@@ -152,7 +152,11 @@ public enum SerializerFeature {
     /**
      * @since 1.2.27
      */
-    MapSortField;
+    MapSortField,
+
+    WriteLocalTimeUseLocalTimeFormat,
+
+    UseDefaultLocalTimeFormat;
 
     SerializerFeature(){
         mask = (1 << ordinal());

--- a/src/main/java/com/alibaba/fastjson/support/config/FastJsonConfig.java
+++ b/src/main/java/com/alibaba/fastjson/support/config/FastJsonConfig.java
@@ -74,6 +74,11 @@ public class FastJsonConfig {
     private String dateFormat;
 
     /**
+     * format localTime type
+     */
+    private String localTimeFormat;
+
+    /**
      * The Write content length.
      */
     private boolean writeContentLength;
@@ -203,6 +208,20 @@ public class FastJsonConfig {
      */
     public void setDateFormat(String dateFormat) {
         this.dateFormat = dateFormat;
+    }
+
+    /**
+     * @return the localTimeFormat
+     */
+    public String getLocalTimeFormat() {
+        return localTimeFormat;
+    }
+
+    /**
+     * @param localTimeFormat the localTimeFormat to set
+     */
+    public void setLocalTimeFormat(String localTimeFormat) {
+        this.localTimeFormat = localTimeFormat;
     }
 
     /**

--- a/src/main/java/com/alibaba/fastjson/support/jaxrs/FastJsonProvider.java
+++ b/src/main/java/com/alibaba/fastjson/support/jaxrs/FastJsonProvider.java
@@ -367,6 +367,7 @@ public class FastJsonProvider //
                     fastJsonConfig.getSerializeConfig(), //
                     fastJsonConfig.getSerializeFilters(), //
                     fastJsonConfig.getDateFormat(), //
+                    fastJsonConfig.getLocalTimeFormat(), //
                     JSON.DEFAULT_GENERATE_FEATURE, //
                     fastJsonConfig.getSerializerFeatures());
 

--- a/src/main/java/com/alibaba/fastjson/support/retrofit/Retrofit2ConverterFactory.java
+++ b/src/main/java/com/alibaba/fastjson/support/retrofit/Retrofit2ConverterFactory.java
@@ -245,6 +245,7 @@ public class Retrofit2ConverterFactory extends Converter.Factory {
                         , fastJsonConfig.getSerializeConfig()
                         , fastJsonConfig.getSerializeFilters()
                         , fastJsonConfig.getDateFormat()
+                        , fastJsonConfig.getLocalTimeFormat()
                         , JSON.DEFAULT_GENERATE_FEATURE
                         , fastJsonConfig.getSerializerFeatures()
                 );

--- a/src/main/java/com/alibaba/fastjson/support/spring/FastJsonHttpMessageConverter.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/FastJsonHttpMessageConverter.java
@@ -318,6 +318,7 @@ public class FastJsonHttpMessageConverter extends AbstractHttpMessageConverter<O
                     //fastJsonConfig.getSerializeFilters(), //
                     allFilters.toArray(new SerializeFilter[allFilters.size()]),
                     fastJsonConfig.getDateFormat(), //
+                    fastJsonConfig.getLocalTimeFormat(), //
                     JSON.DEFAULT_GENERATE_FEATURE, //
                     fastJsonConfig.getSerializerFeatures());
 

--- a/src/main/java/com/alibaba/fastjson/support/spring/FastJsonJsonView.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/FastJsonJsonView.java
@@ -303,6 +303,7 @@ public class FastJsonJsonView extends AbstractView {
                 fastJsonConfig.getSerializeConfig(), //
                 fastJsonConfig.getSerializeFilters(), //
                 fastJsonConfig.getDateFormat(), //
+                fastJsonConfig.getLocalTimeFormat(), //
                 JSON.DEFAULT_GENERATE_FEATURE, //
                 fastJsonConfig.getSerializerFeatures());
 

--- a/src/main/java/com/alibaba/fastjson/support/spring/FastJsonRedisSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/FastJsonRedisSerializer.java
@@ -40,6 +40,7 @@ public class FastJsonRedisSerializer<T> implements RedisSerializer<T> {
                     fastJsonConfig.getSerializeConfig(),
                     fastJsonConfig.getSerializeFilters(),
                     fastJsonConfig.getDateFormat(),
+                    fastJsonConfig.getLocalTimeFormat(),
                     JSON.DEFAULT_GENERATE_FEATURE,
                     fastJsonConfig.getSerializerFeatures()
             );

--- a/src/main/java/com/alibaba/fastjson/support/spring/messaging/MappingFastJsonMessageConverter.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/messaging/MappingFastJsonMessageConverter.java
@@ -85,14 +85,14 @@ public class MappingFastJsonMessageConverter extends AbstractMessageConverter {
                 obj = ((String) payload).getBytes(fastJsonConfig.getCharset());
             } else {
                 obj = JSON.toJSONBytesWithFastJsonConfig(fastJsonConfig.getCharset(), payload, fastJsonConfig.getSerializeConfig(), fastJsonConfig.getSerializeFilters(),
-                        fastJsonConfig.getDateFormat(), JSON.DEFAULT_GENERATE_FEATURE, fastJsonConfig.getSerializerFeatures());
+                        fastJsonConfig.getDateFormat(),fastJsonConfig.getLocalTimeFormat(),JSON.DEFAULT_GENERATE_FEATURE, fastJsonConfig.getSerializerFeatures());
             }
         } else {
             if (payload instanceof String && JSON.isValid((String) payload)) {
                 obj = payload;
             } else {
                 obj = JSON.toJSONString(payload, fastJsonConfig.getSerializeConfig(), fastJsonConfig.getSerializeFilters(),
-                        fastJsonConfig.getDateFormat(), JSON.DEFAULT_GENERATE_FEATURE, fastJsonConfig.getSerializerFeatures());
+                        fastJsonConfig.getDateFormat(),fastJsonConfig.getLocalTimeFormat(), JSON.DEFAULT_GENERATE_FEATURE, fastJsonConfig.getSerializerFeatures());
             }
         }
 

--- a/src/test/java/com/alibaba/json/bvt/UnQuoteFieldNamesTest.java
+++ b/src/test/java/com/alibaba/json/bvt/UnQuoteFieldNamesTest.java
@@ -21,6 +21,7 @@ public class UnQuoteFieldNamesTest extends TestCase {
                 , SerializeConfig.globalInstance
                 , new SerializeFilter[0]
                 , null
+                ,null
                 , JSON.DEFAULT_GENERATE_FEATURE & ~SerializerFeature.QuoteFieldNames.mask
         );
         assertEquals("{value:123}", json);

--- a/src/test/java/com/alibaba/json/bvt/issue_1800/Issue1858.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1800/Issue1858.java
@@ -1,0 +1,57 @@
+package com.alibaba.json.bvt.issue_1800;
+
+import java.time.LocalTime;
+import java.util.Date;
+
+import com.alibaba.fastjson.JSON;
+
+import com.alibaba.fastjson.TypeReference;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import com.alibaba.fastjson.support.config.FastJsonConfig;
+import com.alibaba.json.bvt.issue_3300.Issue3361;
+import junit.framework.TestCase;
+import springfox.documentation.spring.web.json.Json;
+
+/**
+ * @author toretto.huang
+ * @date 2022/1/19
+ */
+public class Issue1858 extends TestCase {
+
+    public void test_for_issue() {
+        LocalTime localDate =LocalTime.of(20,30,0);
+        String json = JSON.toJSONStringWithLocalTimeFormat(localDate, "HH:mm:ss");
+        assertEquals("\"20:30:00\"", json);
+        String json2 = JSON.toJSONStringWithLocalTimeFormat(localDate, "HH:mm");
+        assertEquals("\"20:30\"", json2);
+        LocalTime localDate2 =LocalTime.of(20,30,1);
+        String json3 = JSON.toJSONStringWithLocalTimeFormat(localDate2, "HH:mm:ss");
+        assertEquals("\"20:30:01\"", json3);
+        String json4 = JSON.toJSONStringWithLocalTimeFormat(localDate2, "HH:mm");
+        assertEquals("\"20:30\"", json4);
+        System.out.println(JSON.toJSONString(localDate, SerializerFeature.UseDefaultLocalTimeFormat));
+    }
+
+    public void test_for_issue2() throws Exception {
+        VO vo=new VO();
+        vo.localTime=LocalTime.of(20,30,00);
+        FastJsonConfig config = new FastJsonConfig();
+        config.setSerializerFeatures(SerializerFeature.WriteMapNullValue);
+        config.setWriteContentLength(false);
+        JSON.DEFFAULT_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS";
+        config.setDateFormat(JSON.DEFFAULT_DATE_FORMAT);
+        config.setLocalTimeFormat("HH:mm:ss");
+        String string = JSON.toJSONString(vo,
+            config.getSerializeConfig(),
+            config.getSerializeFilters(),
+            config.getDateFormat(),
+            config.getLocalTimeFormat(),
+            JSON.DEFAULT_GENERATE_FEATURE,
+            config.getSerializerFeatures());
+        assertEquals("{\"localTime\":\"20:30:00\"}", string);
+    }
+
+    public static class VO{
+        public LocalTime localTime;
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3361.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3361.java
@@ -35,6 +35,7 @@ public class Issue3361 extends TestCase {
                 config.getSerializeConfig(),
                 config.getSerializeFilters(),
                 config.getDateFormat(),
+                config.getLocalTimeFormat(),
                 JSON.DEFAULT_GENERATE_FEATURE,
                 config.getSerializerFeatures());
         log.info("{}", string);

--- a/src/test/java/com/alibaba/json/bvt/serializer/enum_/EnumFieldsTest8.java
+++ b/src/test/java/com/alibaba/json/bvt/serializer/enum_/EnumFieldsTest8.java
@@ -29,6 +29,7 @@ public class EnumFieldsTest8 extends TestCase {
         String text = JSON.toJSONString(model, SerializeConfig.getGlobalInstance(), // 
                                         filters, 
                                         null,
+                                        null,
                                         0, // 
                                         SerializerFeature.QuoteFieldNames, // 
                                         SerializerFeature.BrowserCompatible, // 


### PR DESCRIPTION
1、修复LocalTime序列化，格式飘忽不定问题，比如LocalTime（20:30:01)可以正常序列化为20:30:01,但比如LocalTime（20:30:00)却序列化为20:30，没有秒单位。由于原来使用的是LocalTime的toString()方法导致；Fixed [#1858](https://github.com/alibaba/fastjson/issues/1858)
2、支持全局配置LocalTime序列化格式；