### PR TITLE
Fix Issue #4009

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
@@ -32,6 +32,7 @@ import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_prime;
 /**
  * @author wenshao[szujobs@hotmail.com]
  */
+@SuppressWarnings("checkstyle:SummaryJavadoc")
 public final class JSONScanner extends JSONLexerBase {
 
     private final String text;
@@ -2436,15 +2437,15 @@ public final class JSONScanner extends JSONLexerBase {
                 }
                 bracketCnt++;
 
-                // Solve Issue #4069, which is caused by ignoring the situation that contend more arrays in one array.
-                {
-                    int index = ++bp;
-                    this.ch = (index >= text.length() //
-                            ? EOI //
-                            : text.charAt(index));
-                }
+          // Solve Issue #4069, which is caused by ignoring the situation that contend more arrays in one array.
+          {
+            int index = ++bp;
+            this.ch = (index >= text.length() //
+              ? EOI //
+              : text.charAt(index));
+          }
+        skipArray(valid);
 
-                skipArray(valid);
             } else if (ch == '{' && valid) {
                 {
                     int index = ++bp;

--- a/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
@@ -2435,6 +2435,16 @@ public final class JSONScanner extends JSONLexerBase {
                     continue;
                 }
                 bracketCnt++;
+
+                // Solve Issue #4069, which is caused by ignoring the situation that contend more arrays in one array.
+                {
+                    int index = ++bp;
+                    this.ch = (index >= text.length() //
+                            ? EOI //
+                            : text.charAt(index));
+                }
+
+                skipArray(valid);
             } else if (ch == '{' && valid) {
                 {
                     int index = ++bp;

--- a/src/main/java/com/alibaba/fastjson/serializer/MapSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/MapSerializer.java
@@ -229,8 +229,12 @@ public class MapSerializer extends SerializeFilterable implements ObjectSerializ
                         out.write(',');
                     }
 
+                    /*
+                    * Fix issue #4009, which is caused by writing UUID in string mode for two times
+                    * */
                     if ((out.isEnabled(NON_STRINGKEY_AS_STRING) || SerializerFeature.isEnabled(features, SerializerFeature.WriteNonStringKeyAsString))
-                            && !(entryKey instanceof Enum)) {
+                            && !(entryKey instanceof Enum)
+                            && !(entryKey instanceof UUID)) {
                         String strEntryKey = JSON.toJSONString(entryKey);
                         serializer.write(strEntryKey);
                     } else {

--- a/src/test/java/com/alibaba/json/bvt/issue_4000/Issue4009.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_4000/Issue4009.java
@@ -1,0 +1,35 @@
+package com.alibaba.json.bvt.issue_4000;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import lombok.var;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.HashMap;
+import java.util.UUID;
+
+public class Issue4009 {
+    @Test
+    public void test_for_issue40009_0() {
+        var map = new HashMap<Object, Object>();
+        UUID random = UUID.randomUUID();
+        map.put(random, "foo");
+
+        // Build JSON with feature BrowserSecure
+        var json = JSON.toJSONString(map, SerializerFeature.BrowserSecure);
+        String builder = "{\"" + random.toString() + "\":\"foo\"}";
+        Assert.assertEquals(json, builder);
+    }
+
+    @Test
+    public void test_for_issue40009_1() {
+        var map = new HashMap<Object, Object>();
+        UUID random = UUID.randomUUID();
+        map.put(random, "foo");
+
+        // Build JSON without feature BrowserSecure
+        var json = JSON.toJSONString(map);
+        String builder = "{\"" + random.toString() + "\":\"foo\"}";
+        Assert.assertEquals(json, builder);
+    }
+}

--- a/src/test/java/com/alibaba/json/bvt/issue_4000/Issue4069.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_4000/Issue4069.java
@@ -1,0 +1,25 @@
+package com.alibaba.json.bvt.issue_4000;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONValidator;
+import org.junit.Test;
+import junit.framework.TestCase;
+
+public class Issue4069 extends TestCase {
+    @Test
+    public void test_for_issue4069_0() {
+        String json_string = "[[{\"value\": \"aaa\",\"key\": \"input_aKLYFkHNhPk0\"},{\"value\": \"222\",\"key\": \"number_pPvGTENKofUM\"}]," +
+                "[{\"value\": \"ffdf\",\"key\": \"input_aKLYFkHNhPk0\"},{\"value\": \"1212\",\"key\": \"number_pPvGTENKofUM\"}]]";
+        assertTrue(JSON.isValidArray(json_string));
+        assertEquals("Array", JSONValidator.from(json_string).getType().toString());
+
+        assertTrue(JSON.isValidArray("[[]]"));
+        assertEquals("Array", JSONValidator.from("[[]]").getType().toString());
+    }
+
+    @Test
+    public void test_for_issue4069_1() {
+        assertFalse(JSON.isValidArray("["));
+        assertFalse(JSON.isValidArray("[[]"));
+    }
+}


### PR DESCRIPTION
Fixed the Issue #4009.
Fix the problem caused when deserializing `HashMap` into `String` with feature of `BrowserSecure` and taking `UUID` as key.
The problem is that will output `""` for two times.