### PR TITLE
当同一线程重复使用allocateBytes方法时出错

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -1273,7 +1273,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             } else {
                 chars = new byte[length];
             }
-        } else if (chars.length < length) {
+        } else if (chars.length <= length) {
             chars = new byte[length];
         }
 


### PR DESCRIPTION
com.alibaba.fastjson.JSON#allocateBytes
  private static byte[] allocateBytes(int length) {
        byte[] chars = (byte[])bytesLocal.get();
        if (chars == null) {
            if (length <= 65536) {
                chars = new byte[65536];
                bytesLocal.set(chars);
            } else {
                chars = new byte[length];
            }
        } else if (chars.length < length) {
            chars = new byte[length];
        }
        return chars;
    }

之前的byte[]和当前长度一样时，后续读的数据长度小于等于之前的长度时，后续数据会不正确
即chars.length == length时，数据会出现错误