### PR TITLE
修复当设置条件为 Long转String时，但 java.util.List<Long>依然转换为array<long>的bug

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/ToStringSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/ToStringSerializer.java
@@ -16,8 +16,16 @@ public class ToStringSerializer implements ObjectSerializer {
             out.writeNull();
             return;
         }
-
-        String strVal = object.toString();
+        
+        String strVal = null;
+        if (object instanceof Long 
+           && (serializer.out.isEnabled(SerializerFeature.WriteClassName) 
+            || SerializerFeature.isEnabled(features, SerializerFeature.WriteClassName))
+           ) {
+            strVal = new StringBuffer().append(object).append("L").toString();
+        } else {
+            strVal =object.toString();
+        }
         out.writeString(strVal);
     }
 


### PR DESCRIPTION
修复当设置条件为 Long转String时，但 java.util.List<Long>依然转换为array<long>而不是array<string>的bug，该bug导致前端用string在array<long> 中无法查找定位。