### PR TITLE
fix 3824，当path中有特殊字符时,需要转义，否则无法解析ref对象

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/ParseContext.java
+++ b/src/main/java/com/alibaba/fastjson/parser/ParseContext.java
@@ -18,19 +18,71 @@ public class ParseContext {
         this.level = parent == null ? 0 : parent.level + 1;
     }
 
+
+
+    @Override
     public String toString() {
         if (path == null) {
             if (parent == null) {
-                path = "$";
+                return "$";
             } else {
-                if (fieldName instanceof Integer) {
-                    path = parent.toString() + "[" + fieldName + "]";
-                } else {
-                    path = parent.toString() + "." + fieldName;
-                }
+                StringBuilder buf = new StringBuilder();
+                toString(buf);
+                return buf.toString();
             }
         }
 
         return path;
+    }
+
+    /**
+     * 当path中有特殊字符时,需要转义，否则无法解析ref对象
+     * @param buf
+     */
+    protected void toString(StringBuilder buf) {
+        if (parent == null) {
+            buf.append('$');
+        } else {
+            parent.toString(buf);
+            if (fieldName == null) {
+                buf.append(".null");
+            } else if (fieldName instanceof Integer) {
+                buf.append('[');
+                buf.append(((Integer)fieldName).intValue());
+                buf.append(']');
+            } else {
+                buf.append('.');
+
+                String fieldName = this.fieldName.toString();
+                boolean special = false;
+                for (int i = 0; i < fieldName.length(); ++i) {
+                    char ch = fieldName.charAt(i);
+                    if ((ch >= '0' && ch <='9') || (ch >= 'A' && ch <='Z') || (ch >= 'a' && ch <='z') || ch > 128) {
+                        continue;
+                    }
+                    special = true;
+                    break;
+                }
+
+                if (special) {
+                    for (int i = 0; i < fieldName.length(); ++i) {
+                        char ch = fieldName.charAt(i);
+                        if (ch == '\\') {
+                            buf.append('\\');
+                        } else if ((ch >= '0' && ch <='9') || (ch >= 'A' && ch <='Z') || (ch >= 'a' && ch <='z') || ch > 128) {
+                            buf.append(ch);
+                            continue;
+                        } else if(ch == '\"'){
+                            buf.append('\\');
+                        } else {
+                            buf.append('\\');
+                        }
+                        buf.append(ch);
+                    }
+                } else {
+                    buf.append(fieldName);
+                }
+            }
+        }
     }
 }

--- a/src/test/java/com/alibaba/fastjson/serializer/issue3824/TestIssue3824.java
+++ b/src/test/java/com/alibaba/fastjson/serializer/issue3824/TestIssue3824.java
@@ -1,0 +1,49 @@
+package com.alibaba.fastjson.serializer.issue3824;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public class TestIssue3824 {
+
+
+    class X implements Serializable {
+        int a;
+        public int getA() {
+            return a;
+        }
+        public void setA(int a) {
+            this.a = a;
+        }
+    }
+
+
+    @Test
+    public void testIssue3084() {
+        Map<String, Object> result  = new HashMap<>();
+        X a = new  X();
+        a.a = 100;
+        List< X> t = Arrays.asList(a);
+        Map<String, Object> y = new HashMap<>();
+        y.put("2_wdk", t);
+        Map<String, Object> x = new HashMap<>();
+        x.put("y", y);
+        result.put("a.b.c", x);
+        result.put("x", a);
+        String s = JSON.toJSONString(result);
+        System.out.println(s); // {"a.b.c":{"y":{"2\\_wdk":[{"a":100}]}},"x":{"$ref":"$.a\\.b\\.c.y.2\\\\\\_wdk[0]"}}
+        JSONObject revert = JSON.parseObject(s);
+        System.out.println(JSON.toJSONString(revert)); // {"a.b.c":{"y":{"2\\_wdk":[{"a":100}]}},"x":[]}
+        Assert.assertEquals(JSON.toJSONString(revert),s);
+
+    }
+}


### PR DESCRIPTION
当path中有特殊字符时,需要转义，否则无法解析ref对象