### PR TITLE
1、Fixed fastjson handle LocalTime and Add global config for LocalTime

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -38,7 +38,7 @@ import com.alibaba.fastjson.util.TypeUtils;
 
 /**
  * This is the main class for using Fastjson. You usually call these two methods {@link #toJSONString(Object)} and {@link #parseObject(String, Class)}.
- * 
+ *
  * <p>Here is an example of how fastjson is used for a simple Class:
  *
  * <pre>
@@ -46,20 +46,20 @@ import com.alibaba.fastjson.util.TypeUtils;
  * String json = JSON.toJSONString(model); // serializes model to Json
  * Model model2 = JSON.parseObject(json, Model.class); // deserializes json into model2
  * </pre>
- * 
-* <p>If the object that your are serializing/deserializing is a {@code ParameterizedType}
+ *
+ * <p>If the object that your are serializing/deserializing is a {@code ParameterizedType}
  * (i.e. contains at least one type parameter and may be an array) then you must use the
  * {@link #toJSONString(Object)} or {@link #parseObject(String, Type, Feature[])} method.  Here is an
  * example for serializing and deserialing a {@code ParameterizedType}:
- * 
+ *
  * <pre>
  * String json = "[{},...]";
  * Type listType = new TypeReference&lt;List&lt;Model&gt;&gt;() {}.getType();
  * List&lt;Model&gt; modelList = JSON.parseObject(json, listType);
  * </pre>
- * 
+ *
  * @see com.alibaba.fastjson.TypeReference
- * 
+ *
  * @author wenshao[szujobs@hotmail.com]
  */
 public abstract class JSON implements JSONStreamAware, JSONAware {
@@ -72,7 +72,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     public static int              DEFAULT_GENERATE_FEATURE;
 
     private static final ConcurrentHashMap<Type, Type> mixInsMapper = new ConcurrentHashMap<Type, Type>(16);
-    
+
     static {
         int features = 0;
         features |= Feature.AutoCloseSource.getMask();
@@ -117,7 +117,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
 
         {
             if ("true".equals(properties.getProperty("parser.features.ErrorOnEnumNotMatch"))
-                    || "true".equals(properties.getProperty("fastjson.parser.features.ErrorOnEnumNotMatch")))
+                || "true".equals(properties.getProperty("fastjson.parser.features.ErrorOnEnumNotMatch")))
             {
                 DEFAULT_PARSER_FEATURE |= Feature.ErrorOnEnumNotMatch.getMask();
             }
@@ -137,12 +137,12 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
      */
     public static void setDefaultTypeKey(String typeKey) {
         DEFAULT_TYPE_KEY = typeKey;
-        ParserConfig.global.symbolTable.addSymbol(typeKey, 
-                                                  0, 
-                                                  typeKey.length(), 
-                                                  typeKey.hashCode(), true);
+        ParserConfig.global.symbolTable.addSymbol(typeKey,
+            0,
+            typeKey.length(),
+            typeKey.hashCode(), true);
     }
-    
+
     public static Object parse(String text) {
         return parse(text, DEFAULT_PARSER_FEATURE);
     }
@@ -277,7 +277,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     }
 
     /**
-     * 
+     *
      * This method deserializes the specified Json into an object of the specified class. It is not
      * suitable to use if the specified class is a generic type since it will not have the generic
      * type information because of the Type Erasure feature of Java. Therefore, this method should not
@@ -301,7 +301,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     @SuppressWarnings("unchecked")
     public static <T> T parseObject(String text, Class<T> clazz, ParseProcess processor, Feature... features) {
         return (T) parseObject(text, (Type) clazz, ParserConfig.global, processor, DEFAULT_PARSER_FEATURE,
-                               features);
+            features);
     }
 
     /**
@@ -349,7 +349,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
 
         return (T) value;
     }
-    
+
     /**
      * @since 1.2.11
      */
@@ -358,13 +358,13 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     }
 
     public static <T> T parseObject(String input, Type clazz, ParserConfig config, int featureValues,
-                                          Feature... features) {
+        Feature... features) {
         return parseObject(input, clazz, config, null, featureValues, features);
     }
 
     @SuppressWarnings("unchecked")
     public static <T> T parseObject(String input, Type clazz, ParserConfig config, ParseProcess processor,
-                                          int featureValues, Feature... features) {
+        int featureValues, Feature... features) {
         if (input == null || input.length() == 0) {
             return null;
         }
@@ -404,7 +404,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     public static <T> T parseObject(byte[] bytes, Type clazz, Feature... features) {
         return (T) parseObject(bytes, 0, bytes.length, IOUtils.UTF8, clazz, features);
     }
-    
+
     /**
      * @since 1.2.11
      */
@@ -418,12 +418,12 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
      */
     @SuppressWarnings("unchecked")
     public static <T> T parseObject(byte[] bytes,
-                                    Charset charset,
-                                    Type clazz,
-                                    ParserConfig config,
-                                    ParseProcess processor,
-                                    int featureValues,
-                                    Feature... features) {
+        Charset charset,
+        Type clazz,
+        ParserConfig config,
+        ParseProcess processor,
+        int featureValues,
+        Feature... features) {
         return (T) parseObject(bytes, 0, bytes.length, charset, clazz, config, processor, featureValues, features);
     }
 
@@ -432,12 +432,12 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
      */
     @SuppressWarnings("unchecked")
     public static <T> T parseObject(byte[] bytes, int offset, int len,
-                                    Charset charset,
-                                    Type clazz,
-                                    ParserConfig config,
-                                    ParseProcess processor,
-                                    int featureValues,
-                                    Feature... features) {
+        Charset charset,
+        Type clazz,
+        ParserConfig config,
+        ParseProcess processor,
+        int featureValues,
+        Feature... features) {
         if (charset == null) {
             charset = IOUtils.UTF8;
         }
@@ -451,8 +451,8 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
                 InputStreamReader gzipReader = null;
                 try {
                     gzipReader = new InputStreamReader(
-                            new GZIPInputStream(
-                                    new ByteArrayInputStream(bytes, offset, len)), "UTF-8");
+                        new GZIPInputStream(
+                            new ByteArrayInputStream(bytes, offset, len)), "UTF-8");
                     strVal = IOUtils.readAll(gzipReader);
                 } catch (Exception ex) {
                     return null;
@@ -478,11 +478,11 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
 
     @SuppressWarnings("unchecked")
     public static <T> T parseObject(byte[] input, //
-                                    int off, //
-                                    int len, //
-                                    CharsetDecoder charsetDecoder, //
-                                    Type clazz, //
-                                    Feature... features) {
+        int off, //
+        int len, //
+        CharsetDecoder charsetDecoder, //
+        Type clazz, //
+        Feature... features) {
         charsetDecoder.reset();
 
         int scaleLength = (int) (len * (double) charsetDecoder.maxCharsPerByte());
@@ -523,8 +523,8 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
      */
     @SuppressWarnings("unchecked")
     public static <T> T parseObject(InputStream is, //
-                                    Type type, //
-                                    Feature... features) throws IOException {
+        Type type, //
+        Feature... features) throws IOException {
         return (T) parseObject(is, IOUtils.UTF8, type, features);
     }
 
@@ -533,9 +533,9 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
      */
     @SuppressWarnings("unchecked")
     public static <T> T parseObject(InputStream is, //
-                                    Charset charset, //
-                                    Type type, //
-                                    Feature... features) throws IOException {
+        Charset charset, //
+        Type type, //
+        Feature... features) throws IOException {
         return (T) parseObject(is, charset, type, ParserConfig.global, features);
     }
 
@@ -544,10 +544,10 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
      */
     @SuppressWarnings("unchecked")
     public static <T> T parseObject(InputStream is, //
-                                    Charset charset, //
-                                    Type type, //
-                                    ParserConfig config, //
-                                    Feature... features) throws IOException {
+        Charset charset, //
+        Type type, //
+        ParserConfig config, //
+        Feature... features) throws IOException {
         return (T) parseObject(is, charset, type, config, null, DEFAULT_PARSER_FEATURE, features);
     }
 
@@ -556,12 +556,12 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
      */
     @SuppressWarnings("unchecked")
     public static <T> T parseObject(InputStream is, //
-                                    Charset charset, //
-                                    Type type, //
-                                    ParserConfig config, //
-                                    ParseProcess processor, //
-                                    int featureValues, //
-                                    Feature... features) throws IOException {
+        Charset charset, //
+        Type type, //
+        ParserConfig config, //
+        ParseProcess processor, //
+        int featureValues, //
+        Feature... features) throws IOException {
         if (charset == null) {
             charset = IOUtils.UTF8;
         }
@@ -704,9 +704,9 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             String outString = out.toString();
             int len = outString.length();
             if (len > 0
-                    && outString.charAt(len -1) == '.'
-                    && object instanceof Number
-                    && !out.isEnabled(SerializerFeature.WriteClassName)) {
+                && outString.charAt(len -1) == '.'
+                && object instanceof Number
+                && !out.isEnabled(SerializerFeature.WriteClassName)) {
                 return outString.substring(0, len - 1);
             }
             return outString;
@@ -719,16 +719,21 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
      * @since 1.1.14
      */
     public static String toJSONStringWithDateFormat(Object object, String dateFormat,
-                                                          SerializerFeature... features) {
-        return toJSONString(object, SerializeConfig.globalInstance, null, dateFormat, DEFAULT_GENERATE_FEATURE, features);
+        SerializerFeature... features) {
+        return toJSONString(object, SerializeConfig.globalInstance, null, dateFormat,null, DEFAULT_GENERATE_FEATURE, features);
+    }
+
+    public static String toJSONStringWithLocalTimeFormat(Object object,String LocalTimeFormat,
+        SerializerFeature... features) {
+        return toJSONString(object, SerializeConfig.globalInstance, null, null,LocalTimeFormat, DEFAULT_GENERATE_FEATURE, features);
     }
 
     public static String toJSONString(Object object, SerializeFilter filter, SerializerFeature... features) {
-        return toJSONString(object, SerializeConfig.globalInstance, new SerializeFilter[] {filter}, null, DEFAULT_GENERATE_FEATURE, features);
+        return toJSONString(object, SerializeConfig.globalInstance, new SerializeFilter[] {filter}, null,null, DEFAULT_GENERATE_FEATURE, features);
     }
 
     public static String toJSONString(Object object, SerializeFilter[] filters, SerializerFeature... features) {
-        return toJSONString(object, SerializeConfig.globalInstance, filters, null, DEFAULT_GENERATE_FEATURE, features);
+        return toJSONString(object, SerializeConfig.globalInstance, filters, null,null, DEFAULT_GENERATE_FEATURE, features);
     }
 
     public static byte[] toJSONBytes(Object object, SerializerFeature... features) {
@@ -738,9 +743,9 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     public static byte[] toJSONBytes(Object object, SerializeFilter filter, SerializerFeature... features) {
         return toJSONBytes(object, SerializeConfig.globalInstance, new SerializeFilter[] {filter}, DEFAULT_GENERATE_FEATURE, features);
     }
-    
+
     /**
-     * @since 1.2.11 
+     * @since 1.2.11
      */
     public static byte[] toJSONBytes(Object object, int defaultFeatures, SerializerFeature... features) {
         return toJSONBytes(object, SerializeConfig.globalInstance, defaultFeatures, features);
@@ -751,37 +756,43 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     }
 
     public static String toJSONString(Object object, //
-                                      SerializeConfig config, //
-                                      SerializeFilter filter, //
-                                      SerializerFeature... features) {
-        return toJSONString(object, config, new SerializeFilter[] {filter}, null, DEFAULT_GENERATE_FEATURE, features);
+        SerializeConfig config, //
+        SerializeFilter filter, //
+        SerializerFeature... features) {
+        return toJSONString(object, config, new SerializeFilter[] {filter}, null,null, DEFAULT_GENERATE_FEATURE, features);
     }
 
     public static String toJSONString(Object object, //
-                                      SerializeConfig config, //
-                                      SerializeFilter[] filters, //
-                                      SerializerFeature... features) {
-        return toJSONString(object, config, filters, null, DEFAULT_GENERATE_FEATURE, features);
+        SerializeConfig config, //
+        SerializeFilter[] filters, //
+        SerializerFeature... features) {
+        return toJSONString(object, config, filters, null,null, DEFAULT_GENERATE_FEATURE, features);
     }
 
     /**
      * @since 1.2.9
      * @return
      */
-    public static String toJSONString(Object object, // 
-                                      SerializeConfig config, // 
-                                      SerializeFilter[] filters, // 
-                                      String dateFormat, //
-                                      int defaultFeatures, // 
-                                      SerializerFeature... features) {
+    public static String toJSONString(Object object, //
+        SerializeConfig config, //
+        SerializeFilter[] filters, //
+        String dateFormat, //
+        String localTimeFormat,
+        int defaultFeatures, //
+        SerializerFeature... features) {
         SerializeWriter out = new SerializeWriter(null, defaultFeatures, features);
 
         try {
             JSONSerializer serializer = new JSONSerializer(out, config);
-            
+
             if (dateFormat != null && dateFormat.length() != 0) {
                 serializer.setDateFormat(dateFormat);
                 serializer.config(SerializerFeature.WriteDateUseDateFormat, true);
+            }
+
+            if (localTimeFormat != null && localTimeFormat.length() != 0) {
+                serializer.setLocalTimeFormatPattern(localTimeFormat);
+                serializer.config(SerializerFeature.WriteLocalTimeUseLocalTimeFormat, true);
             }
 
             if (filters != null) {
@@ -802,7 +813,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
      * @deprecated
      */
     public static String toJSONStringZ(Object object, SerializeConfig mapping, SerializerFeature... features) {
-        return toJSONString(object, mapping, emptyFilters, null, 0, features);
+        return toJSONString(object, mapping, emptyFilters, null,null, 0, features);
     }
 
     /**
@@ -829,31 +840,32 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     public static byte[] toJSONBytes(Object object, SerializeConfig config, SerializeFilter filter, SerializerFeature... features) {
         return toJSONBytes(object, config, new SerializeFilter[] {filter}, DEFAULT_GENERATE_FEATURE, features);
     }
-    
+
     /**
      * @since 1.2.42
      */
     public static byte[] toJSONBytes(Object object, SerializeConfig config, SerializeFilter[] filters, int defaultFeatures, SerializerFeature... features) {
-        return toJSONBytes(object, config, filters, null, defaultFeatures, features);
+        return toJSONBytes(object, config, filters, null,null, defaultFeatures, features);
     }
 
     /**
      * @since 1.2.55
      */
-    public static byte[] toJSONBytes(Object object, SerializeConfig config, SerializeFilter[] filters, String dateFormat, int defaultFeatures, SerializerFeature... features) {
-        return toJSONBytes(IOUtils.UTF8, object, config, filters, dateFormat, defaultFeatures, features);
+    public static byte[] toJSONBytes(Object object, SerializeConfig config, SerializeFilter[] filters, String dateFormat,String localTimeFormat, int defaultFeatures, SerializerFeature... features) {
+        return toJSONBytes(IOUtils.UTF8, object, config, filters, dateFormat,localTimeFormat, defaultFeatures, features);
     }
 
     /**
      * @since 1.2.55
      */
     public static byte[] toJSONBytes(Charset charset, //
-                                     Object object, //
-                                     SerializeConfig config, //
-                                     SerializeFilter[] filters, //
-                                     String dateFormat, //
-                                     int defaultFeatures, //
-                                     SerializerFeature... features) {
+        Object object, //
+        SerializeConfig config, //
+        SerializeFilter[] filters, //
+        String dateFormat, //
+        String localTimeFormat, //
+        int defaultFeatures, //
+        SerializerFeature... features) {
         SerializeWriter out = new SerializeWriter(null, defaultFeatures, features);
 
         try {
@@ -862,6 +874,11 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             if (dateFormat != null && dateFormat.length() != 0) {
                 serializer.setDateFormat(dateFormat);
                 serializer.config(SerializerFeature.WriteDateUseDateFormat, true);
+            }
+
+            if (localTimeFormat != null && localTimeFormat.length() != 0) {
+                serializer.setLocalTimeFormatPattern(localTimeFormat);
+                serializer.config(SerializerFeature.WriteLocalTimeUseLocalTimeFormat, true);
             }
 
             if (filters != null) {
@@ -884,12 +901,13 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
      * @since 1.2.55
      */
     public static byte[] toJSONBytesWithFastJsonConfig(Charset charset, //
-                                     Object object, //
-                                     SerializeConfig config, //
-                                     SerializeFilter[] filters, //
-                                     String dateFormat, //
-                                     int defaultFeatures, //
-                                     SerializerFeature... features) {
+        Object object, //
+        SerializeConfig config, //
+        SerializeFilter[] filters, //
+        String dateFormat, //
+        String locaTimeFormat, //
+        int defaultFeatures, //
+        SerializerFeature... features) {
         SerializeWriter out = new SerializeWriter(null, defaultFeatures, features);
 
         try {
@@ -898,6 +916,11 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             if (dateFormat != null && dateFormat.length() != 0) {
                 serializer.setFastJsonConfigDateFormatPattern(dateFormat);
                 serializer.config(SerializerFeature.WriteDateUseDateFormat, true);
+            }
+
+            if (locaTimeFormat != null && locaTimeFormat.length() != 0) {
+                serializer.setFastJsonConfigLocalTimeFormatPattern(locaTimeFormat);
+                serializer.config(SerializerFeature.WriteLocalTimeUseLocalTimeFormat, true);
             }
 
             if (filters != null) {
@@ -939,9 +962,9 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     public static void writeJSONString(Writer writer, Object object, SerializerFeature... features) {
         writeJSONString(writer, object, JSON.DEFAULT_GENERATE_FEATURE, features);
     }
-    
+
     /**
-     * @since 1.2.11 
+     * @since 1.2.11
      */
     public static void writeJSONString(Writer writer, Object object, int defaultFeatures, SerializerFeature... features) {
         SerializeWriter out = new SerializeWriter(writer, defaultFeatures, features);
@@ -962,59 +985,67 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
      * @since 1.2.11
      * @throws IOException
      */
-    public static final int writeJSONString(OutputStream os, // 
-                                             Object object, // 
-                                             SerializerFeature... features) throws IOException {
+    public static final int writeJSONString(OutputStream os, //
+        Object object, //
+        SerializerFeature... features) throws IOException {
         return writeJSONString(os, object, DEFAULT_GENERATE_FEATURE, features);
     }
-    
+
     /**
-     * @since 1.2.11 
+     * @since 1.2.11
      */
-    public static final int writeJSONString(OutputStream os, // 
-                                            Object object, // 
-                                            int defaultFeatures, //
-                                            SerializerFeature... features) throws IOException {
-       return writeJSONString(os,  //
-                              IOUtils.UTF8, //
-                              object, //
-                              SerializeConfig.globalInstance, //
-                              null, //
-                              null, // 
-                              defaultFeatures, //
-                              features);
+    public static final int writeJSONString(OutputStream os, //
+        Object object, //
+        int defaultFeatures, //
+        SerializerFeature... features) throws IOException {
+        return writeJSONString(os,  //
+            IOUtils.UTF8, //
+            object, //
+            SerializeConfig.globalInstance, //
+            null, //
+            null, //
+            null, //
+            defaultFeatures, //
+            features);
     }
-    
-    public static final int writeJSONString(OutputStream os, // 
-                                             Charset charset, // 
-                                             Object object, // 
-                                             SerializerFeature... features) throws IOException {
+
+    public static final int writeJSONString(OutputStream os, //
+        Charset charset, //
+        Object object, //
+        SerializerFeature... features) throws IOException {
         return writeJSONString(os, //
-                               charset, //
-                               object, //
-                               SerializeConfig.globalInstance, //
-                               null, //
-                               null, //
-                               DEFAULT_GENERATE_FEATURE, //
-                               features);
+            charset, //
+            object, //
+            SerializeConfig.globalInstance, //
+            null, //
+            null, //
+            null, //
+            DEFAULT_GENERATE_FEATURE, //
+            features);
     }
-    
-    public static final int writeJSONString(OutputStream os, // 
-                                             Charset charset, // 
-                                             Object object, // 
-                                             SerializeConfig config, //
-                                             SerializeFilter[] filters, //
-                                             String dateFormat, //
-                                             int defaultFeatures, //
-                                             SerializerFeature... features) throws IOException {
+
+    public static final int writeJSONString(OutputStream os, //
+        Charset charset, //
+        Object object, //
+        SerializeConfig config, //
+        SerializeFilter[] filters, //
+        String dateFormat, //
+        String localTimeFormat, //
+        int defaultFeatures, //
+        SerializerFeature... features) throws IOException {
         SerializeWriter writer = new SerializeWriter(null, defaultFeatures, features);
 
         try {
             JSONSerializer serializer = new JSONSerializer(writer, config);
-            
+
             if (dateFormat != null && dateFormat.length() != 0) {
                 serializer.setDateFormat(dateFormat);
                 serializer.config(SerializerFeature.WriteDateUseDateFormat, true);
+            }
+
+            if (localTimeFormat != null && localTimeFormat.length() != 0) {
+                serializer.setLocalTimeFormatPattern(localTimeFormat);
+                serializer.config(SerializerFeature.WriteLocalTimeUseLocalTimeFormat, true);
             }
 
             if (filters != null) {
@@ -1022,9 +1053,9 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
                     serializer.addFilter(filter);
                 }
             }
-            
+
             serializer.write(object);
-            
+
             int len = writer.writeToEx(os, charset);
             return len;
         } finally {
@@ -1033,13 +1064,14 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     }
 
     public static final int writeJSONStringWithFastJsonConfig(OutputStream os, //
-                                            Charset charset, //
-                                            Object object, //
-                                            SerializeConfig config, //
-                                            SerializeFilter[] filters, //
-                                            String dateFormat, //
-                                            int defaultFeatures, //
-                                            SerializerFeature... features) throws IOException {
+        Charset charset, //
+        Object object, //
+        SerializeConfig config, //
+        SerializeFilter[] filters, //
+        String dateFormat, //
+        String locaTimeFormat, //
+        int defaultFeatures, //
+        SerializerFeature... features) throws IOException {
         SerializeWriter writer = new SerializeWriter(null, defaultFeatures, features);
 
         try {
@@ -1048,6 +1080,11 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             if (dateFormat != null && dateFormat.length() != 0) {
                 serializer.setFastJsonConfigDateFormatPattern(dateFormat);
                 serializer.config(SerializerFeature.WriteDateUseDateFormat, true);
+            }
+
+            if (locaTimeFormat != null && locaTimeFormat.length() != 0) {
+                serializer.setFastJsonConfigLocalTimeFormatPattern(locaTimeFormat);
+                serializer.config(SerializerFeature.WriteLocalTimeUseLocalTimeFormat, true);
             }
 
             if (filters != null) {
@@ -1122,7 +1159,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     public static Object toJSON(Object javaObject, ParserConfig parserConfig) {
         return toJSON(javaObject, SerializeConfig.globalInstance);
     }
-    
+
     @SuppressWarnings("unchecked")
     public static Object toJSON(Object javaObject, SerializeConfig config) {
         if (javaObject == null) {
@@ -1210,7 +1247,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             if (jsonType != null) {
                 for (SerializerFeature serializerFeature : jsonType.serialzeFeatures()) {
                     if (serializerFeature == SerializerFeature.SortField
-                            || serializerFeature == SerializerFeature.MapSortField) {
+                        || serializerFeature == SerializerFeature.MapSortField) {
                         ordered = true;
                     }
                 }
@@ -1227,7 +1264,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             }
             return json;
         }
-        
+
         String text = JSON.toJSONString(javaObject, config);
         return JSON.parse(text);
     }
@@ -1235,7 +1272,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     public static <T> T toJavaObject(JSON json, Class<T> clazz) {
         return TypeUtils.cast(json, clazz, ParserConfig.getGlobalInstance());
     }
-    
+
     /**
      * @since 1.2.9
      */
@@ -1261,7 +1298,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         Type type = typeReference != null ? typeReference.getType() : null;
         return TypeUtils.cast(this, type, ParserConfig.getGlobalInstance());
     }
-    
+
     private final static ThreadLocal<byte[]> bytesLocal = new ThreadLocal<byte[]>();
     private static byte[] allocateBytes(int length) {
         byte[] chars = bytesLocal.get();
@@ -1397,7 +1434,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     public static <T> void handleResovleTask(DefaultJSONParser parser, T value) {
         parser.handleResovleTask(value);
     }
-    
+
     public static void addMixInAnnotations(Type target, Type mixinSource) {
         if (target != null && mixinSource != null) {
             mixInsMapper.put(target, mixinSource);

--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/Jdk8DateCodec.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/Jdk8DateCodec.java
@@ -34,6 +34,8 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
 
     private final static String            defaultPatttern     = "yyyy-MM-dd HH:mm:ss";
     private final static DateTimeFormatter defaultFormatter    = DateTimeFormatter.ofPattern(defaultPatttern);
+    private final static String defaultLocalTimePatttern = "HH:mm:ss";
+    private final static DateTimeFormatter defaultLocalTimeFormatter    = DateTimeFormatter.ofPattern(defaultLocalTimePatttern);
     private final static DateTimeFormatter defaultFormatter_23 = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
     private final static DateTimeFormatter formatter_dt19_tw   = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
     private final static DateTimeFormatter formatter_dt19_cn   = DateTimeFormatter.ofPattern("yyyy年M月d日 HH:mm:ss");
@@ -54,7 +56,7 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
     private final static DateTimeFormatter formatter_d10_in    = DateTimeFormatter.ofPattern("dd-MM-yyyy");
 
     private final static DateTimeFormatter ISO_FIXED_FORMAT =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault());
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault());
 
     private final static String formatter_iso8601_pattern     = "yyyy-MM-dd'T'HH:mm:ss";
     private final static String formatter_iso8601_pattern_23     = "yyyy-MM-dd'T'HH:mm:ss.SSS";
@@ -100,7 +102,7 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
                 if (text.length() == 23) {
                     LocalDateTime localDateTime = LocalDateTime.parse(text);
                     localDate = LocalDate.of(localDateTime.getYear(), localDateTime.getMonthValue(),
-                            localDateTime.getDayOfMonth());
+                        localDateTime.getDayOfMonth());
                 } else {
                     localDate = parseLocalDate(text, format, formatter);
                 }
@@ -111,7 +113,7 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
                 if (text.length() == 23) {
                     LocalDateTime localDateTime = LocalDateTime.parse(text);
                     localTime = LocalTime.of(localDateTime.getHour(), localDateTime.getMinute(),
-                            localDateTime.getSecond(), localDateTime.getNano());
+                        localDateTime.getSecond(), localDateTime.getNano());
                 } else {
                     boolean digit = true;
                     for (int i = 0; i < text.length(); ++i) {
@@ -125,10 +127,10 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
                     if (digit && text.length() > 8 && text.length() < 19) {
                         long epochMillis = Long.parseLong(text);
                         localTime = LocalDateTime
-                                .ofInstant(
-                                        Instant.ofEpochMilli(epochMillis),
-                                        JSON.defaultTimeZone.toZoneId())
-                                .toLocalTime();
+                            .ofInstant(
+                                Instant.ofEpochMilli(epochMillis),
+                                JSON.defaultTimeZone.toZoneId())
+                            .toLocalTime();
                     } else {
                         localTime = LocalTime.parse(text);
                     }
@@ -241,13 +243,13 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
                 Object nano = object.get("nano");
                 if (epochSecond instanceof Number && nano instanceof Number) {
                     return (T) Instant.ofEpochSecond(
-                            TypeUtils.longExtractValue((Number) epochSecond)
-                            , TypeUtils.longExtractValue((Number) nano));
+                        TypeUtils.longExtractValue((Number) epochSecond)
+                        , TypeUtils.longExtractValue((Number) nano));
                 }
 
                 if (epochSecond instanceof Number) {
                     return (T) Instant.ofEpochSecond(
-                            TypeUtils.longExtractValue((Number) epochSecond));
+                        TypeUtils.longExtractValue((Number) epochSecond));
                 }
             }
         } else {
@@ -292,7 +294,7 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
                                 if (country.equals("US")) {
                                     formatter = formatter_dt19_us;
                                 } else if (country.equals("BR") //
-                                           || country.equals("AU")) {
+                                    || country.equals("AU")) {
                                     formatter = formatter_dt19_eur;
                                 }
                             }
@@ -312,11 +314,11 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
                 char c19 = text.charAt(19);
 
                 if (c13 == ':'
-                        && c16 == ':'
-                        && c4 == '-'
-                        && c7 == '-'
-                        && c10 == ' '
-                        && c19 == '.'
+                    && c16 == ':'
+                    && c4 == '-'
+                    && c7 == '-'
+                    && c10 == ' '
+                    && c19 == '.'
                 ) {
                     formatter = defaultFormatter_23;
                 }
@@ -326,7 +328,7 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
                 char c4 = text.charAt(4);
                 if (c4 == '年') {
                     if (text.charAt(text.length() - 1) == '秒') {
-                        formatter = formatter_dt19_cn_1;    
+                        formatter = formatter_dt19_cn_1;
                     } else {
                         formatter = formatter_dt19_cn;
                     }
@@ -393,7 +395,7 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
                         if (country.equals("US")) {
                             formatter = formatter_d10_us;
                         } else if (country.equals("BR") //
-                                   || country.equals("AU")) {
+                            || country.equals("AU")) {
                             formatter = formatter_d10_eur;
                         }
                     }
@@ -424,10 +426,10 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
             if (digit && text.length() > 8 && text.length() < 19) {
                 long epochMillis = Long.parseLong(text);
                 return LocalDateTime
-                        .ofInstant(
-                                Instant.ofEpochMilli(epochMillis),
-                                JSON.defaultTimeZone.toZoneId())
-                        .toLocalDate();
+                    .ofInstant(
+                        Instant.ofEpochMilli(epochMillis),
+                        JSON.defaultTimeZone.toZoneId())
+                    .toLocalDate();
             }
         }
 
@@ -472,7 +474,7 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
                                 if (country.equals("US")) {
                                     formatter = formatter_dt19_us;
                                 } else if (country.equals("BR") //
-                                        || country.equals("AU")) {
+                                    || country.equals("AU")) {
                                     formatter = formatter_dt19_eur;
                                 }
                             }
@@ -513,8 +515,8 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
         }
 
         return formatter == null ? //
-                ZonedDateTime.parse(text) //
-                : ZonedDateTime.parse(text, formatter);
+            ZonedDateTime.parse(text) //
+            : ZonedDateTime.parse(text, formatter);
     }
 
     public int getFastMatchToken() {
@@ -522,7 +524,7 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
     }
 
     public void write(JSONSerializer serializer, Object object, Object fieldName, Type fieldType,
-                      int features) throws IOException {
+        int features) throws IOException {
         SerializeWriter out = serializer.out;
         if (object == null) {
             out.writeNull();
@@ -540,11 +542,11 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
                     if ((features & mask) != 0 || serializer.isEnabled(SerializerFeature.UseISO8601DateFormat)) {
                         format = formatter_iso8601_pattern;
                     } else if (serializer.isEnabled(SerializerFeature.WriteDateUseDateFormat)) {
-                        if (serializer.getFastJsonConfigDateFormatPattern() != null && 
-                                serializer.getFastJsonConfigDateFormatPattern().length() > 0){
+                        if (serializer.getFastJsonConfigDateFormatPattern() != null &&
+                            serializer.getFastJsonConfigDateFormatPattern().length() > 0){
                             format = serializer.getFastJsonConfigDateFormatPattern();
                         }else{
-                            format = JSON.DEFFAULT_DATE_FORMAT; 
+                            format = JSON.DEFFAULT_DATE_FORMAT;
                         }
                     } else {
                         int nano = dateTime.getNano();
@@ -563,6 +565,25 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
                 } else {
                     out.writeLong(dateTime.atZone(JSON.defaultTimeZone.toZoneId()).toInstant().toEpochMilli());
                 }
+            } else if (fieldType == LocalTime.class) {
+                LocalTime localTime = (LocalTime)object;
+                String format = serializer.getLocalTimeFormatPattern();
+                if (format == null) {
+                    final int mask = SerializerFeature.WriteLocalTimeUseLocalTimeFormat.getMask();
+                    if ((features & mask) != 0 || serializer.isEnabled(SerializerFeature.UseDefaultLocalTimeFormat)) {
+                        format = defaultLocalTimePatttern;
+                    } else if (serializer.isEnabled(SerializerFeature.WriteLocalTimeUseLocalTimeFormat)) {
+                        if (serializer.getFastJsonConfigLocalTimeFormatPattern() != null &&
+                            serializer.getFastJsonConfigLocalTimeFormatPattern().length() > 0){
+                            format = serializer.getFastJsonConfigLocalTimeFormatPattern();
+                        }else{
+                            format = defaultLocalTimePatttern;
+                        }
+                    }else {
+                        format = defaultLocalTimePatttern;
+                    }
+                }
+                write(out, localTime, format);
             } else {
                 out.writeString(object.toString());
             }
@@ -606,9 +627,11 @@ public class Jdk8DateCodec extends ContextObjectDeserializer implements ObjectSe
             }
         }
 
-        if (format == formatter_iso8601_pattern) {
+        if (formatter_iso8601_pattern.equals(format)) {
             formatter = formatter_iso8601;
-        } else {
+        } else if (defaultLocalTimePatttern.equals(format)){
+            formatter=defaultLocalTimeFormatter;
+        }else {
             formatter = DateTimeFormatter.ofPattern(format);
         }
 

--- a/src/main/java/com/alibaba/fastjson/serializer/JSONSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/JSONSerializer.java
@@ -48,7 +48,11 @@ public class JSONSerializer extends SerializeFilterable {
     private String                                   dateFormatPattern;
     private DateFormat                               dateFormat;
 
+    private String                                   localTimeFormatPattern;
+
     private String                                   fastJsonConfigDateFormatPattern;
+
+    private String                                   fastJsonConfigLocalTimeFormatPattern;
 
     protected IdentityHashMap<Object, SerialContext> references  = null;
     protected SerialContext                          context;
@@ -78,6 +82,10 @@ public class JSONSerializer extends SerializeFilterable {
             return ((SimpleDateFormat) dateFormat).toPattern();
         }
         return dateFormatPattern;
+    }
+
+    public String getLocalTimeFormatPattern() {
+        return localTimeFormatPattern;
     }
 
     public DateFormat getDateFormat() {
@@ -111,6 +119,10 @@ public class JSONSerializer extends SerializeFilterable {
         }
     }
 
+    public void setLocalTimeFormatPattern(String localTimeFormatPattern) {
+        this.localTimeFormatPattern = localTimeFormatPattern;
+    }
+
     /**
      * Set global date format pattern in FastJsonConfig
      *
@@ -120,8 +132,21 @@ public class JSONSerializer extends SerializeFilterable {
         this.fastJsonConfigDateFormatPattern = dateFormatPattern;
     }
 
+    /**
+     * Set global LocalTime format pattern in FastJsonConfig
+     *
+     * @param fastJsonConfigLocalTimeFormatPattern global LocalTime format pattern
+     */
+    public void setFastJsonConfigLocalTimeFormatPattern(String fastJsonConfigLocalTimeFormatPattern) {
+        this.fastJsonConfigLocalTimeFormatPattern = fastJsonConfigLocalTimeFormatPattern;
+    }
+
     public String getFastJsonConfigDateFormatPattern() {
         return this.fastJsonConfigDateFormatPattern;
+    }
+
+    public String getFastJsonConfigLocalTimeFormatPattern() {
+        return this.fastJsonConfigLocalTimeFormatPattern;
     }
 
     public SerialContext getContext() {
@@ -160,9 +185,9 @@ public class JSONSerializer extends SerializeFilterable {
 
     public final boolean isWriteClassName(Type fieldType, Object obj) {
         return out.isEnabled(SerializerFeature.WriteClassName) //
-               && (fieldType != null //
-                   || (!out.isEnabled(SerializerFeature.NotWriteRootClassName)) //
-                   || (context != null && (context.parent != null)));
+            && (fieldType != null //
+            || (!out.isEnabled(SerializerFeature.NotWriteRootClassName)) //
+            || (context != null && (context.parent != null)));
     }
 
     public boolean containsReference(Object value) {
@@ -222,20 +247,20 @@ public class JSONSerializer extends SerializeFilterable {
 
     public boolean checkValue(SerializeFilterable filterable) {
         return (valueFilters != null && valueFilters.size() > 0) //
-               || (contextValueFilters != null && contextValueFilters.size() > 0) //
-               || (filterable.valueFilters != null && filterable.valueFilters.size() > 0)
-               || (filterable.contextValueFilters != null && filterable.contextValueFilters.size() > 0)
-               || out.writeNonStringValueAsString;
+            || (contextValueFilters != null && contextValueFilters.size() > 0) //
+            || (filterable.valueFilters != null && filterable.valueFilters.size() > 0)
+            || (filterable.contextValueFilters != null && filterable.contextValueFilters.size() > 0)
+            || out.writeNonStringValueAsString;
     }
-    
+
     public boolean hasNameFilters(SerializeFilterable filterable) {
         return (nameFilters != null && nameFilters.size() > 0) //
-               || (filterable.nameFilters != null && filterable.nameFilters.size() > 0);
+            || (filterable.nameFilters != null && filterable.nameFilters.size() > 0);
     }
 
     public boolean hasPropertyFilters(SerializeFilterable filterable) {
         return (propertyFilters != null && propertyFilters.size() > 0) //
-                || (filterable.propertyFilters != null && filterable.propertyFilters.size() > 0);
+            || (filterable.propertyFilters != null && filterable.propertyFilters.size() > 0);
     }
 
     public int getIndentCount() {
@@ -451,5 +476,5 @@ public class JSONSerializer extends SerializeFilterable {
     public void close() {
         this.out.close();
     }
-   
+
 }

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializerFeature.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializerFeature.java
@@ -21,11 +21,11 @@ package com.alibaba.fastjson.serializer;
 public enum SerializerFeature {
     QuoteFieldNames,
     /**
-     * 
+     *
      */
     UseSingleQuotes,
     /**
-     * 
+     *
      */
     WriteMapNullValue,
     /**
@@ -37,7 +37,7 @@ public enum SerializerFeature {
      */
     WriteEnumUsingName,
     /**
-     * 
+     *
      */
     UseISO8601DateFormat,
     /**
@@ -118,27 +118,27 @@ public enum SerializerFeature {
      * @since 1.1.37
      */
     WriteNonStringKeyAsString,
-    
+
     /**
      * @since 1.1.42
      */
     NotWriteDefaultValue,
-    
+
     /**
      * @since 1.2.6
      */
     BrowserSecure,
-    
+
     /**
      * @since 1.2.7
      */
     IgnoreNonFieldGetter,
-    
+
     /**
      * @since 1.2.9
      */
     WriteNonStringValueAsString,
-    
+
     /**
      * @since 1.2.11
      */
@@ -152,7 +152,11 @@ public enum SerializerFeature {
     /**
      * @since 1.2.27
      */
-    MapSortField;
+    MapSortField,
+
+    WriteLocalTimeUseLocalTimeFormat,
+
+    UseDefaultLocalTimeFormat;
 
     SerializerFeature(){
         mask = (1 << ordinal());
@@ -167,10 +171,10 @@ public enum SerializerFeature {
     public static boolean isEnabled(int features, SerializerFeature feature) {
         return (features & feature.mask) != 0;
     }
-    
+
     public static boolean isEnabled(int features, int featuresB, SerializerFeature feature) {
         int mask = feature.mask;
-        
+
         return (features & mask) != 0 || (featuresB & mask) != 0;
     }
 
@@ -183,28 +187,28 @@ public enum SerializerFeature {
 
         return features;
     }
-    
+
     public static int of(SerializerFeature[] features) {
         if (features == null) {
             return 0;
         }
-        
+
         int value = 0;
-        
+
         for (SerializerFeature feature: features) {
             value |= feature.mask;
         }
-        
+
         return value;
     }
-    
+
     public final static SerializerFeature[] EMPTY = new SerializerFeature[0];
 
     public static final int WRITE_MAP_NULL_FEATURES
-            = WriteMapNullValue.getMask()
-            | WriteNullBooleanAsFalse.getMask()
-            | WriteNullListAsEmpty.getMask()
-            | WriteNullNumberAsZero.getMask()
-            | WriteNullStringAsEmpty.getMask()
-            ;
+        = WriteMapNullValue.getMask()
+        | WriteNullBooleanAsFalse.getMask()
+        | WriteNullListAsEmpty.getMask()
+        | WriteNullNumberAsZero.getMask()
+        | WriteNullStringAsEmpty.getMask()
+        ;
 }

--- a/src/main/java/com/alibaba/fastjson/support/config/FastJsonConfig.java
+++ b/src/main/java/com/alibaba/fastjson/support/config/FastJsonConfig.java
@@ -74,6 +74,11 @@ public class FastJsonConfig {
     private String dateFormat;
 
     /**
+     * format localTime type
+     */
+    private String localTimeFormat;
+
+    /**
      * The Write content length.
      */
     private boolean writeContentLength;
@@ -89,7 +94,7 @@ public class FastJsonConfig {
         this.parserConfig = ParserConfig.getGlobalInstance();
 
         this.serializerFeatures = new SerializerFeature[] {
-                SerializerFeature.BrowserSecure
+            SerializerFeature.BrowserSecure
         };
 
         this.serializeFilters = new SerializeFilter[0];
@@ -179,7 +184,7 @@ public class FastJsonConfig {
      * @param classSerializeFilters the classSerializeFilters to set
      */
     public void setClassSerializeFilters(
-            Map<Class<?>, SerializeFilter> classSerializeFilters) {
+        Map<Class<?>, SerializeFilter> classSerializeFilters) {
 
         if (classSerializeFilters == null)
             return;
@@ -203,6 +208,20 @@ public class FastJsonConfig {
      */
     public void setDateFormat(String dateFormat) {
         this.dateFormat = dateFormat;
+    }
+
+    /**
+     * @return the localTimeFormat
+     */
+    public String getLocalTimeFormat() {
+        return localTimeFormat;
+    }
+
+    /**
+     * @param localTimeFormat the localTimeFormat to set
+     */
+    public void setLocalTimeFormat(String localTimeFormat) {
+        this.localTimeFormat = localTimeFormat;
     }
 
     /**

--- a/src/main/java/com/alibaba/fastjson/support/jaxrs/FastJsonProvider.java
+++ b/src/main/java/com/alibaba/fastjson/support/jaxrs/FastJsonProvider.java
@@ -34,14 +34,14 @@ import java.util.List;
 @Consumes({MediaType.WILDCARD})
 @Produces({MediaType.WILDCARD})
 public class FastJsonProvider //
-        implements MessageBodyReader<Object>, MessageBodyWriter<Object> {
+    implements MessageBodyReader<Object>, MessageBodyWriter<Object> {
 
     /**
      * These are classes that we never use for reading
      * (never try to deserialize instances of these types).
      */
     public final static Class<?>[] DEFAULT_UNREADABLES = new Class<?>[]{
-            InputStream.class, Reader.class
+        InputStream.class, Reader.class
     };
 
     /**
@@ -49,9 +49,9 @@ public class FastJsonProvider //
      * (never try to serialize instances of these types).
      */
     public final static Class<?>[] DEFAULT_UNWRITABLES = new Class<?>[]{
-            InputStream.class,
-            OutputStream.class, Writer.class,
-            StreamingOutput.class, Response.class
+        InputStream.class,
+        OutputStream.class, Writer.class,
+        StreamingOutput.class, Response.class
     };
 
     @Deprecated
@@ -293,12 +293,12 @@ public class FastJsonProvider //
             String subtype = mediaType.getSubtype();
 
             return (("json".equalsIgnoreCase(subtype)) //
-                    || (subtype.endsWith("+json")) //
-                    || ("javascript".equals(subtype)) //
-                    || ("x-javascript".equals(subtype)) //
-                    || ("x-json".equals(subtype)) //
-                    || ("x-www-form-urlencoded".equalsIgnoreCase(subtype)) //
-                    || (subtype.endsWith("x-www-form-urlencoded")));
+                || (subtype.endsWith("+json")) //
+                || ("javascript".equals(subtype)) //
+                || ("x-javascript".equals(subtype)) //
+                || ("x-json".equals(subtype)) //
+                || ("x-www-form-urlencoded".equalsIgnoreCase(subtype)) //
+                || (subtype.endsWith("x-www-form-urlencoded")));
         }
         return true;
     }
@@ -308,9 +308,9 @@ public class FastJsonProvider //
      * (of specified type) can be serialized by this provider.
      */
     public boolean isWriteable(Class<?> type, //
-                               Type genericType, //
-                               Annotation[] annotations, //
-                               MediaType mediaType) {
+        Type genericType, //
+        Annotation[] annotations, //
+        MediaType mediaType) {
         if (!hasMatchingMediaType(mediaType)) {
             return false;
         }
@@ -326,10 +326,10 @@ public class FastJsonProvider //
      * of given value. always return -1 to denote "not known".
      */
     public long getSize(Object t, //
-                        Class<?> type, //
-                        Type genericType, //
-                        Annotation[] annotations, //
-                        MediaType mediaType) {
+        Class<?> type, //
+        Type genericType, //
+        Annotation[] annotations, //
+        MediaType mediaType) {
         return -1;
     }
 
@@ -337,12 +337,12 @@ public class FastJsonProvider //
      * Method that JAX-RS container calls to serialize given value.
      */
     public void writeTo(Object obj, //
-                        Class<?> type, //
-                        Type genericType, //
-                        Annotation[] annotations, //
-                        MediaType mediaType, //
-                        MultivaluedMap<String, Object> httpHeaders, //
-                        OutputStream entityStream //
+        Class<?> type, //
+        Type genericType, //
+        Annotation[] annotations, //
+        MediaType mediaType, //
+        MultivaluedMap<String, Object> httpHeaders, //
+        OutputStream entityStream //
     ) throws IOException, WebApplicationException {
 
         FastJsonConfig fastJsonConfig = locateConfigProvider(type, mediaType);
@@ -362,13 +362,14 @@ public class FastJsonProvider //
 
         try {
             JSON.writeJSONStringWithFastJsonConfig(entityStream, //
-                    fastJsonConfig.getCharset(), //
-                    obj, //
-                    fastJsonConfig.getSerializeConfig(), //
-                    fastJsonConfig.getSerializeFilters(), //
-                    fastJsonConfig.getDateFormat(), //
-                    JSON.DEFAULT_GENERATE_FEATURE, //
-                    fastJsonConfig.getSerializerFeatures());
+                fastJsonConfig.getCharset(), //
+                obj, //
+                fastJsonConfig.getSerializeConfig(), //
+                fastJsonConfig.getSerializeFilters(), //
+                fastJsonConfig.getDateFormat(), //
+                fastJsonConfig.getLocalTimeFormat(), //
+                JSON.DEFAULT_GENERATE_FEATURE, //
+                fastJsonConfig.getSerializerFeatures());
 
             entityStream.flush();
 
@@ -383,9 +384,9 @@ public class FastJsonProvider //
      * given type (and media type) can be deserialized by this provider.
      */
     public boolean isReadable(Class<?> type, //
-                              Type genericType, //
-                              Annotation[] annotations, //
-                              MediaType mediaType) {
+        Type genericType, //
+        Annotation[] annotations, //
+        MediaType mediaType) {
 
         if (!hasMatchingMediaType(mediaType)) {
             return false;
@@ -401,22 +402,22 @@ public class FastJsonProvider //
      * Method that JAX-RS container calls to deserialize given value.
      */
     public Object readFrom(Class<Object> type, //
-                           Type genericType, //
-                           Annotation[] annotations, //
-                           MediaType mediaType, //
-                           MultivaluedMap<String, String> httpHeaders, //
-                           InputStream entityStream) throws IOException, WebApplicationException {
+        Type genericType, //
+        Annotation[] annotations, //
+        MediaType mediaType, //
+        MultivaluedMap<String, String> httpHeaders, //
+        InputStream entityStream) throws IOException, WebApplicationException {
 
         try {
             FastJsonConfig fastJsonConfig = locateConfigProvider(type, mediaType);
 
             return JSON.parseObject(entityStream,
-                    fastJsonConfig.getCharset(),
-                    genericType,
-                    fastJsonConfig.getParserConfig(),
-                    fastJsonConfig.getParseProcess(),
-                    JSON.DEFAULT_PARSER_FEATURE,
-                    fastJsonConfig.getFeatures());
+                fastJsonConfig.getCharset(),
+                genericType,
+                fastJsonConfig.getParserConfig(),
+                fastJsonConfig.getParseProcess(),
+                JSON.DEFAULT_PARSER_FEATURE,
+                fastJsonConfig.getFeatures());
 
         } catch (JSONException ex) {
 

--- a/src/main/java/com/alibaba/fastjson/support/retrofit/Retrofit2ConverterFactory.java
+++ b/src/main/java/com/alibaba/fastjson/support/retrofit/Retrofit2ConverterFactory.java
@@ -58,16 +58,16 @@ public class Retrofit2ConverterFactory extends Converter.Factory {
 
     @Override
     public Converter<ResponseBody, Object> responseBodyConverter(Type type, //
-                                                                 Annotation[] annotations, //
-                                                                 Retrofit retrofit) {
+        Annotation[] annotations, //
+        Retrofit retrofit) {
         return new ResponseBodyConverter<Object>(type);
     }
 
     @Override
     public Converter<Object, RequestBody> requestBodyConverter(Type type, //
-                                                               Annotation[] parameterAnnotations, //
-                                                               Annotation[] methodAnnotations, //
-                                                               Retrofit retrofit) {
+        Annotation[] parameterAnnotations, //
+        Annotation[] methodAnnotations, //
+        Retrofit retrofit) {
         return new RequestBodyConverter<Object>();
     }
 
@@ -219,12 +219,12 @@ public class Retrofit2ConverterFactory extends Converter.Factory {
         public T convert(ResponseBody value) throws IOException {
             try {
                 return JSON.parseObject(value.bytes()
-                        , fastJsonConfig.getCharset()
-                        , type
-                        , fastJsonConfig.getParserConfig()
-                        , fastJsonConfig.getParseProcess()
-                        , JSON.DEFAULT_PARSER_FEATURE
-                        , fastJsonConfig.getFeatures()
+                    , fastJsonConfig.getCharset()
+                    , type
+                    , fastJsonConfig.getParserConfig()
+                    , fastJsonConfig.getParseProcess()
+                    , JSON.DEFAULT_PARSER_FEATURE
+                    , fastJsonConfig.getFeatures()
                 );
             } catch (Exception e) {
                 throw new IOException("JSON parse error: " + e.getMessage(), e);
@@ -241,12 +241,13 @@ public class Retrofit2ConverterFactory extends Converter.Factory {
         public RequestBody convert(T value) throws IOException {
             try {
                 byte[] content = JSON.toJSONBytesWithFastJsonConfig(fastJsonConfig.getCharset()
-                        , value
-                        , fastJsonConfig.getSerializeConfig()
-                        , fastJsonConfig.getSerializeFilters()
-                        , fastJsonConfig.getDateFormat()
-                        , JSON.DEFAULT_GENERATE_FEATURE
-                        , fastJsonConfig.getSerializerFeatures()
+                    , value
+                    , fastJsonConfig.getSerializeConfig()
+                    , fastJsonConfig.getSerializeFilters()
+                    , fastJsonConfig.getDateFormat()
+                    , fastJsonConfig.getLocalTimeFormat()
+                    , JSON.DEFAULT_GENERATE_FEATURE
+                    , fastJsonConfig.getSerializerFeatures()
                 );
                 return RequestBody.create(MEDIA_TYPE, content);
             } catch (Exception e) {

--- a/src/main/java/com/alibaba/fastjson/support/spring/FastJsonHttpMessageConverter.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/FastJsonHttpMessageConverter.java
@@ -54,7 +54,7 @@ import java.util.List;
  */
 
 public class FastJsonHttpMessageConverter extends AbstractHttpMessageConverter<Object>//
-        implements GenericHttpMessageConverter<Object> {
+    implements GenericHttpMessageConverter<Object> {
 
     public static final MediaType APPLICATION_JAVASCRIPT = new MediaType("application", "javascript");
 
@@ -233,8 +233,8 @@ public class FastJsonHttpMessageConverter extends AbstractHttpMessageConverter<O
      * @see org.springframework.http.converter.GenericHttpMessageConverter#read(java.lang.reflect.Type, java.lang.Class, org.springframework.http.HttpInputMessage)
      */
     public Object read(Type type, //
-                       Class<?> contextClass, //
-                       HttpInputMessage inputMessage //
+        Class<?> contextClass, //
+        HttpInputMessage inputMessage //
     ) throws IOException, HttpMessageNotReadableException {
         return readType(getType(type, contextClass), inputMessage);
     }
@@ -253,7 +253,7 @@ public class FastJsonHttpMessageConverter extends AbstractHttpMessageConverter<O
      */
     @Override
     protected Object readInternal(Class<?> clazz, //
-                                  HttpInputMessage inputMessage //
+        HttpInputMessage inputMessage //
     ) throws IOException, HttpMessageNotReadableException {
         return readType(getType(clazz, null), inputMessage);
     }
@@ -263,12 +263,12 @@ public class FastJsonHttpMessageConverter extends AbstractHttpMessageConverter<O
         try {
             InputStream in = inputMessage.getBody();
             return JSON.parseObject(in,
-                    fastJsonConfig.getCharset(),
-                    type,
-                    fastJsonConfig.getParserConfig(),
-                    fastJsonConfig.getParseProcess(),
-                    JSON.DEFAULT_PARSER_FEATURE,
-                    fastJsonConfig.getFeatures());
+                fastJsonConfig.getCharset(),
+                type,
+                fastJsonConfig.getParserConfig(),
+                fastJsonConfig.getParseProcess(),
+                JSON.DEFAULT_PARSER_FEATURE,
+                fastJsonConfig.getFeatures());
         } catch (JSONException ex) {
             throw new HttpMessageNotReadableException("JSON parse error: " + ex.getMessage(), ex);
         } catch (IOException ex) {
@@ -312,14 +312,15 @@ public class FastJsonHttpMessageConverter extends AbstractHttpMessageConverter<O
 
 
             int len = JSON.writeJSONStringWithFastJsonConfig(outnew, //
-                    fastJsonConfig.getCharset(), //
-                    value, //
-                    fastJsonConfig.getSerializeConfig(), //
-                    //fastJsonConfig.getSerializeFilters(), //
-                    allFilters.toArray(new SerializeFilter[allFilters.size()]),
-                    fastJsonConfig.getDateFormat(), //
-                    JSON.DEFAULT_GENERATE_FEATURE, //
-                    fastJsonConfig.getSerializerFeatures());
+                fastJsonConfig.getCharset(), //
+                value, //
+                fastJsonConfig.getSerializeConfig(), //
+                //fastJsonConfig.getSerializeFilters(), //
+                allFilters.toArray(new SerializeFilter[allFilters.size()]),
+                fastJsonConfig.getDateFormat(), //
+                fastJsonConfig.getLocalTimeFormat(), //
+                JSON.DEFAULT_GENERATE_FEATURE, //
+                fastJsonConfig.getSerializerFeatures());
 
             if (isJsonp) {
                 headers.setContentType(APPLICATION_JAVASCRIPT);

--- a/src/main/java/com/alibaba/fastjson/support/spring/FastJsonJsonView.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/FastJsonJsonView.java
@@ -285,8 +285,8 @@ public class FastJsonJsonView extends AbstractView {
 
     @Override
     protected void renderMergedOutputModel(Map<String, Object> model, //
-                                           HttpServletRequest request, //
-                                           HttpServletResponse response) throws Exception {
+        HttpServletRequest request, //
+        HttpServletResponse response) throws Exception {
         Object value = filterModel(model);
         String jsonpParameterValue = getJsonpParameterValue(request);
         if (jsonpParameterValue != null) {
@@ -298,13 +298,14 @@ public class FastJsonJsonView extends AbstractView {
         ByteArrayOutputStream outnew = new ByteArrayOutputStream();
 
         int len = JSON.writeJSONStringWithFastJsonConfig(outnew, //
-                fastJsonConfig.getCharset(), //
-                value, //
-                fastJsonConfig.getSerializeConfig(), //
-                fastJsonConfig.getSerializeFilters(), //
-                fastJsonConfig.getDateFormat(), //
-                JSON.DEFAULT_GENERATE_FEATURE, //
-                fastJsonConfig.getSerializerFeatures());
+            fastJsonConfig.getCharset(), //
+            value, //
+            fastJsonConfig.getSerializeConfig(), //
+            fastJsonConfig.getSerializeFilters(), //
+            fastJsonConfig.getDateFormat(), //
+            fastJsonConfig.getLocalTimeFormat(), //
+            JSON.DEFAULT_GENERATE_FEATURE, //
+            fastJsonConfig.getSerializerFeatures());
 
         if (this.updateContentLength) {
             // Write content length (determined via byte array).
@@ -320,7 +321,7 @@ public class FastJsonJsonView extends AbstractView {
 
     @Override
     protected void prepareResponse(HttpServletRequest request, //
-                                   HttpServletResponse response) {
+        HttpServletResponse response) {
 
         setResponseContentType(request, response);
         response.setCharacterEncoding(fastJsonConfig.getCharset().name());
@@ -366,12 +367,12 @@ public class FastJsonJsonView extends AbstractView {
     protected Object filterModel(Map<String, Object> model) {
         Map<String, Object> result = new HashMap<String, Object>(model.size());
         Set<String> renderedAttributes = !CollectionUtils.isEmpty(this.renderedAttributes) ? //
-                this.renderedAttributes //
-                : model.keySet();
+            this.renderedAttributes //
+            : model.keySet();
 
         for (Map.Entry<String, Object> entry : model.entrySet()) {
             if (!(entry.getValue() instanceof BindingResult)
-                    && renderedAttributes.contains(entry.getKey())) {
+                && renderedAttributes.contains(entry.getKey())) {
                 result.put(entry.getKey(), entry.getValue());
             }
         }

--- a/src/main/java/com/alibaba/fastjson/support/spring/FastJsonRedisSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/FastJsonRedisSerializer.java
@@ -35,13 +35,14 @@ public class FastJsonRedisSerializer<T> implements RedisSerializer<T> {
         }
         try {
             return JSON.toJSONBytesWithFastJsonConfig(
-                    fastJsonConfig.getCharset(),
-                    t,
-                    fastJsonConfig.getSerializeConfig(),
-                    fastJsonConfig.getSerializeFilters(),
-                    fastJsonConfig.getDateFormat(),
-                    JSON.DEFAULT_GENERATE_FEATURE,
-                    fastJsonConfig.getSerializerFeatures()
+                fastJsonConfig.getCharset(),
+                t,
+                fastJsonConfig.getSerializeConfig(),
+                fastJsonConfig.getSerializeFilters(),
+                fastJsonConfig.getDateFormat(),
+                fastJsonConfig.getLocalTimeFormat(),
+                JSON.DEFAULT_GENERATE_FEATURE,
+                fastJsonConfig.getSerializerFeatures()
             );
         } catch (Exception ex) {
             throw new SerializationException("Could not serialize: " + ex.getMessage(), ex);
@@ -55,13 +56,13 @@ public class FastJsonRedisSerializer<T> implements RedisSerializer<T> {
         }
         try {
             return (T) JSON.parseObject(
-                    bytes,
-                    fastJsonConfig.getCharset(),
-                    type,
-                    fastJsonConfig.getParserConfig(),
-                    fastJsonConfig.getParseProcess(),
-                    JSON.DEFAULT_PARSER_FEATURE,
-                    fastJsonConfig.getFeatures()
+                bytes,
+                fastJsonConfig.getCharset(),
+                type,
+                fastJsonConfig.getParserConfig(),
+                fastJsonConfig.getParseProcess(),
+                JSON.DEFAULT_PARSER_FEATURE,
+                fastJsonConfig.getFeatures()
             );
         } catch (Exception ex) {
             throw new SerializationException("Could not deserialize: " + ex.getMessage(), ex);

--- a/src/main/java/com/alibaba/fastjson/support/spring/messaging/MappingFastJsonMessageConverter.java
+++ b/src/main/java/com/alibaba/fastjson/support/spring/messaging/MappingFastJsonMessageConverter.java
@@ -67,10 +67,10 @@ public class MappingFastJsonMessageConverter extends AbstractMessageConverter {
         Object obj = null;
         if (payload instanceof byte[]) {
             obj = JSON.parseObject((byte[]) payload, fastJsonConfig.getCharset(), targetClass, fastJsonConfig.getParserConfig(),
-                    fastJsonConfig.getParseProcess(), JSON.DEFAULT_PARSER_FEATURE, fastJsonConfig.getFeatures());
+                fastJsonConfig.getParseProcess(), JSON.DEFAULT_PARSER_FEATURE, fastJsonConfig.getFeatures());
         } else if (payload instanceof String) {
             obj = JSON.parseObject((String) payload, targetClass, fastJsonConfig.getParserConfig(),
-                    fastJsonConfig.getParseProcess(), JSON.DEFAULT_PARSER_FEATURE, fastJsonConfig.getFeatures());
+                fastJsonConfig.getParseProcess(), JSON.DEFAULT_PARSER_FEATURE, fastJsonConfig.getFeatures());
         }
 
         return obj;
@@ -85,14 +85,14 @@ public class MappingFastJsonMessageConverter extends AbstractMessageConverter {
                 obj = ((String) payload).getBytes(fastJsonConfig.getCharset());
             } else {
                 obj = JSON.toJSONBytesWithFastJsonConfig(fastJsonConfig.getCharset(), payload, fastJsonConfig.getSerializeConfig(), fastJsonConfig.getSerializeFilters(),
-                        fastJsonConfig.getDateFormat(), JSON.DEFAULT_GENERATE_FEATURE, fastJsonConfig.getSerializerFeatures());
+                    fastJsonConfig.getDateFormat(),fastJsonConfig.getLocalTimeFormat(),JSON.DEFAULT_GENERATE_FEATURE, fastJsonConfig.getSerializerFeatures());
             }
         } else {
             if (payload instanceof String && JSON.isValid((String) payload)) {
                 obj = payload;
             } else {
                 obj = JSON.toJSONString(payload, fastJsonConfig.getSerializeConfig(), fastJsonConfig.getSerializeFilters(),
-                        fastJsonConfig.getDateFormat(), JSON.DEFAULT_GENERATE_FEATURE, fastJsonConfig.getSerializerFeatures());
+                    fastJsonConfig.getDateFormat(),fastJsonConfig.getLocalTimeFormat(), JSON.DEFAULT_GENERATE_FEATURE, fastJsonConfig.getSerializerFeatures());
             }
         }
 

--- a/src/test/java/com/alibaba/json/bvt/UnQuoteFieldNamesTest.java
+++ b/src/test/java/com/alibaba/json/bvt/UnQuoteFieldNamesTest.java
@@ -18,10 +18,11 @@ public class UnQuoteFieldNamesTest extends TestCase {
         Map map = Collections.singletonMap("value", 123);
 
         String json = JSON.toJSONString(map
-                , SerializeConfig.globalInstance
-                , new SerializeFilter[0]
-                , null
-                , JSON.DEFAULT_GENERATE_FEATURE & ~SerializerFeature.QuoteFieldNames.mask
+            , SerializeConfig.globalInstance
+            , new SerializeFilter[0]
+            , null
+            ,null
+            , JSON.DEFAULT_GENERATE_FEATURE & ~SerializerFeature.QuoteFieldNames.mask
         );
         assertEquals("{value:123}", json);
     }

--- a/src/test/java/com/alibaba/json/bvt/issue_1800/Issue1858.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_1800/Issue1858.java
@@ -1,0 +1,49 @@
+package com.alibaba.json.bvt.issue_1800;
+
+import java.time.LocalTime;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import com.alibaba.fastjson.support.config.FastJsonConfig;
+
+import junit.framework.TestCase;
+
+/**
+ * @author toretto.huang
+ * @date 2022/1/19
+ */
+public class Issue1858 extends TestCase {
+
+    public void test_for_issue() {
+        LocalTime localDate = LocalTime.of(20, 30, 0);
+        String json = JSON.toJSONStringWithLocalTimeFormat(localDate, "HH:mm:ss");
+        assertEquals("\"20:30:00\"", json);
+        String json2 = JSON.toJSONStringWithLocalTimeFormat(localDate, "HH:mm");
+        assertEquals("\"20:30\"", json2);
+        LocalTime localDate2 = LocalTime.of(20, 30, 1);
+        String json3 = JSON.toJSONStringWithLocalTimeFormat(localDate2, "HH:mm:ss");
+        assertEquals("\"20:30:01\"", json3);
+        String json4 = JSON.toJSONStringWithLocalTimeFormat(localDate2, "HH:mm");
+        assertEquals("\"20:30\"", json4);
+        System.out.println(JSON.toJSONString(localDate, SerializerFeature.UseDefaultLocalTimeFormat));
+    }
+
+    public void test_for_issue2() throws Exception {
+        VO vo = new VO();
+        vo.localTime = LocalTime.of(20, 30, 00);
+        FastJsonConfig config = new FastJsonConfig();
+        config.setSerializerFeatures(SerializerFeature.WriteMapNullValue);
+        config.setWriteContentLength(false);
+        JSON.DEFFAULT_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS";
+        config.setDateFormat(JSON.DEFFAULT_DATE_FORMAT);
+        config.setLocalTimeFormat("HH:mm:ss");
+        String string =
+            JSON.toJSONString(vo, config.getSerializeConfig(), config.getSerializeFilters(), config.getDateFormat(),
+                config.getLocalTimeFormat(), JSON.DEFAULT_GENERATE_FEATURE, config.getSerializerFeatures());
+        assertEquals("{\"localTime\":\"20:30:00\"}", string);
+    }
+
+    public static class VO {
+        public LocalTime localTime;
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3361.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_3300/Issue3361.java
@@ -32,11 +32,12 @@ public class Issue3361 extends TestCase {
         JSON.DEFFAULT_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS";
         config.setDateFormat(JSON.DEFFAULT_DATE_FORMAT);
         String string = JSON.toJSONString(model,
-                config.getSerializeConfig(),
-                config.getSerializeFilters(),
-                config.getDateFormat(),
-                JSON.DEFAULT_GENERATE_FEATURE,
-                config.getSerializerFeatures());
+            config.getSerializeConfig(),
+            config.getSerializeFilters(),
+            config.getDateFormat(),
+            config.getLocalTimeFormat(),
+            JSON.DEFAULT_GENERATE_FEATURE,
+            config.getSerializerFeatures());
         log.info("{}", string);
 
         Model model2 = JSON.parseObject(string, Model.class);

--- a/src/test/java/com/alibaba/json/bvt/serializer/enum_/EnumFieldsTest8.java
+++ b/src/test/java/com/alibaba/json/bvt/serializer/enum_/EnumFieldsTest8.java
@@ -16,23 +16,24 @@ public class EnumFieldsTest8 extends TestCase {
         Model model = new Model();
         model.t1 = Type.A;
         model.t2 = null;
-        
+
         ValueFilter valueFilter = new ValueFilter() {
 
             public Object process(Object object, String name, Object value) {
                 return value;
             }
-            
+
         };
-        
+
         SerializeFilter[] filters = {valueFilter};
         String text = JSON.toJSONString(model, SerializeConfig.getGlobalInstance(), // 
-                                        filters, 
-                                        null,
-                                        0, // 
-                                        SerializerFeature.QuoteFieldNames, // 
-                                        SerializerFeature.BrowserCompatible, // 
-                                        SerializerFeature.WriteEnumUsingName);
+            filters,
+            null,
+            null,
+            0, //
+            SerializerFeature.QuoteFieldNames, //
+            SerializerFeature.BrowserCompatible, //
+            SerializerFeature.WriteEnumUsingName);
         Assert.assertEquals("{\"t1\":\"A\"}", text);
     }
 
@@ -43,6 +44,6 @@ public class EnumFieldsTest8 extends TestCase {
     }
 
     public static enum Type {
-                             A, B, C
+        A, B, C
     }
 }


### PR DESCRIPTION
1、修复LocalTime序列化，格式飘忽不定问题，比如LocalTime（20:30:01)可以正常序列化为20:30:01,但比如LocalTime（20:30:00)却序列化为20:30，没有秒单位。由于原来使用的是LocalTime的toString()方法导致；Fixed [#1858](https://github.com/alibaba/fastjson/issues/1858)
2、支持全局配置LocalTime序列化格式；