### PR TITLE
Fix issue #3821 解决了1.2.83版本下序列化Map时key为数字不满足JSON规范的输出问题

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/MapSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/MapSerializer.java
@@ -213,8 +213,13 @@ public class MapSerializer extends SerializeFilterable implements ObjectSerializ
                     }
                 }
 
-                if (entryKey instanceof String) {
-                    String key = (String) entryKey;
+                if (entryKey instanceof String || entryKey instanceof Number) {
+                    String key;
+                    if( entryKey instanceof Number){
+                         key = String.valueOf(entryKey);
+                    }else{
+                         key = (String) entryKey;
+                    }
 
                     if (!first) {
                         out.write(',');

--- a/src/test/java/com/alibaba/fastjson/serializer/issue3821/JSONParseMapperTest.java
+++ b/src/test/java/com/alibaba/fastjson/serializer/issue3821/JSONParseMapperTest.java
@@ -1,0 +1,29 @@
+package com.alibaba.fastjson.serializer.issue3821;
+
+import com.alibaba.fastjson.JSON;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class JSONParseMapperTest {
+
+    @Test(timeout = 4000)
+    public void testIfKeyIsString() throws JsonProcessingException {
+        Map<Integer, String> data = new HashMap<Integer, String>() {{ put(1, "2"); }};
+
+        Assert.assertEquals(JSON.toJSONString(data),"{\"1\":\"2\"}");
+
+        Gson gson = new GsonBuilder().create();
+        Assert.assertEquals(gson.toJson(data, Map.class),"{\"1\":\"2\"}");
+
+        ObjectMapper jackson = new ObjectMapper();
+        Assert.assertEquals(jackson.writeValueAsString(data),"{\"1\":\"2\"}");
+    }
+}


### PR DESCRIPTION
检测Map中是否为数字输出，如果有，将其转换为字符串并且按字符串进行序列化处理。