### PR TITLE
反序列化时失败

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -1273,7 +1273,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             } else {
                 chars = new byte[length];
             }
-        } else if (chars.length <= length) {
+        } else if (chars.length < length) {
             chars = new byte[length];
         }
 

--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -1273,7 +1273,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
             } else {
                 chars = new byte[length];
             }
-        } else if (chars.length < length) {
+        } else if (chars.length <= length) {
             chars = new byte[length];
         }
 

--- a/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
@@ -1166,8 +1166,13 @@ public final class JSONScanner extends JSONLexerBase {
             token = JSONToken.COMMA;
             return dateVal;
         } else {
-            //condition ch == '}' is always 'true'
-            ch = charAt(++bp);
+            //去除空格换行符,tab等字符
+             for (; ; ) {
+                    ch = charAt(++bp);
+                    if(!isWhitespace(ch)){
+                       break;
+                    }
+             }
             if (ch == ',') {
                 token = JSONToken.COMMA;
                 this.ch = charAt(++bp);


### PR DESCRIPTION
日期类型处理
使用SerializerFeature.PrettyFormat后，反序列化失败
[
	{
		"auditStatus":30,
		"id":"03ff2fea48184cdaaafbfc4d74432f5b",
		"name":"公司",
		"updateTime":"2021-06-03 14:30:58"
	}
]
反序列化时失败[https://github.com/alibaba/fastjson/issues/4279](url)