### PR TITLE
Fix Issue #4132

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/JSONLexerBase.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONLexerBase.java
@@ -26,8 +26,8 @@ import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.util.IOUtils;
 
 import static com.alibaba.fastjson.parser.JSONToken.*;
-import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_hashcode;
-import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_prime;
+import static com.alibaba.fastjson.util.TypeUtils.FNV1A_64_MAGIC_HASHCODE;
+import static com.alibaba.fastjson.util.TypeUtils.FNV1A_64_MAGIC_PRIME;
 
 /**
  * @author wenshao[szujobs@hotmail.com]
@@ -1443,7 +1443,7 @@ public abstract class JSONLexerBase implements JSONLexer, Closeable {
             return 0;
         }
 
-        long hash = fnv1a_64_magic_hashcode;
+        long hash = FNV1A_64_MAGIC_HASHCODE;
         for (;;) {
             chLocal = charAt(bp + (offset++));
             if (chLocal == '\"') {
@@ -1452,7 +1452,7 @@ public abstract class JSONLexerBase implements JSONLexer, Closeable {
             }
 
             hash ^= chLocal;
-            hash *= fnv1a_64_magic_prime;
+            hash *= FNV1A_64_MAGIC_PRIME;
 
             if (chLocal == '\\') {
                 matchStat = NOT_MATCH;
@@ -1514,7 +1514,7 @@ public abstract class JSONLexerBase implements JSONLexer, Closeable {
             return 0;
         }
 
-        long hash = fnv1a_64_magic_hashcode;
+        long hash = FNV1A_64_MAGIC_HASHCODE;
         for (;;) {
             chLocal = charAt(bp + (offset++));
             if (chLocal == '\"') {
@@ -1523,7 +1523,7 @@ public abstract class JSONLexerBase implements JSONLexer, Closeable {
             }
 
             hash ^= ((chLocal >= 'A' && chLocal <= 'Z') ? (chLocal + 32) : chLocal);
-            hash *= fnv1a_64_magic_prime;
+            hash *= FNV1A_64_MAGIC_PRIME;
 
             if (chLocal == '\\') {
                 matchStat = NOT_MATCH;

--- a/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
@@ -24,8 +24,8 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.*;
 
-import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_hashcode;
-import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_prime;
+import static com.alibaba.fastjson.util.TypeUtils.FNV1A_64_MAGIC_HASHCODE;
+import static com.alibaba.fastjson.util.TypeUtils.FNV1A_64_MAGIC_PRIME;
 
 //这个类，为了性能优化做了很多特别处理，一切都是为了性能！！！
 
@@ -1226,7 +1226,7 @@ public final class JSONScanner extends JSONLexerBase {
             }
         }
 
-        long hash = fnv1a_64_magic_hashcode;
+        long hash = FNV1A_64_MAGIC_HASHCODE;
         for (;;) {
             ch = charAt(index++);
             if (ch == '\"') {
@@ -1239,7 +1239,7 @@ public final class JSONScanner extends JSONLexerBase {
             }
 
             hash ^= ch;
-            hash *= fnv1a_64_magic_prime;
+            hash *= FNV1A_64_MAGIC_PRIME;
         }
 
         for (;;) {
@@ -2593,7 +2593,7 @@ public final class JSONScanner extends JSONLexerBase {
 
             long hash;
             if (ch == '"') {
-                hash = fnv1a_64_magic_hashcode;
+                hash = FNV1A_64_MAGIC_HASHCODE;
 
                 for (int i = bp + 1; i < text.length(); ++i) {
                     char c = text.charAt(i);
@@ -2614,7 +2614,7 @@ public final class JSONScanner extends JSONLexerBase {
                     }
 
                     hash ^= c;
-                    hash *= fnv1a_64_magic_prime;
+                    hash *= FNV1A_64_MAGIC_PRIME;
                 }
             } else {
                 throw new UnsupportedOperationException();
@@ -2855,7 +2855,7 @@ public final class JSONScanner extends JSONLexerBase {
 
             long hash;
             if (ch == '"') {
-                hash = fnv1a_64_magic_hashcode;
+                hash = FNV1A_64_MAGIC_HASHCODE;
 
                 for (int i = bp + 1; i < text.length(); ++i) {
                     char c = text.charAt(i);
@@ -2876,7 +2876,7 @@ public final class JSONScanner extends JSONLexerBase {
                     }
 
                     hash ^= c;
-                    hash *= fnv1a_64_magic_prime;
+                    hash *= FNV1A_64_MAGIC_PRIME;
                 }
             } else {
                 throw new UnsupportedOperationException();

--- a/src/main/java/com/alibaba/fastjson/parser/ParserConfig.java
+++ b/src/main/java/com/alibaba/fastjson/parser/ParserConfig.java
@@ -59,8 +59,8 @@ import com.alibaba.fastjson.util.ServiceLoader;
 
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_hashcode;
-import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_prime;
+import static com.alibaba.fastjson.util.TypeUtils.FNV1A_64_MAGIC_HASHCODE;
+import static com.alibaba.fastjson.util.TypeUtils.FNV1A_64_MAGIC_PRIME;
 
 /**
  * @author wenshao[szujobs@hotmail.com]
@@ -1364,21 +1364,21 @@ public class ParserConfig {
         String className = typeName.replace('$', '.');
         Class<?> clazz;
 
-        final long h1 = (fnv1a_64_magic_hashcode ^ className.charAt(0)) * fnv1a_64_magic_prime;
+        final long h1 = (FNV1A_64_MAGIC_HASHCODE ^ className.charAt(0)) * FNV1A_64_MAGIC_PRIME;
         if (h1 == 0xaf64164c86024f1aL) { // [
             throw new JSONException("autoType is not support. " + typeName);
         }
 
-        if ((h1 ^ className.charAt(className.length() - 1)) * fnv1a_64_magic_prime == 0x9198507b5af98f0L) {
+        if ((h1 ^ className.charAt(className.length() - 1)) * FNV1A_64_MAGIC_PRIME == 0x9198507b5af98f0L) {
             throw new JSONException("autoType is not support. " + typeName);
         }
 
-        final long h3 = (((((fnv1a_64_magic_hashcode ^ className.charAt(0))
-                * fnv1a_64_magic_prime)
+        final long h3 = (((((FNV1A_64_MAGIC_HASHCODE ^ className.charAt(0))
+                * FNV1A_64_MAGIC_PRIME)
                 ^ className.charAt(1))
-                * fnv1a_64_magic_prime)
+                * FNV1A_64_MAGIC_PRIME)
                 ^ className.charAt(2))
-                * fnv1a_64_magic_prime;
+                * FNV1A_64_MAGIC_PRIME;
 
         long fullHash = TypeUtils.fnv1a_64(className);
         boolean internalWhite = Arrays.binarySearch(INTERNAL_WHITELIST_HASHCODES,  fullHash) >= 0;
@@ -1387,7 +1387,7 @@ public class ParserConfig {
             long hash = h3;
             for (int i = 3; i < className.length(); ++i) {
                 hash ^= className.charAt(i);
-                hash *= fnv1a_64_magic_prime;
+                hash *= FNV1A_64_MAGIC_PRIME;
                 if (Arrays.binarySearch(internalDenyHashCodes, hash) >= 0) {
                     throw new JSONException("autoType is not support. " + typeName);
                 }
@@ -1398,7 +1398,7 @@ public class ParserConfig {
             long hash = h3;
             for (int i = 3; i < className.length(); ++i) {
                 hash ^= className.charAt(i);
-                hash *= fnv1a_64_magic_prime;
+                hash *= FNV1A_64_MAGIC_PRIME;
                 if (Arrays.binarySearch(acceptHashCodes, hash) >= 0) {
                     clazz = TypeUtils.loadClass(typeName, defaultClassLoader, true);
                     if (clazz != null) {
@@ -1449,7 +1449,7 @@ public class ParserConfig {
             for (int i = 3; i < className.length(); ++i) {
                 char c = className.charAt(i);
                 hash ^= c;
-                hash *= fnv1a_64_magic_prime;
+                hash *= FNV1A_64_MAGIC_PRIME;
 
                 if (Arrays.binarySearch(denyHashCodes, hash) >= 0) {
                     if (typeName.endsWith("Exception") || typeName.endsWith("Error")) {

--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/EnumDeserializer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/EnumDeserializer.java
@@ -12,8 +12,8 @@ import com.alibaba.fastjson.parser.JSONLexer;
 import com.alibaba.fastjson.parser.JSONToken;
 import com.alibaba.fastjson.util.TypeUtils;
 
-import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_hashcode;
-import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_prime;
+import static com.alibaba.fastjson.util.TypeUtils.FNV1A_64_MAGIC_HASHCODE;
+import static com.alibaba.fastjson.util.TypeUtils.FNV1A_64_MAGIC_PRIME;
 
 @SuppressWarnings("rawtypes")
 public class EnumDeserializer implements ObjectDeserializer {
@@ -47,16 +47,16 @@ public class EnumDeserializer implements ObjectDeserializer {
                 // skip
             }
 
-            long hash = fnv1a_64_magic_hashcode;
-            long hash_lower = fnv1a_64_magic_hashcode;
+            long hash = FNV1A_64_MAGIC_HASHCODE;
+            long hash_lower = FNV1A_64_MAGIC_HASHCODE;
             for (int j = 0; j < name.length(); ++j) {
                 char ch = name.charAt(j);
 
                 hash ^= ch;
                 hash_lower ^= ((ch >= 'A' && ch <= 'Z') ? (ch + 32) : ch);
 
-                hash *= fnv1a_64_magic_prime;
-                hash_lower *= fnv1a_64_magic_prime;
+                hash *= FNV1A_64_MAGIC_PRIME;
+                hash_lower *= FNV1A_64_MAGIC_PRIME;
             }
 
             enumMap.put(hash, e);
@@ -66,11 +66,11 @@ public class EnumDeserializer implements ObjectDeserializer {
 
             if (jsonField != null) {
                 for (String alterName : jsonField.alternateNames()) {
-                    long alterNameHash = fnv1a_64_magic_hashcode;
+                    long alterNameHash = FNV1A_64_MAGIC_HASHCODE;
                     for (int j = 0; j < alterName.length(); ++j) {
                         char ch = alterName.charAt(j);
                         alterNameHash ^= ch;
-                        alterNameHash *= fnv1a_64_magic_prime;
+                        alterNameHash *= FNV1A_64_MAGIC_PRIME;
                     }
                     if (alterNameHash != hash && alterNameHash != hash_lower) {
                         enumMap.put(alterNameHash, e);
@@ -137,16 +137,16 @@ public class EnumDeserializer implements ObjectDeserializer {
                     return (T) null;
                 }
 
-                long hash = fnv1a_64_magic_hashcode;
-                long hash_lower = fnv1a_64_magic_hashcode;
+                long hash = FNV1A_64_MAGIC_HASHCODE;
+                long hash_lower = FNV1A_64_MAGIC_HASHCODE;
                 for (int j = 0; j < name.length(); ++j) {
                     char ch = name.charAt(j);
 
                     hash ^= ch;
                     hash_lower ^= ((ch >= 'A' && ch <= 'Z') ? (ch + 32) : ch);
 
-                    hash *= fnv1a_64_magic_prime;
-                    hash_lower *= fnv1a_64_magic_prime;
+                    hash *= FNV1A_64_MAGIC_PRIME;
+                    hash_lower *= FNV1A_64_MAGIC_PRIME;
                 }
 
                 Enum e = getEnumByHashCode(hash);

--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
@@ -18,7 +18,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_hashcode;
+import static com.alibaba.fastjson.util.TypeUtils.FNV1A_64_MAGIC_HASHCODE;
 
 public class JavaBeanDeserializer implements ObjectDeserializer {
 
@@ -1101,7 +1101,7 @@ public class JavaBeanDeserializer implements ObjectDeserializer {
         if (lexer.matchStat > 0) {
             Enum e = enumDeserializer.getEnumByHashCode(enumNameHashCode);
             if (e == null) {
-                if (enumNameHashCode == fnv1a_64_magic_hashcode) {
+                if (enumNameHashCode == FNV1A_64_MAGIC_HASHCODE) {
                     return null;
                 }
 

--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -42,7 +42,6 @@ import java.sql.Clob;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
@@ -53,6 +52,8 @@ import java.util.regex.Pattern;
  */
 public class TypeUtils {
     private static final Pattern NUMBER_WITH_TRAILING_ZEROS_PATTERN = Pattern.compile("\\.0*$");
+    public static final long FNV1A_64_MAGIC_HASHCODE = 0xcbf29ce484222325L;
+    public static final long FNV1A_64_MAGIC_PRIME = 0x100000001b3L;
 
     public static boolean compatibleWithJavaBean = false;
     /**
@@ -3014,11 +3015,8 @@ public class TypeUtils {
         return Float.parseFloat(str);
     }
 
-    public static final long fnv1a_64_magic_hashcode = 0xcbf29ce484222325L;
-    public static final long fnv1a_64_magic_prime = 0x100000001b3L;
-
     public static long fnv1a_64_extract(String key) {
-        long hashCode = fnv1a_64_magic_hashcode;
+        long hashCode = FNV1A_64_MAGIC_HASHCODE;
         for (int i = 0; i < key.length(); ++i) {
             char ch = key.charAt(i);
             if (ch == '_' || ch == '-') {
@@ -3028,30 +3026,33 @@ public class TypeUtils {
                 ch = (char) (ch + 32);
             }
             hashCode ^= ch;
-            hashCode *= fnv1a_64_magic_prime;
+            hashCode *= FNV1A_64_MAGIC_PRIME;
         }
         return hashCode;
     }
 
     public static long fnv1a_64_lower(String key) {
-        long hashCode = fnv1a_64_magic_hashcode;
+        long hashCode = FNV1A_64_MAGIC_HASHCODE;
         for (int i = 0; i < key.length(); ++i) {
             char ch = key.charAt(i);
+            if(ch == '_' || ch == '-'){
+                continue;
+            }
             if (ch >= 'A' && ch <= 'Z') {
                 ch = (char) (ch + 32);
             }
             hashCode ^= ch;
-            hashCode *= fnv1a_64_magic_prime;
+            hashCode *= FNV1A_64_MAGIC_PRIME;
         }
         return hashCode;
     }
 
     public static long fnv1a_64(String key) {
-        long hashCode = fnv1a_64_magic_hashcode;
+        long hashCode = FNV1A_64_MAGIC_HASHCODE;
         for (int i = 0; i < key.length(); ++i) {
             char ch = key.charAt(i);
             hashCode ^= ch;
-            hashCode *= fnv1a_64_magic_prime;
+            hashCode *= FNV1A_64_MAGIC_PRIME;
         }
         return hashCode;
     }

--- a/src/test/java/com/alibaba/fastjson/deserializer/issue4132/TestIssue4132.java
+++ b/src/test/java/com/alibaba/fastjson/deserializer/issue4132/TestIssue4132.java
@@ -1,0 +1,38 @@
+package com.alibaba.fastjson.deserializer.issue4132;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.util.TypeUtils;
+import lombok.Data;
+import lombok.ToString;
+import org.junit.Test;
+
+/**
+ * @author Rongzhen Yan
+ */
+public class TestIssue4132 {
+
+    @Data
+    @ToString
+    static class DTO {
+
+        @JSONField(name = "field_no1")
+        private String fieldNo1;
+
+        @JSONField(name = "field_no2")
+        private String fieldNo2;
+    }
+
+    @Test
+    public void fun1() {
+        String json = "{\"fieldNo1\":\"value1\",\"fieldNo2\":\"value2\"}";
+        DTO dto1 = JSON.parseObject(json, DTO.class);
+        System.out.println(dto1);
+    }
+
+    @Test
+    public void fun2() {
+        System.out.println(TypeUtils.fnv1a_64_lower("field_no") == TypeUtils.fnv1a_64_lower("fieldNo"));
+    }
+}
+

--- a/src/test/java/com/alibaba/json/bvt/parser/JSONScannerTest_scanSymbol.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/JSONScannerTest_scanSymbol.java
@@ -6,10 +6,9 @@ import junit.framework.TestCase;
 
 import com.alibaba.fastjson.parser.JSONScanner;
 import com.alibaba.fastjson.parser.JSONToken;
-import com.alibaba.fastjson.parser.SymbolTable;
 
-import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_hashcode;
-import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_prime;
+import static com.alibaba.fastjson.util.TypeUtils.FNV1A_64_MAGIC_HASHCODE;
+import static com.alibaba.fastjson.util.TypeUtils.FNV1A_64_MAGIC_PRIME;
 
 /**
  * 测试字符':'的处理
@@ -100,11 +99,11 @@ public class JSONScannerTest_scanSymbol extends TestCase {
     }
 
     static long fnv_hash(String text) {
-        long hash = fnv1a_64_magic_hashcode;
+        long hash = FNV1A_64_MAGIC_HASHCODE;
         for (int i = 0; i < text.length(); ++i) {
             char c = text.charAt(i);
             hash ^= c;
-            hash *= fnv1a_64_magic_prime;
+            hash *= FNV1A_64_MAGIC_PRIME;
         }
         return hash;
     }

--- a/src/test/java/com/alibaba/json/test/FNV32_CollisionTest_All.java
+++ b/src/test/java/com/alibaba/json/test/FNV32_CollisionTest_All.java
@@ -4,14 +4,12 @@ import junit.framework.TestCase;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
-import java.io.FilterWriter;
 import java.text.NumberFormat;
 import java.util.BitSet;
 import java.util.Random;
 
-import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_hashcode;
-import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_prime;
+import static com.alibaba.fastjson.util.TypeUtils.FNV1A_64_MAGIC_HASHCODE;
+import static com.alibaba.fastjson.util.TypeUtils.FNV1A_64_MAGIC_PRIME;
 
 /**
  * Created by wenshao on 08/01/2017.
@@ -63,14 +61,14 @@ public class FNV32_CollisionTest_All extends TestCase {
             long n = (long) Math.pow(digLetters.length, chars.length);
 
             for (; v < n; ++v) {
-                long hash = fnv1a_64_magic_hashcode;
+                long hash = FNV1A_64_MAGIC_HASHCODE;
                 for (int i = 0; i < chars.length; ++i) {
                     int power = powers[chars.length - i - 1];
                     int d = (int) ((v / power) % digLetters.length);
                     char c = digLetters[d];
 
                     hash ^= c;
-                    hash *= fnv1a_64_magic_prime;
+                    hash *= FNV1A_64_MAGIC_PRIME;
                 }
                 b[7] = (byte) (hash       );
                 b[6] = (byte) (hash >>>  8);
@@ -106,11 +104,11 @@ public class FNV32_CollisionTest_All extends TestCase {
     }
 
     static long fnv_hash(char[] chars) {
-        long hash = fnv1a_64_magic_hashcode;
+        long hash = FNV1A_64_MAGIC_HASHCODE;
         for (int i = 0; i < chars.length; ++i) {
             char c = chars[i];
             hash ^= c;
-            hash *= fnv1a_64_magic_prime;
+            hash *= FNV1A_64_MAGIC_PRIME;
         }
         return hash;
     }

--- a/src/test/java/com/alibaba/json/test/FNVHashTest.java
+++ b/src/test/java/com/alibaba/json/test/FNVHashTest.java
@@ -4,8 +4,8 @@ import junit.framework.TestCase;
 
 import java.util.*;
 
-import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_hashcode;
-import static com.alibaba.fastjson.util.TypeUtils.fnv1a_64_magic_prime;
+import static com.alibaba.fastjson.util.TypeUtils.FNV1A_64_MAGIC_HASHCODE;
+import static com.alibaba.fastjson.util.TypeUtils.FNV1A_64_MAGIC_PRIME;
 
 /**
  * Created by wenshao on 05/01/2017.
@@ -71,11 +71,11 @@ public class FNVHashTest extends TestCase {
     }
 
     static long fnv_hash64(char[] chars) {
-        long hash = fnv1a_64_magic_hashcode;
+        long hash = FNV1A_64_MAGIC_HASHCODE;
         for (int i = 0; i < chars.length; ++i) {
             char c = chars[i];
             hash ^= c;
-            hash *= fnv1a_64_magic_prime;
+            hash *= FNV1A_64_MAGIC_PRIME;
         }
         return hash;
     }


### PR DESCRIPTION
1. 修复自1.2.69版本之后, 带@JsonField的字段哈希计算及匹配规则不向前兼容的问题, 导致很多用户升级到新版本, 需要大量场景下的回归测试. 不影响alterNateName的使用.
2. 魔数常量规范化