### PR TITLE
Fix Issue #3962

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONPath.java
+++ b/src/main/java/com/alibaba/fastjson/JSONPath.java
@@ -3848,6 +3848,9 @@ public class JSONPath implements JSONAware {
         if (currentObject instanceof String) {
             try {
                 JSONObject object = (JSONObject) JSON.parse((String) currentObject, parserConfig);
+                if (object == null) {
+                    return null;
+                }
                 currentObject = object;
             } catch (Exception ex) {
                 // skip


### PR DESCRIPTION
修复JSONPath读取空字符串时，字符串解析 JSONObject 返回为 null ，赋值后调用方法出现空指针问题