### PR TITLE
修正命名错误，修复fast fail机制导致的kotlin次次失败

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
@@ -125,7 +125,7 @@ public class JavaBeanInfo {
 
             kotlin = TypeUtils.isKotlin(clazz);
             if (kotlin) {
-                this.creatorConstructorParameters = TypeUtils.getKoltinConstructorParameters(clazz);
+                this.creatorConstructorParameters = TypeUtils.getKotlinConstructorParameters(clazz);
                 try {
                     this.kotlinDefaultConstructor = clazz.getConstructor();
                 } catch (Throwable ex) {
@@ -376,7 +376,7 @@ public class JavaBeanInfo {
                         if (field == null) {
                             if (lookupParameterNames == null) {
                                 if (kotlin) {
-                                    lookupParameterNames = TypeUtils.getKoltinConstructorParameters(clazz);
+                                    lookupParameterNames = TypeUtils.getKotlinConstructorParameters(clazz);
                                 } else {
                                     lookupParameterNames = ASMUtils.lookupParameterNames(creatorConstructor);
                                 }
@@ -448,7 +448,7 @@ public class JavaBeanInfo {
 
                 String[] paramNames = null;
                 if (kotlin && constructors.length > 0) {
-                    paramNames = TypeUtils.getKoltinConstructorParameters(clazz);
+                    paramNames = TypeUtils.getKotlinConstructorParameters(clazz);
                     creatorConstructor = TypeUtils.getKotlinConstructor(constructors, paramNames);
                     TypeUtils.setAccessible(creatorConstructor);
                 } else {

--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -83,7 +83,6 @@ public class TypeUtils {
     private static volatile Method kotlin_kclass_getConstructors;
     private static volatile Method kotlin_kfunction_getParameters;
     private static volatile Method kotlin_kparameter_getName;
-    private static volatile boolean kotlin_error;
     private static volatile Map<Class, String[]> kotlinIgnores;
     private static volatile boolean kotlinIgnores_error;
     private static ConcurrentMap<String, Class<?>> mappings = new ConcurrentHashMap<String, Class<?>>(256, 0.75f, 1);
@@ -1970,7 +1969,7 @@ public class TypeUtils {
                     Constructor creatorConstructor = TypeUtils.getKotlinConstructor(constructors);
                     if (creatorConstructor != null) {
                         paramAnnotationArrays = TypeUtils.getParameterAnnotations(creatorConstructor);
-                        paramNames = TypeUtils.getKoltinConstructorParameters(clazz);
+                        paramNames = TypeUtils.getKotlinConstructorParameters(clazz);
                         if (paramNames != null) {
                             String[] paramNames_sorted = new String[paramNames.length];
                             System.arraycopy(paramNames, 0, paramNames_sorted, 0, paramNames.length);
@@ -3090,7 +3089,7 @@ public class TypeUtils {
         return creatorConstructor;
     }
 
-    public static String[] getKoltinConstructorParameters(Class clazz) {
+    public static String[] getKotlinConstructorParameters(Class clazz) {
         if (kotlin_kclass_constructor == null && !kotlin_class_klass_error) {
             try {
                 Class class_kotlin_kclass = Class.forName("kotlin.reflect.jvm.internal.KClassImpl");
@@ -3130,10 +3129,6 @@ public class TypeUtils {
             }
         }
 
-        if (kotlin_error) {
-            return null;
-        }
-
         try {
             Object constructor = null;
             Object kclassImpl = kotlin_kclass_constructor.newInstance(clazz);
@@ -3160,7 +3155,6 @@ public class TypeUtils {
             return names;
         } catch (Throwable e) {
             e.printStackTrace();
-            kotlin_error = true;
         }
         return null;
     }


### PR DESCRIPTION
观察到，在某些并发情况下，会导致kotlin报default constructor not found.