### PR TITLE
修复日期长度为9时反序列化时BUG

### DIFF
--- a/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
+++ b/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
@@ -388,6 +388,10 @@ public final class JSONScanner extends JSONLexerBase {
 
         char c8 = charAt(bp + 8);
         char c9 = charAt(bp + 9);
+        
+        if (rest == 9) {
+            c9 = ' ';
+        }
 
         int date_len = 10;
         char y0, y1, y2, y3, M0, M1, d0, d1;


### PR DESCRIPTION
当日期为"2022-10-1"这样的字符串反序列化时，fastson会报异常

当日期长度为9时，char c9 = charAt(bp + 9);这个取值有问题，bp的长度一共才9，造成了下面代码的对于c9判断不正确