### PR TITLE
Fix1393

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -587,6 +587,8 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     public static <T> T parseObject(String text, Class<T> clazz) {
         return parseObject(text, clazz, new Feature[0]);
     }
+
+    //CS304 Issue link: https://github.com/alibaba/fastjson/issues/1393
     /**
      *
      * This method deserializes the specified Json into an object of the specified class

--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -587,7 +587,16 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
     public static <T> T parseObject(String text, Class<T> clazz) {
         return parseObject(text, clazz, new Feature[0]);
     }
-
+    /**
+     *
+     * This method deserializes the specified Json into an object of the specified class
+     * and can give a check on the enum value.
+     *
+     * @param text the string from which the object is to be deserialized
+     * @param clazz the class of T
+     * @param enumCheck if true,give a check on the enum value
+     * @return an object of type T from the string
+     */
     public static <T> T parseObject(String text, Class<T> clazz, boolean enumCheck) {
         if (enumCheck) {
             JSONObject jo = parseObject(text);

--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -588,6 +588,33 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         return parseObject(text, clazz, new Feature[0]);
     }
 
+    public static <T> T parseObject(String text, Class<T> clazz, boolean enumCheck) {
+        if (enumCheck) {
+            JSONObject jo = parseObject(text);
+            for (String s : jo.keySet()) {
+                try {
+                    Class<?> t = clazz.getDeclaredField(s).getType();
+                    if (t.isEnum()) {
+                        boolean exist = false;
+                        String v = jo.getString(s);
+                        for (Object o : t.getEnumConstants()) {
+                            if (o.toString().equals(v)) {
+                                exist = true;
+                                break;
+                            }
+                        }
+                        if (!exist) {
+                            throw new JSONException("Enum value " + v + " does not exist in " + t + ".");
+                        }
+                    }
+                } catch (NoSuchFieldException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return parseObject(text, clazz, new Feature[0]);
+    }
+
     public static JSONArray parseArray(String text) {
         return parseArray(text, ParserConfig.global);
     }

--- a/src/test/java/com/alibaba/fastjson/Issue1393.java
+++ b/src/test/java/com/alibaba/fastjson/Issue1393.java
@@ -1,0 +1,135 @@
+//CS304 Issue link: https://github.com/alibaba/fastjson/issues/1393
+package com.alibaba.fastjson;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class Issue1393 {
+
+    /**
+     * reproduce the issue
+     **/
+    @Test
+    public void reproduce(){
+        String jsonText;
+        jsonText = "{\"code\":\"SUCCESS\",\"id\":1}";
+        assertEquals("correct enum",jsonText,JSON.parseObject(jsonText, Result.class).toString());
+        jsonText = "{\"code\":\"FAILURE\",\"id\":2}";
+        assertEquals("correct enum",jsonText,JSON.parseObject(jsonText, Result.class).toString());
+        jsonText = "{\"code\":\"ERROR\",\"id\":3}";
+        assertEquals("correct enum",jsonText,JSON.parseObject(jsonText, Result.class).toString());
+    }
+
+    /**
+     * test when enumCheck is false
+     **/
+    @Test
+    public void testUnchecked(){
+        String jsonText;
+        jsonText = "{\"code\":\"SUCCESS\",\"id\":1}";
+        assertEquals("correct enum",jsonText,JSON.parseObject(jsonText, Result2.class,false).toString());
+        jsonText = "{\"code\":\"ERROR\",\"id\":2}";
+        assertEquals("incorrect enum","{\"id\":2}",JSON.parseObject(jsonText, Result2.class,false).toString());
+        jsonText = "{\"code\":\"SUCCESS\",\"id\":3,\"state\":\"CHECKED\"}";
+        assertEquals("correct enum", jsonText,JSON.parseObject(jsonText, Result2.class,false).toString());
+        jsonText = "{\"code\":\"SUCCESS\",\"id\":4,\"state\":\"UNKNOWN\"}";
+        assertEquals("incorrect enum","{\"code\":\"SUCCESS\",\"id\":4}",JSON.parseObject(jsonText, Result2.class,false).toString());
+    }
+
+    /**
+     * test when enumCheck is true
+     **/
+    @Test
+    public void testChecked(){
+        String jsonText;
+        jsonText = "{\"code\":\"SUCCESS\",\"id\":1}";
+        assertEquals("correct enum",jsonText,JSON.parseObject(jsonText, Result2.class,true).toString());
+        jsonText = "{\"code\":\"FAILURE\",\"id\":1}";
+        assertEquals("correct enum",jsonText,JSON.parseObject(jsonText, Result2.class,true).toString());
+        jsonText = "{\"code\":\"ERROR\",\"id\":2}";
+        try {
+            JSON.parseObject(jsonText, Result2.class,true);
+            fail();
+        }
+        catch (JSONException e){
+            assertEquals("error message","Enum value ERROR does not exist in class com.alibaba.fastjson.Code.",e.getMessage());
+        }
+        jsonText = "{\"code\":\"SUCCESS\",\"id\":3,\"state\":\"CHECKED\"}";
+        assertEquals("correct enum", jsonText,JSON.parseObject(jsonText, Result2.class,true).toString());
+        jsonText = "{\"code\":\"SUCCESS\",\"id\":4,\"state\":\"UNKNOWN\"}";
+        try {
+            JSON.parseObject(jsonText, Result2.class,true);
+            fail();
+        }
+        catch (JSONException e){
+            assertEquals("error message","Enum value UNKNOWN does not exist in class com.alibaba.fastjson.State.",e.getMessage());
+        }
+        jsonText = "{\"code\":\"ERROR\",\"id\":5,\"state\":\"UNKNOWN\"}";
+        try {
+            JSON.parseObject(jsonText, Result2.class,true);
+            fail();
+        }
+        catch (JSONException e){
+            assertEquals("error message","Enum value ERROR does not exist in class com.alibaba.fastjson.Code.",e.getMessage());
+        }
+    }
+}
+enum Code{
+    SUCCESS, FAILURE
+}
+class Result{
+    private int id;
+    private Code code;
+    public int getId() {
+        return id;
+    }
+    public void setId(int id) {
+        this.id = id;
+    }
+    public Code getCode() {
+        return code;
+    }
+    public void setCode(Code code) {
+        this.code = code;
+    }
+    @Override
+    public String toString() {
+        return JSON.toJSONString(this);
+    }
+}
+class Result2{
+    private int id;
+    private Code code;
+    private State state;
+
+    public State getState() {
+        return state;
+    }
+
+    public void setState(State state) {
+        this.state = state;
+    }
+
+    public int getId() {
+        return id;
+    }
+    public void setId(int id) {
+        this.id = id;
+    }
+    public Code getCode() {
+        return code;
+    }
+    public void setCode(Code code) {
+        this.code = code;
+    }
+    @Override
+    public String toString() {
+        return JSON.toJSONString(this);
+    }
+}
+enum State{
+    CHECKED(1), UNCHECKED(0);
+    State(int a){
+    }
+}


### PR DESCRIPTION
 对于问题 #1393：错误的枚举值，反序列化时不抛异常。重载JSON.parseObject函数，增加了enumCheck参数，增加枚举值检查，如果枚举值错误则报错。