### PR TITLE
fix #4126

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/JSONLexerBase.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONLexerBase.java
@@ -817,6 +817,31 @@ public abstract class JSONLexerBase implements JSONLexer, Closeable {
         this.sp = 0;
     }
 
+    public final void reset() {
+        this.bp = -1;
+        this.eofPos = 0;
+        this.matchStat = 0;
+        this.nanos = 0;
+        this.np = 0;
+        this.pos = 0;
+        this.sp = 0;
+
+        next();
+        if (this.ch == 65279) {
+            next();
+        }
+
+        if (this.ch == '{') {
+            next();
+            this.token = JSONToken.LBRACE;
+        } else if (this.ch == '[') {
+            next();
+            this.token = JSONToken.LBRACKET;
+        } else {
+            nextToken();
+        }
+    }
+
     public String info() {
         return "";
     }

--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/ASMDeserializerFactory.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/ASMDeserializerFactory.java
@@ -1137,6 +1137,8 @@ public class ASMDeserializerFactory implements Opcodes {
             mw.visitInsn(IASTORE);
         }
 
+        mw.visitVarInsn(ALOAD, context.var("lexer"));
+        mw.visitMethodInsn(INVOKEVIRTUAL, JSONLexerBase, "reset", "()V");
         mw.visitMethodInsn(INVOKEVIRTUAL, type(JavaBeanDeserializer.class),
                            "parseRest", "(L" + DefaultJSONParser
                                         + ";Ljava/lang/reflect/Type;Ljava/lang/Object;Ljava/lang/Object;I[I)Ljava/lang/Object;");


### PR DESCRIPTION
在当前版本上默认 JavaBeanDeserializer 支持将不同类型自动处理为 List。即使 asm 为特殊情况，性能优先但也应保持行为一致性。