### PR TITLE
修复在设置object可访问的情况下，出现异常导致后续setAccessible被跳过的问题

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -59,7 +59,6 @@ public class TypeUtils {
      * 根据field name的大小写输出输入数据
      */
     public static boolean compatibleWithFieldName = false;
-    private static boolean setAccessibleEnable = true;
     private static boolean oracleTimestampMethodInited = false;
     private static Method oracleTimestampMethod;
     private static boolean oracleDateMethodInited = false;
@@ -2544,16 +2543,13 @@ public class TypeUtils {
     }
 
     static void setAccessible(AccessibleObject obj) {
-        if (!setAccessibleEnable) {
-            return;
-        }
         if (obj.isAccessible()) {
             return;
         }
         try {
             obj.setAccessible(true);
         } catch (Throwable error) {
-            setAccessibleEnable = false;
+            throw new JSONException("cannot access object", error);
         }
     }
 


### PR DESCRIPTION
setAccessibleEnable是以true作为默认值的，在setAccessible方法出现异常后被设置为false，此操作会导致在程序运行过程中，任意一次的setAccessible出现异常后（可能为AccessException or SecurityException），都将导致后续使用fastjson内所有的setAccessible被跳过，从而导致程序抛出异常（此异常是由于未设置字段/方法的Accessible导致的，并不是在调用setAccessible方法导致的），此代码会隐藏真实的异常类型，从而导致程序侧无法定位问题