### PR TITLE
Fix Issue#3962

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONPath.java
+++ b/src/main/java/com/alibaba/fastjson/JSONPath.java
@@ -3853,6 +3853,9 @@ public class JSONPath implements JSONAware {
                 // skip
             }
         }
+        if (currentObject == null) {
+            return null;
+        }
 
         if (currentObject instanceof Map) {
             Map map = (Map) currentObject;

--- a/src/test/java/com/alibaba/fastjson/jsonpath/issue3962/TestIssue3962.java
+++ b/src/test/java/com/alibaba/fastjson/jsonpath/issue3962/TestIssue3962.java
@@ -1,0 +1,15 @@
+package com.alibaba.fastjson.jsonpath.issue3962;
+
+import com.alibaba.fastjson.JSONPath;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestIssue3962 {
+
+    @Test
+    public void testIssue3962() {
+        Object val = JSONPath.eval("{\"a\": {\"b\": \"\"}}", "$.a.b.c");
+        Assert.assertNull(val);
+    }
+
+}


### PR DESCRIPTION
Fix Issue3962: 对于JSON.parse()，参数为空字符串时，返回值为null, 若不判空，后边代码会抛出空指针异常。