### PR TITLE
Spring RestController 返回类型为map<Long, Object>时格式错误, long 数据多了一层双引号 #4388

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/MapSerializer.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/MapSerializer.java
@@ -15,13 +15,18 @@
  */
 package com.alibaba.fastjson.serializer;
 
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.util.TypeUtils;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.*;
-
-import com.alibaba.fastjson.JSON;
-import com.alibaba.fastjson.JSONObject;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 /**
  * @author wenshao[szujobs@hotmail.com]
@@ -118,7 +123,7 @@ public class MapSerializer extends SerializeFilterable implements ObjectSerializ
                                 continue;
                             }
                         } else if (entryKey.getClass().isPrimitive() || entryKey instanceof Number) {
-                            String strKey = JSON.toJSONString(entryKey);
+                            String strKey = TypeUtils.cast(entryKey, String.class);
                             if (!this.applyName(serializer, object, strKey)) {
                                 continue;
                             }
@@ -133,7 +138,7 @@ public class MapSerializer extends SerializeFilterable implements ObjectSerializ
                                 continue;
                             }
                         } else if (entryKey.getClass().isPrimitive() || entryKey instanceof Number) {
-                            String strKey = JSON.toJSONString(entryKey);
+                            String strKey = TypeUtils.cast(entryKey, String.class);
                             if (!this.applyName(serializer, object, strKey)) {
                                 continue;
                             }
@@ -149,7 +154,7 @@ public class MapSerializer extends SerializeFilterable implements ObjectSerializ
                                 continue;
                             }
                         } else if (entryKey.getClass().isPrimitive() || entryKey instanceof Number) {
-                            String strKey = JSON.toJSONString(entryKey);
+                            String strKey = TypeUtils.cast(entryKey, String.class);
                             if (!this.apply(serializer, object, strKey, value)) {
                                 continue;
                             }
@@ -164,7 +169,7 @@ public class MapSerializer extends SerializeFilterable implements ObjectSerializ
                                 continue;
                             }
                         } else if (entryKey.getClass().isPrimitive() || entryKey instanceof Number) {
-                            String strKey = JSON.toJSONString(entryKey);
+                            String strKey = TypeUtils.cast(entryKey, String.class);
                             if (!this.apply(serializer, object, strKey, value)) {
                                 continue;
                             }
@@ -178,7 +183,7 @@ public class MapSerializer extends SerializeFilterable implements ObjectSerializ
                         if (entryKey == null || entryKey instanceof String) {
                             entryKey = this.processKey(serializer, object, (String) entryKey, value);
                         } else if (entryKey.getClass().isPrimitive() || entryKey instanceof Number) {
-                            String strKey = JSON.toJSONString(entryKey);
+                            String strKey = TypeUtils.cast(entryKey, String.class);
                             entryKey = this.processKey(serializer, object, strKey, value);
                         }
                     }
@@ -189,7 +194,7 @@ public class MapSerializer extends SerializeFilterable implements ObjectSerializ
                         if (entryKey == null || entryKey instanceof String) {
                             entryKey = this.processKey(serializer, object, (String) entryKey, value);
                         } else if (entryKey.getClass().isPrimitive() || entryKey instanceof Number) {
-                            String strKey = JSON.toJSONString(entryKey);
+                            String strKey = TypeUtils.cast(entryKey, String.class);
                             entryKey = this.processKey(serializer, object, strKey, value);
                         }
                     }
@@ -201,7 +206,7 @@ public class MapSerializer extends SerializeFilterable implements ObjectSerializ
                     } else {
                         boolean objectOrArray = entryKey instanceof Map || entryKey instanceof Collection;
                         if (!objectOrArray) {
-                            String strKey = JSON.toJSONString(entryKey);
+                            String strKey = TypeUtils.cast(entryKey, String.class);
                             value = this.processValue(serializer, null, object, strKey, value, features);
                         }
                     }
@@ -231,7 +236,7 @@ public class MapSerializer extends SerializeFilterable implements ObjectSerializ
 
                     if ((out.isEnabled(NON_STRINGKEY_AS_STRING) || SerializerFeature.isEnabled(features, SerializerFeature.WriteNonStringKeyAsString))
                             && !(entryKey instanceof Enum)) {
-                        String strEntryKey = JSON.toJSONString(entryKey);
+                        String strEntryKey = TypeUtils.cast(entryKey, String.class);
                         serializer.write(strEntryKey);
                     } else {
                         serializer.write(entryKey);

--- a/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -31,18 +31,47 @@ import com.alibaba.fastjson.parser.deserializer.ObjectDeserializer;
 import com.alibaba.fastjson.serializer.CalendarCodec;
 import com.alibaba.fastjson.serializer.SerializeBeanInfo;
 import com.alibaba.fastjson.serializer.SerializerFeature;
-
 import java.io.InputStream;
 import java.io.Reader;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.*;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Clob;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
-import java.util.concurrent.Callable;
+import java.util.AbstractCollection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
@@ -1086,6 +1115,10 @@ public class TypeUtils {
         }
     };
 
+    public static <T> T cast(final Object obj, final Class<T> clazz) {
+        return cast(obj, clazz, null);
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static <T> T cast(final Object obj, final Class<T> clazz, ParserConfig config) {
         if (obj == null) {
@@ -1313,7 +1346,9 @@ public class TypeUtils {
         }
         throw new JSONException("can not cast to : " + clazz.getName());
     }
-
+    public static <T> T cast(Object obj, Type type){
+        return cast(obj, type, null);
+    }
     @SuppressWarnings("unchecked")
     public static <T> T cast(Object obj, Type type, ParserConfig mapping) {
         if (obj == null) {


### PR DESCRIPTION
1、由 JSON.toJSONString(entryKey)调整为TypeUtils.cast(entryKey, String.class)
2、TypeUtils扩展API