### PR TITLE
Fix issue 4073.

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
@@ -779,10 +779,14 @@ public class JavaBeanInfo {
                     }
                 }
             }
-
+            //CS304 Issue link: https://github.com/alibaba/fastjson/issues/4073
+            char c4 = methodName.charAt(4);
             if (Character.isUpperCase(c3) //
                     || c3 > 512 // for unicode method name
                     ) {
+                if (Character.isUpperCase(c4) || c4 > 512){
+                    TypeUtils.compatibleWithJavaBean = true;
+                }
                 // 这里本身的逻辑是通过setAbc这类方法名解析出成员变量名为abc或者Abc, 但是在kotlin中, isAbc, abc成员变量的set方法都是setAbc
                 // 因此如果是kotlin的话还需要进行不一样的判断, 判断的方式是通过get方法进行判断, isAbc的get方法名为isAbc(), abc的get方法名为getAbc()
                 if (kotlin) {
@@ -791,6 +795,7 @@ public class JavaBeanInfo {
                 } else {
                     if (TypeUtils.compatibleWithJavaBean) {
                         propertyName = TypeUtils.decapitalize(methodName.substring(3));
+                        TypeUtils.compatibleWithJavaBean = false;
                     } else {
                         propertyName = TypeUtils.getPropertyNameByMethodName(methodName);
                     }

--- a/src/test/java/com/alibaba/json/bvt/issue_4000/Issue4073.java
+++ b/src/test/java/com/alibaba/json/bvt/issue_4000/Issue4073.java
@@ -1,0 +1,70 @@
+package com.alibaba.json.bvt.issue_4000;
+
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.annotation.JSONField;
+import junit.framework.TestCase;
+import java.util.Date;
+
+
+public class Issue4073 extends TestCase {
+    //CS304 (manually written) Issue link: https://github.com/alibaba/fastjson/issues/4073
+    public void test1() throws Exception {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("aBc", "abc");
+        jsonObject.put("i_d_d", "123456");
+        jsonObject.put("create_date", "2022-04-24 00:00:00");
+        User user = jsonObject.toJavaObject(User.class);
+        assertEquals("User{aBc='abc', ID='123456', date=Sun Apr 24 00:00:00 CST 2022}", user.toString());
+    }
+
+    //CS304 (manually written) Issue link: https://github.com/alibaba/fastjson/issues/4073
+    public void test2() throws Exception {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("aBc", "abc");
+        jsonObject.put("ID", "123456");
+        jsonObject.put("date", "2022-04-24 00:00:00");
+        User user = jsonObject.toJavaObject(User.class);
+        assertEquals("User{aBc='abc', ID='null', date=null}", user.toString());
+    }
+
+    public static class User {
+        private String aBc;
+        @JSONField(name = "i_d_d")
+        private String ID;
+        @JSONField(name = "create_date")
+        private Date date;
+
+        public String getaBc() {
+            return aBc;
+        }
+
+        public void setaBc(String aBc) {
+            this.aBc = aBc;
+        }
+
+        public String getID() {
+            return ID;
+        }
+
+        public void setID(String ID) {
+            this.ID = ID;
+        }
+
+        public Date getDate() {
+            return date;
+        }
+
+        public void setDate(Date date) {
+            this.date = date;
+        }
+
+        @Override
+        public String toString() {
+            return "User{" +
+                    "aBc='" + aBc + '\'' +
+                    ", ID='" + ID + '\'' +
+                    ", date=" + date +
+                    '}';
+        }
+    }
+}


### PR DESCRIPTION
在 #4073 的问题中，提到属性名与别名无法正确映射，其实是因为在反序列化时读取了自定义User类的set方法来得到变量名出错，具体原因在于'ID'这个变量的特殊性（首字母大写），所以程序将其处理成为'iD'以至于无法正常得到值。为了避免这种情况的发生，也就是为了在有专有名词变量存在时使该功能也正常使用，我在反序列化处理时对于前两个字母都是大写的情况进行了特殊处理--暂时将其兼容JavaBean设置为true，这样可以使得将'ID'正确处理以至于没有错误发生。另外，若是对变量定义了JSONField，则在加入JSONObject时需用其别名，若仍使用原变量名则会无法识别。