### PR TITLE
#4518 新增序列化枚举WriteSqlDateUseDefaultFormat，在使用JSONObject.toJSONStringWithDat…

### DIFF
--- a/src/main/java/com/alibaba/fastjson/serializer/DateCodec.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/DateCodec.java
@@ -51,7 +51,7 @@ public class DateCodec extends AbstractDateDeserializer implements ObjectSeriali
         }
 
         Class<?> clazz = object.getClass();
-        if (clazz == java.sql.Date.class && !out.isEnabled(SerializerFeature.WriteDateUseDateFormat)) {
+        if (clazz == java.sql.Date.class && (!out.isEnabled(SerializerFeature.WriteDateUseDateFormat)||out.isEnabled(SerializerFeature.WriteSqlDateUseDefaultFormat))) {
             long millis = ((java.sql.Date) object).getTime();
             TimeZone timeZone = serializer.timeZone;
             int offset = timeZone.getOffset(millis);

--- a/src/main/java/com/alibaba/fastjson/serializer/SerializerFeature.java
+++ b/src/main/java/com/alibaba/fastjson/serializer/SerializerFeature.java
@@ -152,7 +152,11 @@ public enum SerializerFeature {
     /**
      * @since 1.2.27
      */
-    MapSortField;
+    MapSortField,
+    /**
+     * java.sql.date按数据库默认格式进行格式化
+     */
+    WriteSqlDateUseDefaultFormat;
 
     SerializerFeature(){
         mask = (1 << ordinal());


### PR DESCRIPTION
fixed #4518 ,使用JSONObject.toJSONStringWithDateFormat时，传WriteSqlDateUseDefaultFormat枚举时，java.sql.date不受WriteDateUseDateFormat格式控制，默认格式化为数据库存储格式